### PR TITLE
feat(web): Nerd Font provisioning, theme colors, and Alt-key fix for ttyd browser access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ RimZ is alpha software on the 0.x line. Commands, flags, config keys, and output
 ### Added
 
 - First-run setup asks whether to enable auto-continue and automatic Codex reset-credit redemption together, defaulting yes. → [loops](./docs/guide/loops.md)
+- tmux browser rooms provision a verified JetBrainsMono or CaskaydiaCove Nerd Font, accept a local or HTTPS custom font, and use the active RimZ terminal colors. macOS Option chords now reach tmux as Meta input instead of composing browser characters. → [web](./docs/guide/web.md#tmux-rooms)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3144,6 +3144,7 @@ dependencies = [
  "anstyle",
  "anyhow",
  "assert_cmd",
+ "base64",
  "clap 4.6.3",
  "clap_complete 4.6.7",
  "colorchoice",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }
+# ttyd custom pages inline cached fonts as data URLs. `base64` is already in
+# the dependency graph through Sentry; making it direct avoids another local
+# codec on a browser-input boundary.
+base64 = "0.22"
 dotenvy = "0.15"
 # `rimz config` probes unknown keys through the serde model so the editable key
 # surface stays derived from the real config structs instead of a hand-mirrored

--- a/crates/rimz/Cargo.toml
+++ b/crates/rimz/Cargo.toml
@@ -133,6 +133,7 @@ workspace = true
 [dependencies]
 anstream.workspace = true
 anstyle.workspace = true
+base64.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
 colorchoice.workspace = true

--- a/crates/rimz/src/cli/web.rs
+++ b/crates/rimz/src/cli/web.rs
@@ -179,10 +179,10 @@ fn open(args: WebOpenArgs, globals: &GlobalFlags) -> Result<()> {
         return crate::cli::render::json(&outcome.payload);
     }
     print_url(&outcome.payload.url)?;
