### PR TITLE
build(deps): consolidate the Dependabot queue into one bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -347,6 +347,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -918,7 +929,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1024,7 +1035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1270,6 +1281,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1675,7 +1687,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1690,7 +1702,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2287,7 +2299,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2888,6 +2900,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2924,6 +2947,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -3254,7 +3283,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3500,13 +3529,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3660,7 +3689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3878,7 +3907,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3900,7 +3929,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3920,7 +3949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4290,16 +4319,16 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
 dependencies = [
  "bytes",
  "data-encoding",
  "http 1.4.2",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.10.2",
  "sha1",
  "thiserror 2.0.19",
 ]
@@ -4729,7 +4758,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -88,14 +88,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -378,19 +378,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
 dependencies = [
  "clap_builder",
- "clap_derive 4.6.1",
+ "clap_derive 4.6.3",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -414,7 +414,7 @@ version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
 dependencies = [
- "clap 4.6.1",
+ "clap 4.6.3",
  "clap_lex 1.1.0",
  "is_executable",
  "shlex",
@@ -435,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -814,7 +814,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -918,7 +918,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -939,7 +939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a405457ec78b8fe08b0e32b4a3570ab5dff6dd16eb9e76a5ee0a9d9cbd898933"
 dependencies = [
  "cfg-if",
- "clap 4.6.1",
+ "clap 4.6.3",
  "condtype",
  "divan-macros",
  "libc",
@@ -1024,7 +1024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1675,7 +1675,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1690,7 +1690,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1751,11 +1751,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.31"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
 dependencies = [
  "defmt",
+ "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
@@ -1766,11 +1767,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.31"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -1810,7 +1821,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1985,7 +1996,7 @@ dependencies = [
  "log-mdc",
  "mock_instant",
  "parking_lot",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "thread-id",
  "unicode-segmentation",
 ]
@@ -2276,7 +2287,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2955,7 +2966,7 @@ dependencies = [
  "palette",
  "serde",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.2",
@@ -3058,7 +3069,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3104,7 +3115,7 @@ dependencies = [
  "anstyle",
  "anyhow",
  "assert_cmd",
- "clap 4.6.1",
+ "clap 4.6.3",
  "clap_complete 4.6.7",
  "colorchoice",
  "crc32fast",
@@ -3142,7 +3153,7 @@ dependencies = [
  "tar",
  "tempfile",
  "terminal_size 0.4.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "toml",
  "toml_edit",
@@ -3187,7 +3198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3243,7 +3254,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3337,9 +3348,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "sentry"
-version = "0.48.3"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1975064d9f3d9d87a7c8f0371f7fac10d876906ca3e39faad72e61c263ff9b87"
+checksum = "d631477761f57c76148456e55e80e9a479ff3fa4c65b2b4a0c3acf1167fd4638"
 dependencies = [
  "cfg_aliases 0.2.1",
  "httpdate",
@@ -3352,9 +3363,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.48.3"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134f552b6b147f77aeee46ece875d67a8bfc1d56fe3860d78446ed4c25bb5f9f"
+checksum = "448b0981fbde6cdc9eb087ba3dc01035a253fef9a0d9e79aaf198fc26acb2e64"
 dependencies = [
  "backtrace",
  "regex",
@@ -3363,9 +3374,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.48.3"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cff96247f4dc36867511d108709e703eb354143e7893319d763d2dd1edb4f48"
+checksum = "ecf0b1a4a4e9ec88395b52e6fa4868b95564c1fa96b26a0606f5f6288a0f7149"
 dependencies = [
  "rand 0.9.4",
  "sentry-types",
@@ -3376,9 +3387,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.48.3"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de3f4a1fc77d4c57e8bacd8ef064c26aaa88ea5b2541a761d37c7c3703b9a9"
+checksum = "0b7d93d6ecb55d2251c5fc084c55c03a2bc68904918d76117e602c999e92f00f"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -3386,9 +3397,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.48.3"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc59b27dae3bb495e37e6d62d252214840a2e7e1875531ee9fa2953df8985537"
+checksum = "58d26379236c4ef97eaf081bca3c7bf0ef6f06b3aa881eca2ee8e8dbc923e5b8"
 dependencies = [
  "bitflags 2.13.0",
  "sentry-backtrace",
@@ -3399,16 +3410,16 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.48.3"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7e78132ccfb4a1c777b959fb2944d1f6d5145bffe6be2a98ee6b25d244f72c"
+checksum = "2239099d47e76857b0825a182ecdb90159add7aa1097b60247c6e7ca6bf49c6a"
 dependencies = [
  "debugid",
  "hex",
  "rand 0.9.4",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "url",
  "uuid",
@@ -3456,9 +3467,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -3649,7 +3660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3812,6 +3823,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3824,9 +3846,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.5"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
  "libc",
  "memchr",
@@ -3856,7 +3878,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3878,7 +3900,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3898,7 +3920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3998,11 +4020,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -4018,13 +4040,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -4090,9 +4112,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -4279,7 +4301,7 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4415,9 +4437,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",
@@ -4672,9 +4694,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.4"
+version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
 dependencies = [
  "libc",
 ]
@@ -4707,7 +4729,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ url = "2"
 # fragmentation state machine over any `Read + Write`; hand-rolling that would
 # put protocol correctness on RimZ for a transport that must fail safe. Default
 # features are enough here; TLS stays out because the stream is UDS-local.
-tungstenite = "0.29"
+tungstenite = "0.30"
 
 # Off-box error/event reporting. RimZ `warn!`/`error!` and observed agent
 # rate-limit/overload conditions surface in a Sentry project an operator can

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-trixie
+FROM node:26-trixie
 
 ARG ZELLIJ_VERSION=0.44.3
 ARG TMUX_VERSION=3.7

--- a/deny.toml
+++ b/deny.toml
@@ -55,6 +55,9 @@ skip = [
     # `sentry-core`'s `rand 0.9` (event sampling) pins getrandom 0.3 into the
     # shipped graph, where `uuid` otherwise carries 0.4; drop when they converge.
     { crate = "getrandom@0.3.4", reason = "sentry-core's rand 0.9 pins getrandom 0.3; uuid carries 0.4" },
+    # `thiserror-impl` 2.0.19 leads the proc-macro stack onto syn 3; every other
+    # derive crate still carries syn 2. Drop when the rest follow.
+    { crate = "syn@3.0.2", reason = "thiserror-impl 2.0.19 pins syn 3; the rest of the proc-macro stack carries syn 2" },
     # `toml_edit`/`indexmap` has moved to hashbrown 0.17 while the ratatui
     # stack still carries 0.16; drop when either upstream converges.
     { crate = "hashbrown@0.17.1", reason = "toml_edit/indexmap pins hashbrown 0.17; ratatui stack pins 0.16" },

--- a/deny.toml
+++ b/deny.toml
@@ -41,20 +41,16 @@ deny = [
     { name = "fs2", reason = "unmaintained; use std `File` locking instead" },
 ]
 skip = [
-    # `tungstenite`'s WebSocket handshake uses `sha1` 0.10, whose RustCrypto
-    # stack trails the workspace's `sha2` 0.11 line; drop when sha1 updates.
-    { crate = "block-buffer@0.10.4", reason = "tungstenite's sha1 0.10 handshake stack trails workspace sha2 0.11" },
-    { crate = "cpufeatures@0.2.17", reason = "tungstenite's sha1 0.10 handshake stack trails workspace sha2 0.11" },
-    { crate = "crypto-common@0.1.7", reason = "tungstenite's sha1 0.10 handshake stack trails workspace sha2 0.11" },
-    { crate = "digest@0.10.7", reason = "tungstenite's sha1 0.10 handshake stack trails workspace sha2 0.11" },
     # The `ring` crypto backend reached via `ureq`/`rustls` pins older support
     # crates than the rest of the tree; isolated to the TLS stack, drop when ring
     # catches up. (The former wit-bindgen and windows-sys skips left with the
     # graph's target scoping — wasm and windows triples are no longer audited.)
     { crate = "getrandom@0.2.17", reason = "ring pins getrandom 0.2; workspace otherwise on 0.3/0.4" },
-    # `sentry-core`'s `rand 0.9` (event sampling) pins getrandom 0.3 into the
-    # shipped graph, where `uuid` otherwise carries 0.4; drop when they converge.
-    { crate = "getrandom@0.3.4", reason = "sentry-core's rand 0.9 pins getrandom 0.3; uuid carries 0.4" },
+    # `proptest` and `sentry-core` still carry rand 0.9 after tungstenite moved
+    # to rand 0.10; drop these when both roots follow.
+    { crate = "getrandom@0.3.4", reason = "proptest and sentry-core's rand 0.9 pin getrandom 0.3; uuid and tungstenite carry 0.4" },
+    { crate = "rand@0.9.4", reason = "proptest and sentry retain rand 0.9; tungstenite carries rand 0.10" },
+    { crate = "rand_core@0.9.5", reason = "proptest and sentry's rand 0.9 pins rand_core 0.9; tungstenite carries 0.10" },
     # `thiserror-impl` 2.0.19 leads the proc-macro stack onto syn 3; every other
     # derive crate still carries syn 2. Drop when the rest follow.
     { crate = "syn@3.0.2", reason = "thiserror-impl 2.0.19 pins syn 3; the rest of the proc-macro stack carries syn 2" },

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -129,6 +129,10 @@ criteria = "safe-to-deploy"
 version = "1.2.65"
 criteria = "safe-to-deploy"
 
+[[exemptions.chacha20]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.chrono]]
 version = "0.4.45"
 criteria = "safe-to-run"
@@ -901,6 +905,14 @@ criteria = "safe-to-deploy"
 version = "6.0.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.rand]]
+version = "0.10.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_core]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.ratatui]]
 version = "0.30.2"
 criteria = "safe-to-deploy"
@@ -1064,6 +1076,10 @@ criteria = "safe-to-deploy"
 [[exemptions.serial2]]
 version = "0.2.37"
 criteria = "safe-to-run"
+
+[[exemptions.sha1]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
 
 [[exemptions.sha2]]
 version = "0.11.0"
@@ -1290,7 +1306,7 @@ version = "0.3.23"
 criteria = "safe-to-deploy"
 
 [[exemptions.tungstenite]]
-version = "0.29.0"
+version = "0.30.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.typenum]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -50,7 +50,7 @@ version = "3.0.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.anyhow]]
-version = "1.0.103"
+version = "1.0.104"
 criteria = "safe-to-deploy"
 
 [[exemptions.approx]]
@@ -138,11 +138,11 @@ version = "3.2.25"
 criteria = "safe-to-run"
 
 [[exemptions.clap]]
-version = "4.6.1"
+version = "4.6.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_builder]]
-version = "4.6.0"
+version = "4.6.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_complete]]
@@ -158,7 +158,7 @@ version = "3.2.25"
 criteria = "safe-to-run"
 
 [[exemptions.clap_derive]]
-version = "4.6.1"
+version = "4.6.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_lex]]
@@ -381,10 +381,6 @@ criteria = "safe-to-deploy"
 version = "2.4.1"
 criteria = "safe-to-run"
 
-[[exemptions.fdeflate]]
-version = "0.3.7"
-criteria = "safe-to-deploy"
-
 [[exemptions.filedescriptor]]
 version = "0.8.3"
 criteria = "safe-to-deploy"
@@ -558,11 +554,15 @@ version = "1.0.18"
 criteria = "safe-to-deploy"
 
 [[exemptions.jiff]]
-version = "0.2.31"
+version = "0.2.34"
+criteria = "safe-to-deploy"
+
+[[exemptions.jiff-core]]
+version = "0.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.jiff-static]]
-version = "0.2.31"
+version = "0.2.34"
 criteria = "safe-to-deploy"
 
 [[exemptions.jiff-tzdb]]
@@ -739,10 +739,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.num_threads]]
 version = "0.1.7"
-criteria = "safe-to-deploy"
-
-[[exemptions.objc2-core-foundation]]
-version = "0.3.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.objc2-io-kit]]
@@ -1030,27 +1026,27 @@ version = "1.0.28"
 criteria = "safe-to-deploy"
 
 [[exemptions.sentry]]
-version = "0.48.3"
+version = "0.48.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.sentry-backtrace]]
-version = "0.48.3"
+version = "0.48.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.sentry-core]]
-version = "0.48.3"
+version = "0.48.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.sentry-panic]]
-version = "0.48.3"
+version = "0.48.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.sentry-tracing]]
-version = "0.48.3"
+version = "0.48.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.sentry-types]]
-version = "0.48.3"
+version = "0.48.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_ignored]]
@@ -1058,7 +1054,7 @@ version = "0.1.14"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_json]]
-version = "1.0.150"
+version = "1.0.151"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_spanned]]
@@ -1068,10 +1064,6 @@ criteria = "safe-to-deploy"
 [[exemptions.serial2]]
 version = "0.2.37"
 criteria = "safe-to-run"
-
-[[exemptions.sha1]]
-version = "0.10.6"
-criteria = "safe-to-deploy"
 
 [[exemptions.sha2]]
 version = "0.11.0"
@@ -1185,8 +1177,12 @@ criteria = "safe-to-deploy"
 version = "2.0.118"
 criteria = "safe-to-deploy"
 
+[[exemptions.syn]]
+version = "3.0.2"
+criteria = "safe-to-deploy"
+
 [[exemptions.sysinfo]]
-version = "0.39.5"
+version = "0.39.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.tar]]
@@ -1214,11 +1210,11 @@ version = "0.23.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror]]
-version = "2.0.18"
+version = "2.0.19"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror-impl]]
-version = "2.0.18"
+version = "2.0.19"
 criteria = "safe-to-deploy"
 
 [[exemptions.thread-id]]
@@ -1242,7 +1238,7 @@ version = "0.2.31"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio]]
-version = "1.52.3"
+version = "1.53.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-macros]]
@@ -1330,7 +1326,7 @@ version = "0.8.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.uuid]]
-version = "1.23.4"
+version = "1.24.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.valuable]]
@@ -1418,7 +1414,7 @@ version = "0.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.which]]
-version = "8.0.4"
+version = "8.0.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.widestring]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -716,12 +716,6 @@ criteria = "safe-to-deploy"
 delta = "0.9.2 -> 0.9.4"
 notes = "Minor bugfix release"
 
-[[audits.bytecode-alliance.audits.sha1]]
-who = "Andrew Brown <andrew.brown@intel.com>"
-criteria = "safe-to-deploy"
-delta = "0.10.5 -> 0.10.6"
-notes = "Only new code is some loongarch64 additions which include assembly code for that platform."
-
 [[audits.bytecode-alliance.audits.sharded-slab]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -1533,13 +1527,6 @@ criteria = "safe-to-deploy"
 delta = "1.0.218 -> 1.0.219"
 notes = "Minor changes (clippy tweaks, using `mem::take` instead of `mem::replace`)."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.sha1]]
-who = "David Koloski <dkoloski@google.com>"
-criteria = "safe-to-deploy"
-version = "0.10.5"
-notes = "Reviewed on https://fxrev.dev/712371."
-aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.smallvec]]
 who = "Manish Goregaokar <manishearth@google.com>"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -716,6 +716,12 @@ criteria = "safe-to-deploy"
 delta = "0.9.2 -> 0.9.4"
 notes = "Minor bugfix release"
 
+[[audits.bytecode-alliance.audits.sha1]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+delta = "0.10.5 -> 0.10.6"
+notes = "Only new code is some loongarch64 additions which include assembly code for that platform."
+
 [[audits.bytecode-alliance.audits.sharded-slab]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -927,6 +933,38 @@ who = "Jonathan Hao <phao@chromium.org>"
 criteria = "safe-to-deploy"
 delta = "1.0.1 -> 1.0.2"
 notes = "No changes to any .rs files or Rust code."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.fdeflate]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.3.4"
+notes = '''
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'`, `'\bnet\b'`, `'\bunsafe\b'`
+and there were no hits.
+
+Note that some additional, internal notes about an older version of this crate
+can be found at go/image-crate-chromium-security-review.
+'''
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.fdeflate]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.4 -> 0.3.5"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.fdeflate]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.5 -> 0.3.6"
+notes = "No unsafe, no crypto, mysterious tables replaced with const expressions"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.fdeflate]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.6 -> 0.3.7"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.foldhash]]
@@ -1495,6 +1533,13 @@ criteria = "safe-to-deploy"
 delta = "1.0.218 -> 1.0.219"
 notes = "Minor changes (clippy tweaks, using `mem::take` instead of `mem::replace`)."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.sha1]]