-    match outcome
-        .credential
-        .map_or_else(|| engine.ensure_credential(), std::result::Result::Ok)
-    {
+    match outcome.credential.map_or_else(
+        || engine.ensure_credential(&config),
+        std::result::Result::Ok,
+    ) {
         Ok(credential) => write_web_credential(&credential),
         Err(err) => write_credential_error(&err),
     }
@@ -346,7 +346,7 @@ fn stop() -> Result<()> {
 
 fn token(command: WebTokenSubcmd, globals: &GlobalFlags) -> Result<()> {
     let engine = WebEngine::from(rimz::mux::auto_detect_backend(globals.mux)?);
-    render_credential_outcome(engine.credential(command.into())?)
+    render_credential_outcome(engine.credential(command.into(), &machine_config())?)
 }
 
 fn render_credential_outcome(outcome: CredentialOutcome) -> Result<()> {
@@ -361,7 +361,9 @@ fn render_credential_outcome(outcome: CredentialOutcome) -> Result<()> {
         CredentialOutcome::Rotated {
             credential,
             restarted_instances,
+            warnings,
         } => {
+            write_warnings(&warnings);
             write_web_credential(&credential);
             writeln!(
                 std::io::stdout().lock(),
@@ -413,6 +415,9 @@ fn write_warnings(warnings: &[WebWarning]) {
     let mut stderr = std::io::stderr().lock();
     for warning in warnings {
         match warning {
+            WebWarning::BrowserFontSkipped(detail) => {
+                let _ = writeln!(stderr, "rimz: skipping browser font: {detail}");
+            }
             WebWarning::BrowserThemeSkipped(detail) => {
                 let _ = writeln!(stderr, "rimz: skipping browser theme: {detail}");
             }

--- a/crates/rimz/src/config/template_tests.rs
+++ b/crates/rimz/src/config/template_tests.rs
@@ -71,6 +71,7 @@ fn template_covers_serialized_default_leaves() {
 
     let allowed_template_only = BTreeSet::from([
         "web.tmux.base_url".to_owned(),
+        "web.tmux.font_source".to_owned(),
         "web.zellij.base_url".to_owned(),
     ]);
     for path in template.difference(&expected) {

--- a/crates/rimz/src/config/templates/config.template.toml
+++ b/crates/rimz/src/config/templates/config.template.toml
@@ -91,6 +91,9 @@
 # reverse proxy serves the per-room ttyd process under a public host or path.
 ## base_url = "https://devbox.example/tmux"
 # auto_start = true                   # `rimz web open` starts ttyd for the room when needed
+# font = "JetBrainsMono Nerd Font Mono" # browser terminal font; built-in JetBrainsMono and CaskaydiaCove Nerd Font Mono presets download automatically
+## font_source = "/path/to/font.woff2" # optional local font file or https URL; declared under the configured font family
+# style_client = true                 # style ttyd from [theme] and provision the configured browser font
 
 [mux]
 ## default = "tmux"                   # preferred backend when both zellij and tmux are installed; unset resolves to tmux

--- a/crates/rimz/src/config/web.rs
+++ b/crates/rimz/src/config/web.rs
@@ -3,10 +3,10 @@ use serde::{Deserialize, Serialize};
 /// Browser-access preferences for host-local room access.
 ///
 /// These are per-machine preferences: base URLs can name private hostnames,
-/// loopback tunnels, or reverse-proxy paths, and no field executes a command;
-/// `enabled` gates auto-granting RimZ's presence-plugin permissions and
-/// enabling browser sharing. The section therefore stays outside the project
-/// trust hash.
+/// loopback tunnels, or reverse-proxy paths, font sources name read-only paths
+/// or HTTPS URLs, and no field executes a command; `enabled` gates
+/// auto-granting RimZ's presence-plugin permissions and enabling browser
+/// sharing. The section therefore stays outside the project trust hash.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct WebPrefs {
@@ -32,6 +32,10 @@ pub struct TmuxWebPrefs {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
     pub auto_start: bool,
+    pub font: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub font_source: Option<String>,
+    pub style_client: bool,
 }
 
 impl Default for TmuxWebPrefs {
@@ -39,6 +43,9 @@ impl Default for TmuxWebPrefs {
         Self {
             base_url: None,
             auto_start: true,
+            font: "JetBrainsMono Nerd Font Mono".to_owned(),
+            font_source: None,
+            style_client: true,
         }
     }
 }

--- a/crates/rimz/src/web/colors.rs
+++ b/crates/rimz/src/web/colors.rs
@@ -1,0 +1,193 @@
+//! Shared browser-terminal palette projection.
+
+use serde_json::{Map, Value};
+
+use crate::config::{InlinePalette, parse_hex};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct WebClientColors {
+    pub background: (u8, u8, u8),
+    pub foreground: (u8, u8, u8),
+    pub cursor: (u8, u8, u8),
+    pub cursor_accent: (u8, u8, u8),
+    pub normal: [(u8, u8, u8); 8],
+    pub bright: [(u8, u8, u8); 8],
+    pub selection_background: Option<(u8, u8, u8)>,
+    pub selection_foreground: Option<(u8, u8, u8)>,
+}
+
+impl WebClientColors {
+    /// Build browser-client colors from an Alacritty palette. Missing optional
+    /// colors fall back to terminal conventions; malformed provided colors
+    /// return `None` so callers can skip theming without losing browser access.
+    pub(super) fn from_palette(palette: &InlinePalette) -> Option<Self> {
+        let primary = palette.primary.as_ref()?;
+        let normal = palette.normal.as_ref()?;
+        let background = parse_required_color(primary.background.as_deref())?;
+        let foreground = parse_required_color(primary.foreground.as_deref())?;
+        let normal = [
+            parse_optional_color(normal.black.as_deref())?.unwrap_or(background),
+            parse_required_color(normal.red.as_deref())?,
+            parse_required_color(normal.green.as_deref())?,
+            parse_required_color(normal.yellow.as_deref())?,
+            parse_required_color(normal.blue.as_deref())?,
+            parse_required_color(normal.magenta.as_deref())?,
+            parse_required_color(normal.cyan.as_deref())?,
+            parse_optional_color(normal.white.as_deref())?.unwrap_or(foreground),
+        ];
+        let bright = match palette.bright.as_ref() {
+            Some(bright) => [
+                parse_optional_color(bright.black.as_deref())?.unwrap_or(normal[0]),
+                parse_optional_color(bright.red.as_deref())?.unwrap_or(normal[1]),
+                parse_optional_color(bright.green.as_deref())?.unwrap_or(normal[2]),
+                parse_optional_color(bright.yellow.as_deref())?.unwrap_or(normal[3]),
+                parse_optional_color(bright.blue.as_deref())?.unwrap_or(normal[4]),
+                parse_optional_color(bright.magenta.as_deref())?.unwrap_or(normal[5]),
+                parse_optional_color(bright.cyan.as_deref())?.unwrap_or(normal[6]),
+                parse_optional_color(bright.white.as_deref())?.unwrap_or(normal[7]),
+            ],
+            None => normal,
+        };
+        let cursor = palette.cursor.as_ref();
+        let cursor_color =
+            parse_optional_color(cursor.and_then(|c| c.cursor.as_deref()))?.unwrap_or(foreground);
+        let cursor_accent =
+            parse_optional_color(cursor.and_then(|c| c.text.as_deref()))?.unwrap_or(background);
+        let selection = palette.selection.as_ref();
+        Some(Self {
+            background,
+            foreground,
+            cursor: cursor_color,
+            cursor_accent,
+            normal,
+            bright,
+            selection_background: parse_optional_color(
+                selection.and_then(|s| s.background.as_deref()),
+            )?,
+            selection_foreground: parse_optional_color(selection.and_then(|s| s.text.as_deref()))?,
+        })
+    }
+
+    pub(super) fn to_xterm_theme(&self) -> Value {
+        let mut theme = Map::new();
+        for (name, rgb) in [
+            ("background", self.background),
+            ("foreground", self.foreground),
+            ("cursor", self.cursor),
+            ("cursorAccent", self.cursor_accent),
+        ] {
+            theme.insert(name.to_owned(), Value::String(hex_color(rgb)));
+        }
+        if let Some(rgb) = self.selection_background {
+            theme.insert(
+                "selectionBackground".to_owned(),
+                Value::String(hex_color(rgb)),
+            );
+        }
+        if let Some(rgb) = self.selection_foreground {
+            theme.insert(
+                "selectionForeground".to_owned(),
+                Value::String(hex_color(rgb)),
+            );
+        }
+        for (name, rgb) in XTERM_NORMAL_COLOR_NAMES
+            .iter()
+            .copied()
+            .zip(self.normal.iter().copied())
+            .chain(
+                XTERM_BRIGHT_COLOR_NAMES
+                    .iter()
+                    .copied()
+                    .zip(self.bright.iter().copied()),
+            )
+        {
+            theme.insert(name.to_owned(), Value::String(hex_color(rgb)));
+        }
+        Value::Object(theme)
+    }
+}
+
+fn parse_required_color(value: Option<&str>) -> Option<(u8, u8, u8)> {
+    parse_hex(value?).ok()
+}
+
+fn parse_optional_color(value: Option<&str>) -> Option<Option<(u8, u8, u8)>> {
+    match value {
+        Some(value) => parse_hex(value).ok().map(Some),
+        None => Some(None),
+    }
+}
+
+fn hex_color((red, green, blue): (u8, u8, u8)) -> String {
+    format!("#{red:02x}{green:02x}{blue:02x}")
+}
+
+const XTERM_NORMAL_COLOR_NAMES: [&str; 8] = [
+    "black", "red", "green", "yellow", "blue", "magenta", "cyan", "white",
+];
+
+const XTERM_BRIGHT_COLOR_NAMES: [&str; 8] = [
+    "brightBlack",
+    "brightRed",
+    "brightGreen",
+    "brightYellow",
+    "brightBlue",
+    "brightMagenta",
+    "brightCyan",
+    "brightWhite",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{InlineAnsiColors, InlinePrimaryColors};
+
+    #[test]
+    fn xterm_theme_uses_hex_keys_and_omits_absent_selection_colors() {
+        let colors = WebClientColors {
+            background: (1, 2, 3),
+            foreground: (4, 5, 6),
+            cursor: (7, 8, 9),
+            cursor_accent: (10, 11, 12),
+            normal: [(13, 14, 15); 8],
+            bright: [(16, 17, 18); 8],
+            selection_background: None,
+            selection_foreground: None,
+        };
+        let theme = colors.to_xterm_theme();
+
+        assert_eq!(theme["background"], "#010203");
+        assert_eq!(theme["cursorAccent"], "#0a0b0c");
+        assert_eq!(theme["black"], "#0d0e0f");
+        assert_eq!(theme["brightWhite"], "#101112");
+        assert!(theme.get("selectionBackground").is_none());
+        assert!(theme.get("selectionForeground").is_none());
+    }
+
+    #[test]
+    fn palette_projection_applies_fallbacks_and_rejects_malformed_colors() {
+        let mut palette = InlinePalette {
+            primary: Some(InlinePrimaryColors {
+                background: Some("#010203".to_owned()),
+                foreground: Some("#fafbfc".to_owned()),
+            }),
+            normal: Some(InlineAnsiColors {
+                red: Some("#111213".to_owned()),
+                green: Some("#212223".to_owned()),
+                yellow: Some("#313233".to_owned()),
+                blue: Some("#414243".to_owned()),
+                magenta: Some("#515253".to_owned()),
+                cyan: Some("#616263".to_owned()),
+                ..InlineAnsiColors::default()
+            }),
+            ..InlinePalette::default()
+        };
+        let colors = WebClientColors::from_palette(&palette).expect("colors");
+        assert_eq!(colors.normal[0], colors.background);
+        assert_eq!(colors.normal[7], colors.foreground);
+        assert_eq!(colors.bright, colors.normal);
+
+        palette.normal.as_mut().expect("normal").green = Some("bad".to_owned());
+        assert_eq!(WebClientColors::from_palette(&palette), None);
+    }
+}

--- a/crates/rimz/src/web/fonts.rs
+++ b/crates/rimz/src/web/fonts.rs
@@ -1,0 +1,324 @@
+//! Browser-font resolution, verified downloads, and cache reuse.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use sha2::{Digest, Sha256};
+use url::Url;
+
+use crate::store::{atomic, paths};
+
+const OFFLINE_ENV: &str = "RIMZ_WEB_FONTS_OFFLINE";
+const FONT_CACHE_DIR: &str = "rimz/web-fonts";
+const FONT_FETCH_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_FONT_BYTES: u64 = 16 * 1024 * 1024;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct FontFace {
+    pub bytes: Vec<u8>,
+    pub extension: String,
+    pub weight: u16,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(super) struct FontResolution {
+    pub faces: Vec<FontFace>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PresetFace {
+    url: &'static str,
+    sha256: &'static str,
+    weight: u16,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct FontPreset {
+    family: &'static str,
+    faces: &'static [PresetFace],
+}
+
+const JETBRAINS_MONO_FACES: &[PresetFace] = &[
+    PresetFace {
+        url: "https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v3.4.0/patched-fonts/JetBrainsMono/Ligatures/Regular/JetBrainsMonoNerdFontMono-Regular.ttf",
+        sha256: "f01031f40e48dc29e1112e6b0b0450a2c6cd097f3f35cfff05c55cb311f8034c",
+        weight: 400,
+    },
+    PresetFace {
+        url: "https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v3.4.0/patched-fonts/JetBrainsMono/Ligatures/Bold/JetBrainsMonoNerdFontMono-Bold.ttf",
+        sha256: "5bdd4a873f3cd32f882d2c55545089123926e27707d5880fc9eaf84eb01b6686",
+        weight: 700,
+    },
+];
+
+const CASKAYDIA_COVE_FACES: &[PresetFace] = &[
+    PresetFace {
+        url: "https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v3.4.0/patched-fonts/CascadiaCode/CaskaydiaCoveNerdFontMono-Regular.ttf",
+        sha256: "32aa528c1d9be2240ceac90aa05f4e554679cabeb11b93684eb24ec4930bd0ea",
+        weight: 400,
+    },
+    PresetFace {
+        url: "https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v3.4.0/patched-fonts/CascadiaCode/CaskaydiaCoveNerdFontMono-Bold.ttf",
+        sha256: "3b7960d16d56bc3e0fd109c3f0e18b0ef547c863144dbf79e2ec71ab6ff3dd1e",
+        weight: 700,
+    },
+];
+
+const FONT_PRESETS: &[FontPreset] = &[
+    FontPreset {
+        family: "JetBrainsMono Nerd Font Mono",
+        faces: JETBRAINS_MONO_FACES,
+    },
+    FontPreset {
+        family: "CaskaydiaCove Nerd Font Mono",
+        faces: CASKAYDIA_COVE_FACES,
+    },
+];
+
+pub(super) fn resolve(family: &str, source: Option<&str>) -> FontResolution {
+    match source.map(str::trim).filter(|source| !source.is_empty()) {
+        Some(source) => match resolve_custom(source) {
+            Ok(face) => FontResolution {
+                faces: vec![face],
+                warnings: Vec::new(),
+            },
+            Err(err) => FontResolution {
+                faces: Vec::new(),
+                warnings: vec![err],
+            },
+        },
+        None => resolve_preset(family),
+    }
+}
+
+fn resolve_custom(source: &str) -> Result<FontFace, String> {
+    if source.starts_with("https://") {
+        let url =
+            Url::parse(source).map_err(|err| format!("invalid font URL `{source}`: {err}"))?;
+        let extension = extension_from_path(Path::new(url.path()))?;
+        let path = font_cache_dir().join(format!(
+            "{}.{}",
+            hex::encode(Sha256::digest(source.as_bytes())),
+            extension
+        ));
+        let bytes = match fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                if offline() {
+                    return Err(format!(
+                        "font `{source}` is not cached and {OFFLINE_ENV} is set"
+                    ));
+                }
+                let bytes = fetch(source)?;
+                atomic::write_cache_bytes_atomically(&path, &bytes)
+                    .map_err(|err| format!("could not cache font `{}`: {err}", path.display()))?;
+                bytes
+            }
+            Err(err) => {
+                return Err(format!(
+                    "could not read font cache `{}`: {err}",
+                    path.display()
+                ));
+            }
+        };
+        validate_size(source, &bytes)?;
+        return Ok(FontFace {
+            bytes,
+            extension,
+            weight: 400,
+        });
+    }
+    if source.contains("://") {
+        return Err(format!("font URL must use https: `{source}`"));
+    }
+    let path = PathBuf::from(source);
+    let extension = extension_from_path(&path)?;
+    let bytes = fs::read(&path)
+        .map_err(|err| format!("could not read font `{}`: {err}", path.display()))?;
+    validate_size(source, &bytes)?;
+    Ok(FontFace {
+        bytes,
+        extension,
+        weight: 400,
+    })
+}
+
+fn resolve_preset(family: &str) -> FontResolution {
+    let Some(preset) = FONT_PRESETS.iter().find(|preset| preset.family == family) else {
+        return FontResolution::default();
+    };
+    let mut resolution = FontResolution::default();
+    for face in preset.faces {
+        match resolve_preset_face(*face) {
+            Ok(face) => resolution.faces.push(face),
+            Err(err) => resolution.warnings.push(err),
+        }
+    }
+    resolution
+}
+
+fn resolve_preset_face(face: PresetFace) -> Result<FontFace, String> {
+    let url = Url::parse(face.url).map_err(|err| format!("invalid built-in font URL: {err}"))?;
+    let file = Path::new(url.path())
+        .file_name()
+        .ok_or_else(|| format!("built-in font URL has no filename: {}", face.url))?;
+    let extension = extension_from_path(Path::new(file))?;
+    let path = font_cache_dir().join(file);
+    match fs::read(&path) {
+        Ok(bytes) if sha256_hex(&bytes) == face.sha256 => {
+            return Ok(FontFace {
+                bytes,
+                extension,
+                weight: face.weight,
+            });
+        }
+        Ok(_) if offline() => {
+            return Err(format!(
+                "cached font `{}` failed checksum verification and {OFFLINE_ENV} is set",
+                path.display()
+            ));
+        }
+        Ok(_) => {}
+        Err(err) if err.kind() == io::ErrorKind::NotFound && offline() => {
+            return Err(format!(
+                "font `{}` is not cached and {OFFLINE_ENV} is set",
+                preset_filename(face.url)
+            ));
+        }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+        Err(err) => {
+            return Err(format!(
+                "could not read font cache `{}`: {err}",
+                path.display()
+            ));
+        }
+    }
+
+    let bytes = fetch(face.url)?;
+    let actual = sha256_hex(&bytes);
+    if actual != face.sha256 {
+        return Err(format!(
+            "downloaded font `{}` failed checksum verification",
+            preset_filename(face.url)
+        ));
+    }
+    atomic::write_cache_bytes_atomically(&path, &bytes)
+        .map_err(|err| format!("could not cache font `{}`: {err}", path.display()))?;
+    Ok(FontFace {
+        bytes,
+        extension,
+        weight: face.weight,
+    })
+}
+
+fn fetch(url: &str) -> Result<Vec<u8>, String> {
+    let agent = ureq::Agent::config_builder()
+        .timeout_global(Some(FONT_FETCH_TIMEOUT))
+        .build()
+        .new_agent();
+    let mut response = agent
+        .get(url)
+        .call()
+        .map_err(|err| format!("could not download font `{url}`: {err}"))?;
+    if response.status().as_u16() != 200 {
+        return Err(format!(
+            "font download `{url}` returned HTTP {}",
+            response.status().as_u16()
+        ));
+    }
+    response
+        .body_mut()
+        .with_config()
+        .limit(MAX_FONT_BYTES)
+        .read_to_vec()
+        .map_err(|err| format!("could not read font download `{url}`: {err}"))
+}
+
+fn extension_from_path(path: &Path) -> Result<String, String> {
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(str::to_ascii_lowercase)
+        .ok_or_else(|| {
+            format!(
+                "font source `{}` must end in .ttf, .otf, .woff, or .woff2",
+                path.display()
+            )
+        })?;
+    match extension.as_str() {
+        "ttf" | "otf" | "woff" | "woff2" => Ok(extension),
+        _ => Err(format!(
+            "font source `{}` must end in .ttf, .otf, .woff, or .woff2",
+            path.display()
+        )),
+    }
+}
+
+fn validate_size(source: &str, bytes: &[u8]) -> Result<(), String> {
+    if bytes.len() as u64 <= MAX_FONT_BYTES {
+        Ok(())
+    } else {
+        Err(format!(
+            "font `{source}` exceeds the {} MiB browser-font limit",
+            MAX_FONT_BYTES / 1024 / 1024
+        ))
+    }
+}
+
+fn font_cache_dir() -> PathBuf {
+    paths::cache_home().join(FONT_CACHE_DIR)
+}
+
+fn offline() -> bool {
+    std::env::var_os(OFFLINE_ENV).is_some()
+}
+
+fn preset_filename(url: &str) -> &str {
+    url.rsplit('/').next().unwrap_or(url)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn presets_are_https_sha256_pinned_regular_and_bold_fonts() {
+        assert_eq!(FONT_PRESETS.len(), 2);
+        for preset in FONT_PRESETS {
+            assert!(preset.family.ends_with("Nerd Font Mono"));
+            assert_eq!(
+                preset
+                    .faces
+                    .iter()
+                    .map(|face| face.weight)
+                    .collect::<Vec<_>>(),
+                [400, 700]
+            );
+            for face in preset.faces {
+                assert!(face.url.starts_with("https://"));
+                assert!(face.url.contains("/v3.4.0/patched-fonts/"));
+                assert_eq!(face.sha256.len(), 64);
+                assert!(face.sha256.bytes().all(|byte| byte.is_ascii_hexdigit()));
+                assert_eq!(
+                    extension_from_path(Path::new(face.url)),
+                    Ok("ttf".to_owned())
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn unsupported_font_extensions_are_rejected() {
+        assert!(extension_from_path(Path::new("font.ttf")).is_ok());
+        assert!(extension_from_path(Path::new("font.WOFF2")).is_ok());
+        assert!(extension_from_path(Path::new("font.zip")).is_err());
+        assert!(extension_from_path(Path::new("font")).is_err());
+    }
+}

--- a/crates/rimz/src/web/fonts.rs
+++ b/crates/rimz/src/web/fonts.rs
@@ -124,7 +124,7 @@ fn resolve_custom(source: &str) -> Result<FontFace, String> {
                 ));
             }
         };
-        validate_size(source, &bytes)?;
+        validate_size(source, bytes.len() as u64)?;
         return Ok(FontFace {
             bytes,
             extension,
@@ -134,11 +134,14 @@ fn resolve_custom(source: &str) -> Result<FontFace, String> {
     if source.contains("://") {
         return Err(format!("font URL must use https: `{source}`"));
     }
-    let path = PathBuf::from(source);
+    let path = expand_home(Path::new(source));
     let extension = extension_from_path(&path)?;
+    let size = fs::metadata(&path)
+        .map_err(|err| format!("could not inspect font `{}`: {err}", path.display()))?
+        .len();
+    validate_size(source, size)?;
     let bytes = fs::read(&path)
         .map_err(|err| format!("could not read font `{}`: {err}", path.display()))?;
-    validate_size(source, &bytes)?;
     Ok(FontFace {
         bytes,
         extension,
@@ -257,8 +260,8 @@ fn extension_from_path(path: &Path) -> Result<String, String> {
     }
 }
 
-fn validate_size(source: &str, bytes: &[u8]) -> Result<(), String> {
-    if bytes.len() as u64 <= MAX_FONT_BYTES {
+fn validate_size(source: &str, size: u64) -> Result<(), String> {
+    if size <= MAX_FONT_BYTES {
         Ok(())
     } else {
         Err(format!(
@@ -266,6 +269,21 @@ fn validate_size(source: &str, bytes: &[u8]) -> Result<(), String> {
             MAX_FONT_BYTES / 1024 / 1024
         ))
     }
+}
+
+fn expand_home(path: &Path) -> PathBuf {
+    let raw = path.as_os_str().to_string_lossy();
+    if raw == "~" {
+        return std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("~"));
+    }
+    if let Some(rest) = raw.strip_prefix("~/")
+        && let Some(home) = std::env::var_os("HOME")
+    {
+        return PathBuf::from(home).join(rest);
+    }
+    path.to_path_buf()
 }
 
 fn font_cache_dir() -> PathBuf {

--- a/crates/rimz/src/web/mod.rs
+++ b/crates/rimz/src/web/mod.rs
@@ -13,6 +13,8 @@ use crate::ids::MuxName;
 use crate::mux::{CommandSpec, MuxErr};
 use crate::store::atomic;
 
+mod colors;
+mod fonts;
 mod ttyd;
 mod zellij;
 
@@ -134,15 +136,19 @@ impl WebEngine {
         }
     }
 
-    pub fn credential(self, command: CredentialCommand) -> Result<CredentialOutcome> {
+    pub fn credential(
+        self,
+        command: CredentialCommand,
+        config: &MachineConfig,
+    ) -> Result<CredentialOutcome> {
         match self {
-            Self::Zellij => zellij::credential(command),
-            Self::Ttyd => ttyd::credential(command),
+            Self::Zellij => zellij::credential(command, config),
+            Self::Ttyd => ttyd::credential(command, config),
         }
     }
 
-    pub fn ensure_credential(self) -> Result<WebCredential> {
-        match self.credential(CredentialCommand::Ensure)? {
+    pub fn ensure_credential(self, config: &MachineConfig) -> Result<WebCredential> {
+        match self.credential(CredentialCommand::Ensure, config)? {
             CredentialOutcome::Ensured(credential) => Ok(credential),
             // Concrete engine dispatch maps Ensure to this one outcome.
             _ => unreachable!("ensure command returns an ensured credential"),
@@ -213,6 +219,7 @@ pub struct WebStatusPayload {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum WebWarning {
+    BrowserFontSkipped(String),
     BrowserThemeSkipped(String),
 }
 
@@ -301,6 +308,7 @@ pub enum CredentialOutcome {
     Rotated {
         credential: WebCredential,
         restarted_instances: usize,
+        warnings: Vec<WebWarning>,
     },
     Listed(Vec<CredentialSummary>),
     Revoked {

--- a/crates/rimz/src/web/ttyd.rs
+++ b/crates/rimz/src/web/ttyd.rs
@@ -8,8 +8,10 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 
+use base64::Engine as _;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::config::MachineConfig;
 use crate::mux::CommandSpec;
@@ -17,15 +19,19 @@ use crate::store::{atomic, paths};
 
 use super::{
     CredentialCommand, CredentialOutcome, CredentialSummary, Result, TtydStatusInstance,
-    WebAccessOutcome, WebCredential, WebEngine, WebErr, WebOpenPayload, derive_port,
+    WebAccessOutcome, WebCredential, WebEngine, WebErr, WebOpenPayload, WebWarning, derive_port,
     normalized_base_url, port_scan,
 };
+use super::{colors::WebClientColors, fonts::FontFace};
 
 const TTYD_BIN_ENV: &str = "RIMZ_TTYD_BIN";
 const TTYD_PORT_RANGE: RangeInclusive<u16> = 8200..=8299;
 const CREDENTIAL_FILE: &str = "web-ttyd-credential.json";
 const INSTANCE_DIR: &str = "web-ttyd";
 const START_TIMEOUT: Duration = Duration::from_secs(5);
+const STOCK_INDEX_TIMEOUT: Duration = Duration::from_secs(5);
+const STOCK_INDEX_MAX_BYTES: u64 = 16 * 1024 * 1024;
+const INDEX_CACHE_DIR: &str = "rimz/web-ttyd";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 struct TtydCredential {
@@ -39,6 +45,12 @@ struct TtydInstance {
     session: String,
     pid: u32,
     port: u16,
+}
+
+#[derive(Clone, Debug, Default)]
+struct TtydClientProfile {
+    args: Vec<String>,
+    warnings: Vec<WebWarning>,
 }
 
 pub(super) fn preflight() -> Result<()> {
@@ -74,7 +86,7 @@ pub(super) fn open_session(
     may_start: bool,
 ) -> Result<WebAccessOutcome> {
     preflight()?;
-    let (instance, credential) = ensure_instance(session, may_start)?;
+    let (instance, credential, warnings) = ensure_instance(session, config, may_start)?;
     let fallback = format!("http://127.0.0.1:{}", instance.port);
     let base_url = normalized_base_url(config.web.tmux.base_url.as_deref(), None, &fallback);
     Ok(WebAccessOutcome {
@@ -87,7 +99,7 @@ pub(super) fn open_session(
             1,
         ),
         credential: Some(basic_auth(&credential)),
-        warnings: Vec::new(),
+        warnings,
     })
 }
 
@@ -108,14 +120,18 @@ pub(super) fn inspect_session(session: &str, config: &MachineConfig) -> Result<W
     ))
 }
 
-pub(super) fn credential(command: CredentialCommand) -> Result<CredentialOutcome> {
+pub(super) fn credential(
+    command: CredentialCommand,
+    config: &MachineConfig,
+) -> Result<CredentialOutcome> {
     match command {
         CredentialCommand::Create { read_only: true } => Err(WebErr::TtydReadOnlyCredential),
         CredentialCommand::Create { read_only: false } => {
-            let (credential, restarted_instances) = rotate_credential()?;
+            let (credential, restarted_instances, warnings) = rotate_credential(config)?;
             Ok(CredentialOutcome::Rotated {
                 credential: basic_auth(&credential),
                 restarted_instances,
+                warnings,
             })
         }
         CredentialCommand::List => Ok(CredentialOutcome::Listed(
@@ -194,24 +210,42 @@ fn clear_credential() -> Result<bool> {
     remove_optional(&credential_path())
 }
 
-fn ensure_instance(session: &str, may_start: bool) -> Result<(TtydInstance, TtydCredential)> {
+fn ensure_instance(
+    session: &str,
+    config: &MachineConfig,
+    may_start: bool,
+) -> Result<(TtydInstance, TtydCredential, Vec<WebWarning>)> {
     let credential = ensure_credential()?;
     if let Some(instance) = inventory()?
         .into_iter()
         .find(|instance| instance.session == session)
     {
-        return Ok((instance, credential));
+        return Ok((instance, credential, Vec::new()));
     }
     if !may_start {
         return Err(WebErr::TtydOffline(session.to_owned()));
     }
-    let instance = start_instance(session, &credential)?;
-    Ok((instance, credential))
+    let (instance, warnings) = start_instance(session, &credential, config)?;
+    Ok((instance, credential, warnings))
 }
 
-fn start_instance(session: &str, credential: &TtydCredential) -> Result<TtydInstance> {
+fn start_instance(
+    session: &str,
+    credential: &TtydCredential,
+    config: &MachineConfig,
+) -> Result<(TtydInstance, Vec<WebWarning>)> {
+    let profile = client_profile(config);
+    let instance = start_instance_with_profile(session, credential, &profile)?;
+    Ok((instance, profile.warnings))
+}
+
+fn start_instance_with_profile(
+    session: &str,
+    credential: &TtydCredential,
+    profile: &TtydClientProfile,
+) -> Result<TtydInstance> {
     let port = choose_instance_port(session)?;
-    let spec = spawn_spec(session, port, &credential.secret)?;
+    let spec = spawn_spec(session, port, &credential.secret, &profile.args)?;
     let pid = spawn_detached(spec)?;
     let instance = TtydInstance {
         session: session.to_owned(),
@@ -229,14 +263,18 @@ fn start_instance(session: &str, credential: &TtydCredential) -> Result<TtydInst
     Ok(instance)
 }
 
-fn rotate_credential() -> Result<(TtydCredential, usize)> {
+fn rotate_credential(config: &MachineConfig) -> Result<(TtydCredential, usize, Vec<WebWarning>)> {
     let credential = mint_credential()?;
     let instances = inventory()?;
     stop_instances(&instances)?;
-    for instance in &instances {
-        start_instance(&instance.session, &credential)?;
+    if instances.is_empty() {
+        return Ok((credential, 0, Vec::new()));
     }
-    Ok((credential, instances.len()))
+    let profile = client_profile(config);
+    for instance in &instances {
+        start_instance_with_profile(&instance.session, &credential, &profile)?;
+    }
+    Ok((credential, instances.len(), profile.warnings))
 }
 
 fn revoke_credential() -> Result<usize> {
@@ -318,13 +356,213 @@ fn stop_instances(instances: &[TtydInstance]) -> Result<()> {
     }
 }
 
-fn spawn_spec(session: &str, port: u16, secret: &str) -> Result<CommandSpec> {
+fn client_profile(config: &MachineConfig) -> TtydClientProfile {
+    let mut profile = TtydClientProfile {
+        args: vec!["-t".to_owned(), "macOptionIsMeta=true".to_owned()],
+        warnings: Vec::new(),
+    };
+    if !config.web.enabled || !config.web.tmux.style_client {
+        return profile;
+    }
+
+    let family = &config.web.tmux.font;
+    profile
+        .args
+        .extend(["-t".to_owned(), format!("fontFamily={family},monospace")]);
+    match WebClientColors::from_palette(&crate::config::resolve_inline_palette(&config.theme)) {
+        Some(colors) => match serde_json::to_string(&colors.to_xterm_theme()) {
+            Ok(theme) => profile
+                .args
+                .extend(["-t".to_owned(), format!("theme={theme}")]),
+            Err(err) => profile
+                .warnings
+                .push(WebWarning::BrowserThemeSkipped(format!(
+                    "could not serialize browser theme: {err}"
+                ))),
+        },
+        None => profile.warnings.push(WebWarning::BrowserThemeSkipped(
+            "scheme palette is incomplete or malformed".to_owned(),
+        )),
+    }
+
+    let resolution = super::fonts::resolve(family, config.web.tmux.font_source.as_deref());
+    profile.warnings.extend(
+        resolution
+            .warnings
+            .into_iter()
+            .map(WebWarning::BrowserFontSkipped),
+    );
+    if resolution.faces.is_empty() {
+        return profile;
+    }
+
+    let index = program()
+        .and_then(|program| version_at(&program).map(|version| (program, version)))
+        .map_err(|err| err.to_string())
+        .and_then(|(program, version)| {
+            ensure_custom_index(&program, &version, family, &resolution.faces)
+        });
+    match index {
+        Ok(Some(path)) => profile
+            .args
+            .extend(["-I".to_owned(), path.display().to_string()]),
+        Ok(None) => profile.warnings.push(WebWarning::BrowserFontSkipped(
+            "stock ttyd index has no </head> marker".to_owned(),
+        )),
+        Err(err) => profile.warnings.push(WebWarning::BrowserFontSkipped(err)),
+    }
+    profile
+}
+
+fn ensure_custom_index(
+    program: &Path,
+    ttyd_version: &str,
+    family: &str,
+    faces: &[FontFace],
+) -> std::result::Result<Option<PathBuf>, String> {
+    let key = custom_index_key(ttyd_version, family, faces);
+    let path = paths::cache_home()
+        .join(INDEX_CACHE_DIR)
+        .join(format!("index-{key}.html"));
+    if path.is_file() {
+        return Ok(Some(path));
+    }
+
+    let stock = fetch_stock_index(program)?;
+    let Some(rendered) = inject_font_faces(&stock, family, faces) else {
+        return Ok(None);
+    };
+    atomic::write_cache_bytes_atomically(&path, rendered.as_bytes()).map_err(|err| {
+        format!(
+            "could not cache generated ttyd index `{}`: {err}",
+            path.display()
+        )
+    })?;
+    Ok(Some(path))
+}
+
+fn fetch_stock_index(program: &Path) -> std::result::Result<String, String> {
+    let session = "rimz-stock-index";
+    let port = choose_instance_port(session).map_err(|err| err.to_string())?;
+    let secret = random_secret();
+    let spec = CommandSpec::new(program.display().to_string())
+        .args(["-c", &format!("rimz:{secret}"), "-i", "127.0.0.1", "-p"])
+        .arg(port.to_string())
+        .arg("sh");
+    let pid = spawn_detached(spec).map_err(|err| err.to_string())?;
+    let instance = TtydInstance {
+        session: session.to_owned(),
+        pid,
+        port,
+    };
+    if !wait_for_port(port, START_TIMEOUT) {
+        let _ = stop_instances(std::slice::from_ref(&instance));
+        return Err(format!(
+            "stock ttyd did not accept connections on 127.0.0.1:{port} within 5 seconds"
+        ));
+    }
+
+    let fetched = get_stock_index(port, &secret);
+    let stopped = stop_instances(std::slice::from_ref(&instance)).map_err(|err| err.to_string());
+    match (fetched, stopped) {
+        (Ok(index), Ok(())) => Ok(index),
+        (Err(err), _) | (Ok(_), Err(err)) => Err(err),
+    }
+}
+
+fn get_stock_index(port: u16, secret: &str) -> std::result::Result<String, String> {
+    let agent = ureq::Agent::config_builder()
+        .timeout_global(Some(STOCK_INDEX_TIMEOUT))
+        .build()
+        .new_agent();
+    let credentials = base64::engine::general_purpose::STANDARD.encode(format!("rimz:{secret}"));
+    let url = format!("http://127.0.0.1:{port}/");
+    let mut response = agent
+        .get(&url)
+        .header("Authorization", format!("Basic {credentials}"))
+        .call()
+        .map_err(|err| format!("could not fetch stock ttyd index: {err}"))?;
+    if response.status().as_u16() != 200 {
+        return Err(format!(
+            "stock ttyd index returned HTTP {}",
+            response.status().as_u16()
+        ));
+    }
+    let bytes = response
+        .body_mut()
+        .with_config()
+        .limit(STOCK_INDEX_MAX_BYTES)
+        .read_to_vec()
+        .map_err(|err| format!("could not read stock ttyd index: {err}"))?;
+    String::from_utf8(bytes).map_err(|err| format!("stock ttyd index is not UTF-8: {err}"))
+}
+
+fn custom_index_key(ttyd_version: &str, family: &str, faces: &[FontFace]) -> String {
+    let mut hasher = Sha256::new();
+    hash_index_part(&mut hasher, ttyd_version.as_bytes());
+    hash_index_part(&mut hasher, family.as_bytes());
+    for face in faces {
+        hash_index_part(&mut hasher, face.extension.as_bytes());
+        hash_index_part(&mut hasher, &face.weight.to_le_bytes());
+        hash_index_part(&mut hasher, &Sha256::digest(&face.bytes));
+    }
+    hex::encode(&hasher.finalize()[..16])
+}
+
+fn hash_index_part(hasher: &mut Sha256, value: &[u8]) {
+    hasher.update((value.len() as u64).to_le_bytes());
+    hasher.update(value);
+}
+
+fn inject_font_faces(stock: &str, family: &str, faces: &[FontFace]) -> Option<String> {
+    let marker = stock.find("</head>")?;
+    let family = css_string(family);
+    let mut style = String::from("<style id=\"rimz-web-fonts\">");
+    for face in faces {
+        let payload = base64::engine::general_purpose::STANDARD.encode(&face.bytes);
+        style.push_str(&format!(
+            "@font-face{{font-family:\"{family}\";font-style:normal;font-weight:{};src:url(data:font/{};base64,{payload})}}",
+            face.weight, face.extension
+        ));
+    }
+    style.push_str("</style>");
+
+    let mut rendered = String::with_capacity(stock.len() + style.len());
+    rendered.push_str(&stock[..marker]);
+    rendered.push_str(&style);
+    rendered.push_str(&stock[marker..]);
+    Some(rendered)
+}
+
+fn css_string(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '<' => escaped.push_str("\\3c "),
+            '\n' => escaped.push_str("\\a "),
+            '\r' => escaped.push_str("\\d "),
+            '\0' => escaped.push_str("\\fffd "),
+            ch => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+fn spawn_spec(
+    session: &str,
+    port: u16,
+    secret: &str,
+    extra_args: &[String],
+) -> Result<CommandSpec> {
     Ok(spawn_spec_for(
         &program()?,
         session,
         port,
         secret,
         &crate::mux::tmux::managed_server_socket_path(),
+        extra_args,
     ))
 }
 
@@ -336,6 +574,7 @@ fn spawn_spec_for(
     port: u16,
     secret: &str,
     tmux_socket: &Path,
+    extra_args: &[String],
 ) -> CommandSpec {
     CommandSpec::new(program.display().to_string())
         .args(["-W", "-O", "-c"])
@@ -344,6 +583,7 @@ fn spawn_spec_for(
         .arg(port.to_string())
         .args(["-b"])
         .arg(format!("/{session}"))
+        .args(extra_args.iter().cloned())
         .args(["tmux", "-S"])
         .arg(tmux_socket.display().to_string())
         .args(["attach", "-t"])
@@ -474,6 +714,7 @@ mod tests {
             8201,
             "secret",
             Path::new("/run/user/1000/rimz/tmux/server"),
+            &["-t".to_owned(), "macOptionIsMeta=true".to_owned()],
         );
         assert_eq!(
             spec.args,
@@ -488,6 +729,8 @@ mod tests {
                 "8201",
                 "-b",
                 "/rimz-project-a1b2c3",
+                "-t",
+                "macOptionIsMeta=true",
                 "tmux",
                 "-S",
                 "/run/user/1000/rimz/tmux/server",
@@ -496,6 +739,58 @@ mod tests {
                 "rimz-project-a1b2c3"
             ]
         );
+    }
+
+    #[test]
+    fn styled_argv_keeps_all_client_options_before_tmux() {
+        let extra = vec![
+            "-t".to_owned(),
+            "macOptionIsMeta=true".to_owned(),
+            "-t".to_owned(),
+            "fontFamily=RimZ Font,monospace".to_owned(),
+            "-t".to_owned(),
+            "theme={\"background\":\"#010203\"}".to_owned(),
+            "-I".to_owned(),
+            "/cache/index.html".to_owned(),
+        ];
+        let spec = spawn_spec_for(
+            Path::new("/tmp/ttyd"),
+            "room",
+            8202,
+            "secret",
+            Path::new("/tmp/tmux.sock"),
+            &extra,
+        );
+
+        let tmux = spec
+            .args
+            .iter()
+            .position(|arg| arg == "tmux")
+            .expect("tmux argv");
+        assert_eq!(&spec.args[tmux - extra.len()..tmux], extra);
+    }
+
+    #[test]
+    fn custom_index_key_is_stable_and_font_faces_inject_before_head_close() {
+        let faces = vec![FontFace {
+            bytes: b"font bytes".to_vec(),
+            extension: "woff2".to_owned(),
+            weight: 400,
+        }];
+        let key = custom_index_key("ttyd 1.7.7", "RimZ \"Font\"", &faces);
+        assert_eq!(key, custom_index_key("ttyd 1.7.7", "RimZ \"Font\"", &faces));
+        assert_ne!(key, custom_index_key("ttyd 1.7.8", "RimZ \"Font\"", &faces));
+
+        let rendered = inject_font_faces(
+            "<html><head><title>ttyd</title></head><body></body></html>",
+            "RimZ \"Font\" </style>",
+            &faces,
+        )
+        .expect("head marker");
+        assert!(rendered.contains("font-family:\"RimZ \\\"Font\\\" \\3c /style>\""));
+        assert!(rendered.contains("data:font/woff2;base64,Zm9udCBieXRlcw=="));
+        assert!(rendered.find("rimz-web-fonts").unwrap() < rendered.find("</head>").unwrap());
+        assert_eq!(inject_font_faces("<html></html>", "font", &faces), None);
     }
 
     #[test]

--- a/crates/rimz/src/web/ttyd.rs
+++ b/crates/rimz/src/web/ttyd.rs
@@ -264,13 +264,13 @@ fn start_instance_with_profile(
 }
 
 fn rotate_credential(config: &MachineConfig) -> Result<(TtydCredential, usize, Vec<WebWarning>)> {
-    let credential = mint_credential()?;
     let instances = inventory()?;
-    stop_instances(&instances)?;
     if instances.is_empty() {
-        return Ok((credential, 0, Vec::new()));
+        return Ok((mint_credential()?, 0, Vec::new()));
     }
     let profile = client_profile(config);
+    let credential = mint_credential()?;
+    stop_instances(&instances)?;
     for instance in &instances {
         start_instance_with_profile(&instance.session, &credential, &profile)?;
     }
@@ -768,6 +768,21 @@ mod tests {
             .position(|arg| arg == "tmux")
             .expect("tmux argv");
         assert_eq!(&spec.args[tmux - extra.len()..tmux], extra);
+    }
+
+    #[test]
+    fn alt_meta_option_survives_disabled_client_styling_and_web() {
+        let mut config = MachineConfig::default();
+        config.web.tmux.style_client = false;
+        let profile = client_profile(&config);
+        assert_eq!(profile.args, ["-t", "macOptionIsMeta=true"]);
+        assert!(profile.warnings.is_empty());
+
+        config.web.tmux.style_client = true;
+        config.web.enabled = false;
+        let profile = client_profile(&config);
+        assert_eq!(profile.args, ["-t", "macOptionIsMeta=true"]);
+        assert!(profile.warnings.is_empty());
     }
 
     #[test]

--- a/crates/rimz/src/web/ttyd.rs
+++ b/crates/rimz/src/web/ttyd.rs
@@ -270,6 +270,7 @@ fn rotate_credential(config: &MachineConfig) -> Result<(TtydCredential, usize, V
     }
     let profile = client_profile(config);
     let credential = mint_credential()?;
+    let instances = inventory()?;
     stop_instances(&instances)?;
     for instance in &instances {
         start_instance_with_profile(&instance.session, &credential, &profile)?;

--- a/crates/rimz/src/web/zellij.rs
+++ b/crates/rimz/src/web/zellij.rs
@@ -8,10 +8,11 @@ use kdl::{KdlDocument, KdlEntry, KdlNode};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::config::{InlinePalette, MachineConfig, parse_hex};
+use crate::config::MachineConfig;
 use crate::mux::CommandSpec;
 use crate::store::{atomic, paths};
 
+use super::colors::WebClientColors;
 use super::{
     CredentialCommand, CredentialOutcome, RawCommandOutput, Result, WebAccessOutcome,
     WebCredential, WebEngine, WebErr, WebOpenPayload, WebStartOptions, WebWarning,
@@ -54,72 +55,6 @@ impl Default for ZellijWebEndpoint {
             ip: DEFAULT_IP.to_owned(),
             port: DEFAULT_PORT,
         }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct WebClientColors {
-    pub background: (u8, u8, u8),
-    pub foreground: (u8, u8, u8),
-    pub cursor: (u8, u8, u8),
-    pub cursor_accent: (u8, u8, u8),
-    pub normal: [(u8, u8, u8); 8],
-    pub bright: [(u8, u8, u8); 8],
-    pub selection_background: Option<(u8, u8, u8)>,
-    pub selection_foreground: Option<(u8, u8, u8)>,
-}
-
-impl WebClientColors {
-    /// Build Zellij web-client colors from an Alacritty palette. Missing
-    /// optional colors fall back to terminal conventions; malformed provided
-    /// colors return `None` so callers can skip browser theming without
-    /// discarding the user's Zellij config.
-    fn from_palette(palette: &InlinePalette) -> Option<Self> {
-        let primary = palette.primary.as_ref()?;
-        let normal = palette.normal.as_ref()?;
-        let background = parse_required_color(primary.background.as_deref())?;
-        let foreground = parse_required_color(primary.foreground.as_deref())?;
-        let normal = [
-            parse_optional_color(normal.black.as_deref())?.unwrap_or(background),
-            parse_required_color(normal.red.as_deref())?,
-            parse_required_color(normal.green.as_deref())?,
-            parse_required_color(normal.yellow.as_deref())?,
-            parse_required_color(normal.blue.as_deref())?,
-            parse_required_color(normal.magenta.as_deref())?,
-            parse_required_color(normal.cyan.as_deref())?,
-            parse_optional_color(normal.white.as_deref())?.unwrap_or(foreground),
-        ];
-        let bright = match palette.bright.as_ref() {
-            Some(bright) => [
-                parse_optional_color(bright.black.as_deref())?.unwrap_or(normal[0]),
-                parse_optional_color(bright.red.as_deref())?.unwrap_or(normal[1]),
-                parse_optional_color(bright.green.as_deref())?.unwrap_or(normal[2]),
-                parse_optional_color(bright.yellow.as_deref())?.unwrap_or(normal[3]),
-                parse_optional_color(bright.blue.as_deref())?.unwrap_or(normal[4]),
-                parse_optional_color(bright.magenta.as_deref())?.unwrap_or(normal[5]),
-                parse_optional_color(bright.cyan.as_deref())?.unwrap_or(normal[6]),
-                parse_optional_color(bright.white.as_deref())?.unwrap_or(normal[7]),
-            ],
-            None => normal,
-        };
-        let cursor = palette.cursor.as_ref();
-        let cursor_color =
-            parse_optional_color(cursor.and_then(|c| c.cursor.as_deref()))?.unwrap_or(foreground);
-        let cursor_accent =
-            parse_optional_color(cursor.and_then(|c| c.text.as_deref()))?.unwrap_or(background);
-        let selection = palette.selection.as_ref();
-        Some(Self {
-            background,
-            foreground,
-            cursor: cursor_color,
-            cursor_accent,
-            normal,
-            bright,
-            selection_background: parse_optional_color(
-                selection.and_then(|s| s.background.as_deref()),
-            )?,
-            selection_foreground: parse_optional_color(selection.and_then(|s| s.text.as_deref()))?,
-        })
     }
 }
 
@@ -244,7 +179,10 @@ pub(super) fn stop() -> Result<()> {
         })
 }
 
-pub(super) fn credential(command: CredentialCommand) -> Result<CredentialOutcome> {
+pub(super) fn credential(
+    command: CredentialCommand,
+    _config: &MachineConfig,
+) -> Result<CredentialOutcome> {
     if command == CredentialCommand::Ensure {
         return Ok(CredentialOutcome::Ensured(WebCredential::ZellijLogin {
             secret: ensure_login_token()?,
@@ -611,17 +549,6 @@ fn push_color_node(document: &mut KdlDocument, name: &str, (red, green, blue): (
     node.push(KdlEntry::new(i64::from(green)));
     node.push(KdlEntry::new(i64::from(blue)));
     document.nodes_mut().push(node);
-}
-
-fn parse_required_color(value: Option<&str>) -> Option<(u8, u8, u8)> {
-    parse_hex(value?).ok()
-}
-
-fn parse_optional_color(value: Option<&str>) -> Option<Option<(u8, u8, u8)>> {
-    match value {
-        Some(value) => parse_hex(value).ok().map(Some),
-        None => Some(None),
-    }
 }
 
 const NORMAL_WEB_COLOR_NAMES: [&str; 8] = [

--- a/crates/rimz/tests/fixtures/dummy-font.woff2
+++ b/crates/rimz/tests/fixtures/dummy-font.woff2
@@ -1,0 +1,1 @@
+rimz browser font fixture

--- a/crates/rimz/tests/fixtures/ttyd-trace/main.rs
+++ b/crates/rimz/tests/fixtures/ttyd-trace/main.rs
@@ -2,8 +2,11 @@
 
 use std::env;
 use std::fs::OpenOptions;
-use std::io::Write as _;
+use std::io::{Read as _, Write as _};
 use std::net::TcpListener;
+use std::time::Duration;
+
+const INDEX: &str = "<html><head></head><body></body></html>";
 
 fn main() {
     let args = env::args().skip(1).collect::<Vec<_>>();
@@ -25,8 +28,23 @@ fn main() {
         .expect("ttyd -p port");
     let listener = TcpListener::bind(("127.0.0.1", port)).expect("bind ttyd trace port");
     for stream in listener.incoming() {
-        if stream.is_err() {
-            break;
-        }
+        let Ok(mut stream) = stream else { break };
+        std::thread::spawn(move || {
+            stream
+                .set_read_timeout(Some(Duration::from_secs(1)))
+                .expect("set request timeout");
+            let mut request = [0_u8; 8192];
+            let Ok(read) = stream.read(&mut request) else {
+                return;
+            };
+            if read == 0 || !request[..read].starts_with(b"GET ") {
+                return;
+            }
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{INDEX}",
+                INDEX.len()
+            );
+            let _ = stream.write_all(response.as_bytes());
+        });
     }
 }

--- a/crates/rimz/tests/integration/web.rs
+++ b/crates/rimz/tests/integration/web.rs
@@ -202,6 +202,7 @@ impl TmuxWebFixture {
             .env("PATH", &self.bin_dir)
             .env("RIMZ_TTYD_BIN", ttyd_shim())
             .env("RIMZ_TEST_TTYD_LOG", &self.ttyd_log)
+            .env("RIMZ_WEB_FONTS_OFFLINE", "1")
             .env("RIMZ_TEST_TMUX_LOG", &self.tmux_log)
             .env("RIMZ_TEST_TMUX_SESSION", &self.workspace.session_name)
             .env("RIMZ_TEST_TMUX_CWD", &self.env.project_root);
@@ -540,6 +541,12 @@ fn tmux_open_rotate_revoke_reopen_and_stop() {
         .args(["--print", "--json"])
         .bounded_output()
         .expect("open tmux web");
+    let open_stderr = String::from_utf8_lossy(&open.stderr);
+    assert!(
+        open_stderr.contains("skipping browser font")
+            && open_stderr.contains("RIMZ_WEB_FONTS_OFFLINE"),
+        "{open_stderr}"
+    );
     let open = success_json(&open, "tmux web open");
     assert_eq!(open["engine"], "ttyd");
     assert_eq!(open["session"], fixture.workspace.session_name);
@@ -562,6 +569,13 @@ fn tmux_open_rotate_revoke_reopen_and_stop() {
     );
     let log = std::fs::read_to_string(&fixture.ttyd_log).expect("read ttyd log");
     assert_eq!(log.lines().count(), 1, "{log}");
+    assert!(log.contains("\t-t\tmacOptionIsMeta=true"), "{log}");
+    assert!(
+        log.contains("\t-t\tfontFamily=JetBrainsMono Nerd Font Mono,monospace"),
+        "{log}"
+    );
+    assert!(log.contains("\t-t\ttheme={"), "{log}");
+    assert!(!log.contains("\t-I\t"), "{log}");
 
     let rotate = fixture
         .command()
@@ -575,6 +589,13 @@ fn tmux_open_rotate_revoke_reopen_and_stop() {
     );
     let log = std::fs::read_to_string(&fixture.ttyd_log).expect("read rotated ttyd log");
     assert_eq!(log.lines().count(), 2, "{log}");
+    assert!(
+        log.lines()
+            .all(|line| line.contains("\t-t\tmacOptionIsMeta=true")
+                && line.contains("\t-t\tfontFamily=JetBrainsMono Nerd Font Mono,monospace")
+                && line.contains("\t-t\ttheme={")),
+        "credential rotation must preserve styled ttyd args: {log}"
+    );
 
     let revoke = fixture
         .command()
@@ -621,6 +642,66 @@ fn tmux_open_rotate_revoke_reopen_and_stop() {
         .expect("stop ttyd");
     assert_success(&stop, "ttyd web stop");
     assert!(String::from_utf8_lossy(&stop.stdout).contains("1 ttyd instance"));
+}
+
+#[cfg(unix)]
+#[test]
+fn tmux_custom_font_generates_and_uses_an_inlined_index() {
+    let fixture = TmuxWebFixture::new("ttyd-custom-font.log");
+    let font = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/dummy-font.woff2")
+        .canonicalize()
+        .expect("dummy font path");
+    write_machine_config(
+        &fixture.env,
+        &format!(
+            "[web.tmux]\nfont = \"RimZ Test Font\"\nfont_source = \"{}\"\n",
+            font.display()
+        ),
+    );
+
+    let open = fixture
+        .command()
+        .args(["--mux", "tmux", "web", "open", "--session"])
+        .arg(&fixture.workspace.session_name)
+        .args(["--print", "--json"])
+        .bounded_output()
+        .expect("open tmux web with custom font");
+    success_json(&open, "tmux custom-font web open");
+
+    let log = std::fs::read_to_string(&fixture.ttyd_log).expect("read ttyd log");
+    assert_eq!(
+        log.lines().count(),
+        2,
+        "stock-index fetch plus room ttyd: {log}"
+    );
+    let room_argv = log
+        .lines()
+        .find(|line| line.contains("\ttmux\t-S\t"))
+        .expect("room ttyd argv");
+    assert!(
+        room_argv.contains("\t-t\tfontFamily=RimZ Test Font,monospace"),
+        "{room_argv}"
+    );
+    let args = room_argv.split('\t').collect::<Vec<_>>();
+    let index = args
+        .windows(2)
+        .find(|pair| pair[0] == "-I")
+        .map(|pair| PathBuf::from(pair[1]))
+        .expect("generated -I path");
+    let index = std::fs::read_to_string(&index).expect("read generated ttyd index");
+    assert!(index.contains("font-family:\"RimZ Test Font\""), "{index}");
+    assert!(
+        index.contains("data:font/woff2;base64,cmlteiBicm93c2VyIGZvbnQgZml4dHVyZQo="),
+        "{index}"
+    );
+
+    let stop = fixture
+        .command()
+        .args(["web", "stop"])
+        .bounded_output()
+        .expect("stop custom-font ttyd");
+    assert_success(&stop, "stop custom-font ttyd");
 }
 
 #[cfg(unix)]

--- a/crates/rimz/tests/integration/web.rs
+++ b/crates/rimz/tests/integration/web.rs
@@ -648,16 +648,15 @@ fn tmux_open_rotate_revoke_reopen_and_stop() {
 #[test]
 fn tmux_custom_font_generates_and_uses_an_inlined_index() {
     let fixture = TmuxWebFixture::new("ttyd-custom-font.log");
-    let font = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/fixtures/dummy-font.woff2")
-        .canonicalize()
-        .expect("dummy font path");
+    let font = fixture.env.home_root.join("custom-font.woff2");
+    std::fs::copy(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/dummy-font.woff2"),
+        &font,
+    )
+    .expect("copy dummy font under sandbox HOME");
     write_machine_config(
         &fixture.env,
-        &format!(
-            "[web.tmux]\nfont = \"RimZ Test Font\"\nfont_source = \"{}\"\n",
-            font.display()
-        ),
+        "[web.tmux]\nfont = \"RimZ Test Font\"\nfont_source = \"~/custom-font.woff2\"\n",
     );
 
     let open = fixture

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -211,13 +211,16 @@ style_client = true
 [web.tmux]
 base_url = "https://devbox.example/tmux"
 auto_start = true
+font = "JetBrainsMono Nerd Font Mono"
+# font_source = "/path/to/font.woff2"
+style_client = true
 ```
 
 `[web] enabled` defaults to true and gates `rimz web open` plus `rimz remote connect --web`. RimZ always seeds Zellij's permission cache for its own presence plugin's pane-topology permissions; when web is enabled it also seeds the web-sharing permission so runtime browser sharing works without a one-time prompt. When disabled, web commands fail before any room change and tell you to change the config on the machine serving the room.
 
 `[web.zellij]` tunes browser access through Zellij's web server. `base_url` is the URL prefix RimZ prints for `rimz web open` and `rimz web url`, useful when a reverse proxy serves Zellij under a public host or path. `auto_start` lets `rimz web open` run `zellij web --start --daemonize` when the server is offline; set it to `false` when another supervisor owns the server. `style_client` lets RimZ write a generated Zellij `web_client` block on server start so the browser terminal uses `[theme]`; `font` sets that browser terminal font. These keys are per-machine and outside the project trust hash because they run no command and often name private hostnames or tunnels. Command detail is in [web.md](../reference/cli/web.md), and remote browser tunnels in [remote.md](../internals/remote.md#web-tunnels).
 
-`[web.tmux]` tunes browser access through ttyd. `base_url` is the reverse-proxy prefix for per-room ttyd routes, and `auto_start` lets `rimz web open` start the room's loopback ttyd process. The ttyd engine is selected by the room's tmux backend; install it with `brew install ttyd` or `apt install ttyd`. These keys execute nothing and stay outside the trust hash.
+`[web.tmux]` tunes browser access through ttyd. `base_url` is the reverse-proxy prefix for per-room ttyd routes, and `auto_start` lets `rimz web open` start the room's loopback ttyd process. `style_client` passes the active theme and `font` family to the browser terminal. The built-in `JetBrainsMono Nerd Font Mono` and `CaskaydiaCove Nerd Font Mono` families download and cache verified regular and bold faces automatically; `font_source` instead names one local font file or HTTPS font URL, while an unrecognized `font` with no source passes through for browser-local resolution. The ttyd engine is selected by the room's tmux backend; install it with `brew install ttyd` or `apt install ttyd`. These read-only path and URL fields execute nothing, so the section stays outside the trust hash.
 
 ### Daemon view
 

--- a/docs/guide/web.md
+++ b/docs/guide/web.md
@@ -50,6 +50,8 @@ RimZ gives ttyd the active RimZ theme and provisions the configured browser font
 
 Set `font_source` to a local `.ttf`, `.otf`, `.woff`, or `.woff2` file, or to an HTTPS URL for a font RimZ should download and cache. A `font` with no matching preset and no `font_source` names a font already installed in the browser. Set `style_client = false` to keep ttyd's browser defaults. A missing font cache or download degrades to the stock ttyd page with a warning, so offline access still starts.
 
+Styling is fixed when the room's ttyd process starts. After changing these fields or `[theme]`, run `rimz web stop` and then `rimz web open` to apply the new profile.
+
 On macOS, ttyd treats Option as Meta before the browser composes characters. Chords such as `alt+,` and `alt+.` therefore reach tmux instead of becoming `≤` and `≥`; this input fix remains active when client styling is disabled.
 
 ## Open a remote room

--- a/docs/guide/web.md
+++ b/docs/guide/web.md
@@ -46,6 +46,12 @@ The browser shows a Basic-Auth prompt; use the printed user `rimz` and password.
 
 ttyd servers are per room, so `rimz web start` remains a Zellij-server command; use `rimz web open` to start a tmux room server.
 
+RimZ gives ttyd the active RimZ theme and provisions the configured browser font by default. `JetBrainsMono Nerd Font Mono` and `CaskaydiaCove Nerd Font Mono` are built-in presets: RimZ downloads their regular and bold faces from the pinned Nerd Fonts release, verifies them, and caches them under `$XDG_CACHE_HOME/rimz/web-fonts` (normally `~/.cache/rimz/web-fonts`). The browser loads those bytes from the generated loopback page and makes no third-party request.
+
+Set `font_source` to a local `.ttf`, `.otf`, `.woff`, or `.woff2` file, or to an HTTPS URL for a font RimZ should download and cache. A `font` with no matching preset and no `font_source` names a font already installed in the browser. Set `style_client = false` to keep ttyd's browser defaults. A missing font cache or download degrades to the stock ttyd page with a warning, so offline access still starts.
+
+On macOS, ttyd treats Option as Meta before the browser composes characters. Chords such as `alt+,` and `alt+.` therefore reach tmux instead of becoming `≤` and `≥`; this input fix remains active when client styling is disabled.
+
 ## Open a remote room
 
 ```sh
@@ -95,6 +101,9 @@ style_client = true
 [web.tmux]
 base_url = "https://devbox.example/tmux"
 auto_start = true
+font = "JetBrainsMono Nerd Font Mono"
+# font_source = "/path/to/font.woff2"
+style_client = true
 ```
 
 Each `base_url` is the prefix RimZ prints when a reverse proxy mounts that engine; the room session remains the final path segment.

--- a/docs/internals/web.md
+++ b/docs/internals/web.md
@@ -35,10 +35,16 @@ tmux uses one ttyd process per room.
 The process argv is structurally fixed:
 
 ```text
-ttyd -W -O -c rimz:<secret> -i 127.0.0.1 -p <port> -b /<session> tmux attach -t <session>
+ttyd -W -O -c rimz:<secret> -i 127.0.0.1 -p <port> -b /<session> -t macOptionIsMeta=true [client styling] tmux -S <socket> attach -t <session>
 ```
 
-`-W` enables terminal input, `-O` enforces origin checks, `-c` makes Basic Auth mandatory, `-i` keeps the listener on loopback, and `-b` gives both engines the uniform `<base>/<session>` URL.
+`-W` enables terminal input, `-O` enforces origin checks, `-c` makes Basic Auth mandatory, `-i` keeps the listener on loopback, and `-b` gives both engines the uniform `<base>/<session>` URL. `macOptionIsMeta=true` keeps macOS Option chords on the terminal input path rather than letting the browser compose them into characters.
+
+Client styling passes `fontFamily` and the shared `WebClientColors` palette as ttyd `-t` preferences. The palette projects to xterm.js `ITheme` keys, keeping Zellij and ttyd browser colors aligned.
+
+The two built-in Nerd Font families resolve to SHA-256-pinned regular and bold faces from a pinned Nerd Fonts tag. HTTPS custom sources use a URL-hashed cache entry, local custom sources are read directly, and all font inputs require a `.ttf`, `.otf`, `.woff`, or `.woff2` extension. Font bytes live under `$XDG_CACHE_HOME/rimz/web-fonts`; `RIMZ_WEB_FONTS_OFFLINE` makes resolution cache-only.
+
+ttyd serves no additional static-file route, so RimZ generates a custom index for resolved font bytes. A cache miss starts a throwaway loopback ttyd from the same binary, fetches its stock `/` page with temporary Basic Auth, stops the process, injects base64 `@font-face` rules immediately before `</head>`, and writes the result atomically under `$XDG_CACHE_HOME/rimz/web-ttyd`. The cache key covers the ttyd version, family, face weights and formats, and font content hashes. Missing fonts, network failures, an unreadable index, or a stock page without `</head>` return a warning and start the room with ttyd's stock page.
 
 The ttyd binary resolves from `RIMZ_TTYD_BIN`, then `PATH`; a missing binary returns the Homebrew and apt install fix before a room server can start.
 
@@ -72,9 +78,9 @@ Token verbs operate on Zellij's token store or ttyd's single machine credential;
 
 `[web.zellij]` carries `base_url`, `auto_start`, `font`, and `style_client`.
 
-`[web.tmux]` carries `base_url` and `auto_start`.
+`[web.tmux]` carries `base_url`, `auto_start`, `font`, `font_source`, and `style_client`.
 
-Both sections are per-machine and stay outside the trust hash because no field executes a command.
+Both sections are per-machine and stay outside the trust hash because no field executes a command; `font_source` is a read-only local path or HTTPS URL.
 
 ## Remote rooms
 


### PR DESCRIPTION
## Context

`rimz web open` on a tmux room serves the terminal through ttyd, which RimZ spawned with bare arguments — auth, port, base path, `tmux attach`. Two user-reported problems followed from that.

The browser page rendered without a Nerd Font, so sidebar glyphs and powerline symbols were missing. On macOS, Option composes characters before xterm.js sees the key, so `alt+,` produced `≤` instead of reaching tmux.

Zellij browser access already had both halves of the styling story — `web.zellij.font`, `web.zellij.style_client`, palette derivation through `WebClientColors`, and graceful degradation via a warning. tmux had neither, so this also closes a Zellij/tmux parity gap.

## Design choices

**Fonts are inlined into a generated index page.** ttyd's HTTP server serves exactly three routes — the index, `/token`, and `/ws` — and cannot serve extra static files, so font bytes have to travel inside the page. RimZ downloads and caches the faces server-side, then base64-inlines them into a custom index passed with `-I`. The result is offline-friendly after the first fetch and makes no third-party request at page load.

**The stock page is fetched from the user's own ttyd, not vendored.** `-I` replaces ttyd's embedded index entirely, and the only version-proof way to obtain that page is to GET `/` from a running instance of the same binary. On a cache miss RimZ starts a throwaway authenticated loopback ttyd, fetches its page, stops it, and injects the `@font-face` rules before `</head>`. Embedding a copy of ttyd's page in RimZ was rejected: it would couple us to ttyd's websocket protocol.

**Presets are `JetBrainsMono Nerd Font Mono` (default) and `CaskaydiaCove Nerd Font Mono`.** Both are fetched per file from a pinned nerd-fonts tag with per-file SHA-256 verification. Microsoft's own "Cascadia Code NF" ships only in a release zip and we have no zip dependency, so the nerd-fonts patched Cascadia stands in.

**Custom fonts declare themselves under the configured family.** Because RimZ writes the `@font-face` itself, `web.tmux.font_source` can name any local file or HTTPS URL without its internal metadata matching `web.tmux.font`. A `font` that is neither a preset nor backed by a source passes through as `fontFamily` only, trusting a browser-local install — the same semantics as `web.zellij.font`.

**The Alt fix is always on.** `macOptionIsMeta=true` is a correctness fix rather than styling, so it survives `style_client = false` and `[web] enabled = false`.

**No new state files for spawn arguments.** `WebEngine::credential` takes a `&MachineConfig` so credential rotation can rebuild the client profile from config, instead of persisting argv on disk.

## Implementation

`WebClientColors`, its palette projection, and the hex-parsing helpers move out of `web/zellij.rs` into a shared `web/colors.rs`; zellij keeps only its KDL emission. The new `to_xterm_theme` projects the same palette to the xterm.js `ITheme` shape, so both engines derive browser colors from one place.

`[web.tmux]` gains `font`, `font_source`, and `style_client`. Every field is a read-only path or URL and executes nothing, so the section stays outside the project trust hash.

Font resolution honors `RIMZ_WEB_FONTS_OFFLINE` for cache-only operation, caps files at 16 MiB, publishes cache entries atomically, and turns every failure into a warning that preserves stock ttyd access. Index generation is keyed on the ttyd version, family, and face content, and the room process receives `-I` only after generation succeeds.

Deviations from the plan, each for cause:

- Nerd Fonts v3.4.0 stores the CaskaydiaCove files directly under `patched-fonts/CascadiaCode/` rather than in the `Regular/` and `Bold/` subdirectories the plan assumed. The working pinned URLs are recorded in `web/fonts.rs`.
- `CredentialOutcome::Rotated` carries warnings so font and theme degradation during a restart stays on the established domain-to-CLI warning path instead of being discarded.
- The generated-index cache key also covers face weight and format, so identical bytes declared with different CSS semantics cannot share an index.
- `base64` was promoted from a transitive dependency to a direct one rather than adding a third hand-rolled encoder on a browser-input boundary.

Verified against real ttyd 1.7.7 rather than only the test fixture: all four pinned URLs return 200 with digests matching the embedded constants; the full generated argv parses correctly, with ttyd logging `start command: tmux -S ... attach` intact, so the inserted `-t` options do not swallow the command; ttyd's page contains exactly one `</head>`, before the script bundle; `ureq` transparently decodes ttyd's gzip response; and a 4 MB generated index is served byte-identical through `-I` in about 2 ms over loopback. A sandbox `web open` against the installed ttyd completed the whole cold-cache path with no warning.

## Advisories

Known weak spots, all deliberate:

- **The stock-index probe is not recorded in the instance inventory.** A crash or Ctrl-C during its roughly ten-second window orphans a ttyd holding a port in the 8200–8299 range, invisible to `rimz web status` and `rimz web stop`. Recording it as a room instance would surface an internal session in status output, and since the instance directory is keyed by session name, concurrent probes would collide on one record. A dedicated transient-process record is larger than this change warrants. The normal path always stops the probe.
- **Cold-cache provisioning is synchronous and can be silent.** A stalled network can hold `rimz web open` for up to the per-face timeouts with no progress output, and there is no negative caching, so a persistently failing network pays that cost on every open. A spinner belongs in the CLI layer wrapping the domain call, and negative caching needs a retry and expiry contract; both are follow-up UX work rather than correctness.
- **Page weight.** A default JetBrainsMono page inlines about 4.9 MB of font bytes, roughly 6.6 MB base64, on top of ttyd's stock page. This stays loopback-only and cached, but it is a substantially larger first document than stock ttyd.
- **Custom HTTPS font sources have no checksum surface.** They are immutable by URL — a URL whose content changes serves the cached copy — whereas built-in preset entries are checksum-verified on every use.
- **Not confirmed visually.** Glyph rendering and macOS browser key composition could not be checked in a Linux environment. Both warrant a manual pass in a macOS browser before anyone relies on them.