+who = "David Koloski <dkoloski@google.com>"
+criteria = "safe-to-deploy"
+version = "0.10.5"
+notes = "Reviewed on https://fxrev.dev/712371."
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.smallvec]]
 who = "Manish Goregaokar <manishearth@google.com>"
@@ -2095,6 +2140,22 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.4.0 -> 0.4.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.objc2-core-foundation]]
+who = "Andy Leiserson <aleiserson@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.3.2"
+notes = """
+Contains substantial unsafe code, as is typical for FFI.
+
+The (non-published) `header-translator` crate that produces generated bindings
+in this crate was also reviewed, in lieu of a full review of the generated
+bindings.
+
+Users of this crate should be aware of the information in
+https://github.com/madsmtm/objc2/blob/main/crates/objc2/src/topics/frameworks_soundness.md.
+"""
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.option-ext]]


### PR DESCRIPTION
## Context

Six Dependabot PRs were open against this repo, and every one of them was red for a reason none of them could fix on its own. `cargo xtask vet` wants an audit entry for every new or bumped crate version, and `deny.toml` pins exact duplicate versions in its skip list. No Dependabot branch touches `supply-chain/` or `deny.toml`, and because `cargo deny check -D warnings` promotes `multiple-versions = "warn"` to fatal, any bump that leaves a second copy of a crate in the audited graph fails CI.

Consolidating the queue into one branch pays that gate work once instead of six times. Three of the six are taken here; the other three are declined on their merits, below.

Beyond these six, nothing is outdated: all 55 direct workspace dependencies were checked against crates.io, and once this lands every one sits at its newest stable. `zellij-tile` — the one dependency Dependabot structurally cannot see, pinned in lockstep with `ZELLIJ_VERSION` in `ci/Dockerfile` — is already current at 0.44.3.

## Design choices

**Take thiserror 2.0.19 and accept a transitional `syn` duplicate.** `thiserror-impl` 2.0.19 is the sole holder of `syn` 3.0.2, while 31 other proc-macro crates still carry `syn` 2.0.118. The alternative, holding thiserror, needs an exact `=2.0.18` pin to be durable — trading a temporary duplicate for permanent version drift and a Dependabot PR re-raised every Monday, all to defer a patch release. The skip names the subtree that jumped ahead and the condition that retires it.

**Take tungstenite 0.30, which shrinks the skip list on net.** It clears four dead entries: `sha1` 0.10.6 was the sole holder of `digest` 0.10.7 (and through it `block-buffer` 0.10.4 and `crypto-common` 0.1.7) and of `cpufeatures` 0.2.17. tungstenite 0.30 moves to sha1 0.11, whose stack is already present in the tree. It costs two new entries, because tungstenite moves to rand 0.10 while `proptest` and the optional `sentry` stack keep rand 0.9. Four deleted, three added: the skip list goes from ten entries to nine.

**Decline kdl 4.7.1 → 6.7.1, because it is silent data loss rather than churn.** kdl 6 parses and emits KDL v2 by default. RimZ does not own the KDL files it touches — it round-trips files Zellij owns, merging its presence-plugin grant into `permissions.kdl` and the `web_client` block of `config.kdl`. Zellij 0.44.3 reads KDL v1, so a v2 emit produces files it cannot parse. Worse, the permissions reader treats a parse failure as an empty document, so a v1 file kdl 6 rejects would be silently replaced, destroying every other plugin's grants with no error surfaced.

**Decline similar 2 → 3 and signal-hook 0.3 → 0.4, because their documented holds still stand.** `insta` 1.48.0 is the newest release and still requires `similar ^2`; `crossterm` 0.29.0 is the newest crossterm and still requires `signal-hook ^0.3.17`. Both would compile unchanged, so each buys no behaviour in exchange for a permanent duplicate — and signal-hook would add a skip entry nothing downstream could ever retire, undoing a third of the cleanup here.

**No Dependabot `ignore` rules for the three declined crates.** Each hold's trigger is an upstream move we need to *notice* — Zellij adopting kdl 6, insta adopting similar 3, crossterm adopting signal-hook 0.4. The recurring Dependabot PR is precisely that notification, and the comment beside each pin tells whoever triages it what to check. Suppressing the PR would hide the event we are waiting for.

## Implementation

Three self-contained commits, each independently green under `cargo deny check bans -D warnings`.

1. **The `cargo-minor-patch` group, 11 crates** — tokio 1.53.1, serde_json 1.0.151, thiserror 2.0.19, anyhow 1.0.104, uuid 1.24.0, jiff 0.2.34, clap 4.6.3, sentry and sentry-tracing 0.48.5, which 8.0.5, sysinfo 0.39.6. Lock-only; every manifest range already admitted these versions. Adds the `syn@3.0.2` skip in the same commit that introduces the duplicate.
2. **tungstenite 0.29 → 0.30** — one manifest line, the lock, and the deny skip-list rebalance described above.
3. **The CI image to `node:26-trixie`** — one line in `ci/Dockerfile`; the pinned tool `ARG`s are independent.

Supply-chain was refreshed after each dependency commit, regenerating upstream imports before exemptions so that versions already audited by Mozilla, Google, Embark, ISRG, or the Bytecode Alliance never acquire a local exemption. `jiff-core` and `chacha20` are new entries; everything else is a version bump on an existing one. Two exemptions were dropped outright — `fdeflate` and `objc2-core-foundation` — because the refreshed imports now cover them.

Deviations from the plan, both mechanical: `cargo update` rejects bare `-p thiserror` and `-p clap` as ambiguous, since the lock carries `thiserror` 1.0.69 and `clap` 3.2.25 alongside the workspace lines, so the selectors were disambiguated by version. Exemptions were generated rather than hand-audited, since adding local audits without a source review would misrepresent the review that actually happened.

No new tests: these are dependency bumps with no behaviour change on RimZ's side, and the existing transport tests already cover the one upstream behaviour that moved. No changelog entry, since nothing here is user-visible.

An independent review confirmed the change against the code rather than the report, and found no blocking defects. Worth recording, because two things look wrong at a glance and are not:

- The four deleted sha1-stack skips correspond to crates still present in `Cargo.lock`. They are not in the *audited* graph — their sole remaining holder is `sha2` 0.10.9 by way of `zellij-utils` and the wasm32 presence plugin, a target `deny.toml` deliberately excludes. `syn` 1.0.109 and `clap_complete` 3.2.5 sit in the lock un-skipped for the same reason.
- The matching `supply-chain/config.toml` exemptions were kept while the deny skips were deleted. That divergence is intended: cargo-deny excludes the wasm target, cargo-vet covers it at safe-to-run, so those exemptions remain live entries.

Verified green: `cargo xtask externals` (`advisories ok, bans ok, licenses ok, sources ok`, vetting succeeded), `cargo deny check bans -D warnings`, clippy, and the fast test subset, including the four `ws_transport` unit tests and the `codex_broker` integration test that drives the full client handshake against a stub app server. All of it re-run after the branch was rebased onto the current `main`.

## Advisories

- The node 26 image is not validated by this PR's `tests` job, which runs inside the currently published node-24 image. The `ci-image` workflow triggers a separate, non-pushing validation build on `pull_request` for `ci/Dockerfile`; that job is the one to watch here. The image publishes on merge to `main`.
- The `syn@3.0.2`, `rand@0.9.4`, and `rand_core@0.9.5` skips are transitional by construction. Each reason names its holders and its retirement condition, but nothing enforces removal — a future bump has to notice the graph converged and delete them.
- tungstenite 0.30's one behavioural change, a server rejecting a malformed `Sec-WebSocket-Key`, cannot reach production here: RimZ is purely a WebSocket client, and the only `tungstenite::accept` calls in the tree are in the transport module's own test harness.
- After merge, close the six Dependabot PRs, leaving a one-line reason on the kdl, similar, and signal-hook ones that points at the pin comment governing each hold, so the next triage does not re-litigate them.