### PR TITLE
fix(message): resolve the smart-compact config default in domain dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ RimZ is alpha software on the 0.x line. Commands, flags, config keys, and output
 
 ### Fixed
 
+- Scheduled loop wakes honor the `[harness] smart_compact` default, so unattended prompts compact first at the configured context threshold.
 - A remote browser tunnel that accepts connections and then loses SSH with exit 255 now reconnects immediately instead of reporting that it was never established.
 - `rimz loop add`, `remove`, and `rename` on project tasks keep project trust when the workspace was already trusted, so your own task edit needs no re-review.
 - Interrupting a Claude subagent no longer leaves its finished parent pinned to `running` in the sidebar; the next parent tool or turn boundary closes the interrupted child from Claude's durable transcript marker.

--- a/crates/rimz/src/cli/loop_cmd/run.rs
+++ b/crates/rimz/src/cli/loop_cmd/run.rs
@@ -314,6 +314,7 @@ fn execute_prepared_delivery(
                 enter: true,
                 gate: DeliveryGate::Done,
                 force: false,
+                // Domain dispatch resolves this from [harness] smart_compact.
                 auto_compact: None,
                 not_before: None,
                 after: Vec::new(),

--- a/crates/rimz/src/cli/message/dispatch.rs
+++ b/crates/rimz/src/cli/message/dispatch.rs
@@ -139,7 +139,6 @@ fn dispatch_mode(
     smart_compact: Option<AutoCompact>,
 ) -> Result<DispatchMode> {
     let machine_config = crate::cli::machine_config();
-    let auto_compact = smart_compact.or(machine_config.harness.smart_compact);
     let SendKind::Boundary {
         gate,
         schedule,
@@ -150,7 +149,7 @@ fn dispatch_mode(
         return Ok(DispatchMode::Steer {
             enter,
             force,
-            auto_compact,
+            auto_compact: smart_compact,
         });
     };
     if create {
@@ -169,7 +168,7 @@ fn dispatch_mode(
         enter,
         gate,
         force,
-        auto_compact,
+        auto_compact: smart_compact,
         not_before: schedule
             .as_deref()
             .map(|raw| parse_schedule_at(raw, &now).map_err(anyhow::Error::msg))

--- a/crates/rimz/src/config/harness.rs
+++ b/crates/rimz/src/config/harness.rs
@@ -119,8 +119,8 @@ pub struct HarnessConfig {
     /// Default local-calendar-day cap for one room's whole agent fleet.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub budget: Option<DayCap>,
-    /// Compact before `message` sends when the agent's context window
-    /// has reached this threshold. Unset keeps compact-first sends opt-in.
+    /// Compact before messages and scheduled loop wakes when the agent's
+    /// context window has reached this threshold. Unset keeps compaction opt-in.
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",

--- a/crates/rimz/src/config/templates/config.template.toml
+++ b/crates/rimz/src/config/templates/config.template.toml
@@ -150,5 +150,5 @@ aggressive_resize = true
 
 [harness]
 ## budget = "50/day"             # turn on the whole-room local-day cap; adjust the live cap with `rimz budget`
-## smart_compact = "70%"          # default compact-first threshold for message ("70%", "120000", or "180k"); unset = off
+## smart_compact = "70%"          # default for messages/wakes ("70%", "120000", or "180k"); unset = off
 # rtk = "auto"                    # wrap agent cargo runs (build/check/test/nextest/clippy) through `rtk`; auto = when rtk is on PATH, on = force, off = never

--- a/crates/rimz/src/message/dispatch.rs
+++ b/crates/rimz/src/message/dispatch.rs
@@ -40,12 +40,16 @@ pub enum DispatchMode {
     Steer {
         enter: bool,
         force: bool,
+        /// An explicit threshold for this dispatch; `None` inherits the
+        /// `[harness] smart_compact` machine default in [`dispatch`].
         auto_compact: Option<AutoCompact>,
     },
     Boundary {
         enter: bool,
         gate: DeliveryGate,
         force: bool,
+        /// An explicit threshold for this dispatch; `None` inherits the
+        /// `[harness] smart_compact` machine default in [`dispatch`].
         auto_compact: Option<AutoCompact>,
         not_before: Option<Timestamp>,
         after: Vec<String>,
@@ -69,6 +73,13 @@ impl DispatchMode {
         match self {
             Self::Steer { force, .. } | Self::Boundary { force, .. } => *force,
         }
+    }
+
+    fn resolve_auto_compact(&mut self, default: Option<AutoCompact>) {
+        let auto_compact = match self {
+            Self::Steer { auto_compact, .. } | Self::Boundary { auto_compact, .. } => auto_compact,
+        };
+        *auto_compact = (*auto_compact).or(default);
     }
 
     fn needs_agent_context(&self) -> bool {
@@ -207,8 +218,13 @@ pub enum DispatchErr {
 pub fn dispatch(
     workspace: &ResolvedWorkspace,
     store: &Store,
-    request: DispatchRequest,
+    mut request: DispatchRequest,
 ) -> Result<DispatchResult> {
+    request.mode.resolve_auto_compact(
+        crate::config::MachineConfig::load_lenient()
+            .harness
+            .smart_compact,
+    );
     let boundary = !request.mode.steer();
     let mut pending = if boundary {
         store.list_messages()?

--- a/crates/rimz/tests/integration/loop_schedule.rs
+++ b/crates/rimz/tests/integration/loop_schedule.rs
@@ -19,7 +19,7 @@ use rimz::harness::schedule::run_log::{self, LoopRunMode, LoopRunRecord, LoopRun
 use rimz::harness::schedule::runner::RunLockInfo;
 use rimz::harness::schedule::strikes;
 use rimz::ids::{AgentKind, AgentSessionId};
-use rimz::message::MessageStatus;
+use rimz::message::{AutoCompact, MessageStatus};
 
 #[cfg(unix)]
 use crate::common::write_fake_login_shell;
@@ -118,6 +118,7 @@ fn loop_wake_workflow_pins_and_delivers_to_live_session() {
     let env = Env::new();
     env.install_agent_hooks("claude");
     register_running_agent(&env, "sess-loop-live", "feature-loop");
+    loop_ok(&env, &["config", "set", "harness.smart_compact", "70%"]);
 
     let added = loop_ok(
         &env,
@@ -147,6 +148,10 @@ fn loop_wake_workflow_pins_and_delivers_to_live_session() {
 
     loop_ok(&env, &["loop", "run", "wake"]);
     assert_pending_message(&env, "sess-loop-live", "next step");
+    assert_eq!(
+        env.store().list_pending_messages().unwrap()[0].auto_compact,
+        Some(AutoCompact::Percent(70))
+    );
     assert_eq!(last_loop_record(&env).result, LoopRunResult::Delivered);
     let list = loop_ok(&env, &["loop", "list"]);
     let show = loop_ok(&env, &["loop", "show", "wake"]);

--- a/crates/rimz/tests/integration/message.rs
+++ b/crates/rimz/tests/integration/message.rs
@@ -11,7 +11,8 @@ use rimz::agents::{
 };
 use rimz::ids::{AgentKind, AgentSessionId, MessageId, MuxName, PaneId};
 use rimz::message::{
-    DeliveryGate, MessageBody, MessageRecord, MessageSender, MessageStatus, WhenCondition,
+    AutoCompact, DeliveryGate, MessageBody, MessageRecord, MessageSender, MessageStatus,
+    WhenCondition,
 };
 use rimz::store::event::{AgentLaunchPayload, AgentLaunchState, EventEnvelope, MessageEventMethod};
 
@@ -2025,6 +2026,27 @@ fn steer_auto_compact_runs_before_a_full_window() {
             ..
         } if kind.as_str() == "claude" && agent_id == "sess-ac" && label == "@claude"
     ));
+}
+
+#[test]
+fn message_inherits_smart_compact_default() {
+    let env = Env::new();
+    env.install_agent_hooks("claude");
+    register_running_agent(&env, "sess-ac-default", "feature-ac-default", &[]);
+    run_success(
+        env.rimz()
+            .args(["config", "set", "harness.smart_compact", "70%"]),
+        "set smart compact default",
+    );
+
+    queue_add(&env, "@claude", "inherit compact threshold");
+
+    let messages = env
+        .store()
+        .list_pending_messages()
+        .expect("pending messages");
+    assert_eq!(messages.len(), 1, "{messages:?}");
+    assert_eq!(messages[0].auto_compact, Some(AutoCompact::Percent(70)));
 }
 
 #[test]

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -175,7 +175,7 @@ These keys are the on-switch; `rimz budget` inspects and adjusts an armed cap at
 smart_compact = "200k"
 ```
 
-`smart_compact` sets the default threshold for compact-first `message` sends, an occupied-token count (`"200k"` or `"120000"`) or a percentage of the window (`"70%"`). When an agent's context window has reached the threshold, RimZ submits its `/compact` ahead of your text so the prompt lands against a fresh window. Leave it unset to keep compaction opt-in through the per-command `--smart-compact` flag, which overrides this value. The mechanics are in [messaging.md](../internals/harness/messaging.md#smart-compaction).
+`smart_compact` sets the default threshold for compact-first `rimz message` sends and scheduled loop wakes, as an occupied-token count (`"200k"` or `"120000"`) or a percentage of the window (`"70%"`). When an agent's context window has reached the threshold, RimZ submits its `/compact` ahead of the text so the prompt lands against a fresh window. Leave it unset to keep compaction opt-in through the per-command `--smart-compact` flag for messages, which overrides this value. The mechanics are in [messaging.md](../internals/harness/messaging.md#smart-compaction).
 
 ### rtk output compression
 

--- a/docs/guide/loops.md
+++ b/docs/guide/loops.md
@@ -139,7 +139,7 @@ Every agent CLI already compacts. `/compact` is the manual command: summarize th
 
 In a fleet, most prompts arrive with no human there to make that call. A reviewer sends comments back to a coder sitting at 90% context; the coder takes the message, edits two files, hits the ceiling, and the automatic summary captures a half-changed tree mid-fix. Smart compaction restores the by-hand habit at the same spot. When a `rimz message` is about to land, yours or another agent's, and the receiver's context has passed your threshold, RimZ submits the agent's own `/compact` first, the exact command you would have typed, then delivers the text against the fresh window. A message boundary is the strongest checkpoint available: the previous task has ended and the next has not begun, so the summary is a handover rather than a snapshot of work in flight.
 
-Set the default once with `harness.smart_compact`, an occupied-token count like `200k` or a percentage like `70%`, and every message send inherits it; or leave it unset and pass `--smart-compact` per send. The threshold grammar and delivery mechanics are in [messaging.md → land against a fresh window](./messaging.md#land-against-a-fresh-window).
+Set the default once with `harness.smart_compact`, an occupied-token count like `200k` or a percentage like `70%`, and every message send and scheduled wake inherits it; or leave it unset and pass `--smart-compact` per message. The threshold grammar and delivery mechanics are in [messaging.md → land against a fresh window](./messaging.md#land-against-a-fresh-window).
 
 ### Two brakes on hands-off work
 

--- a/docs/guide/setup.md
+++ b/docs/guide/setup.md
@@ -147,7 +147,7 @@ A turn that dies mid-flight — a rate limit, a spend limit, a provider overload
 smart_compact = "200k"   # occupied-token count; a percentage of the window such as "70%" works too
 ```
 
-`smart_compact` makes `rimz message` compact-first: when the target agent's context window has reached the threshold, RimZ submits the agent's `/compact` ahead of your text so the prompt lands against a fresh window instead of dying at the context ceiling. Unset, compaction stays opt-in per send through `rimz message --smart-compact`. The mechanics are in [message internals → Smart compaction](../internals/harness/messaging.md#smart-compaction).
+`smart_compact` makes `rimz message` sends and scheduled loop wakes compact-first: when the target agent's context window has reached the threshold, RimZ submits the agent's `/compact` ahead of the text so the prompt lands against a fresh window instead of dying at the context ceiling. Unset, compaction stays opt-in per message through `rimz message --smart-compact`. The mechanics are in [message internals → Smart compaction](../internals/harness/messaging.md#smart-compaction).
 
 ### Put a turn on a schedule
 

--- a/docs/internals/harness/loops.md
+++ b/docs/internals/harness/loops.md
@@ -164,7 +164,7 @@ Two patterns fall out of the guard. A **watchdog** runs a command on a schedule 
 
 `wake` pins a schedule to one exact agent session. `rimz loop add <name> --wake @<handle>` resolves the address against the live rollup **at add time**, records a `wake` sub-table of `kind`, `session`, and `handle`, and rejects `agent` and every supervised-run flag, because delivery opens no pane.
 
-On fire, the runner resolves the recorded root, confirms the pinned root session still exists, and sends the prompt through the same path as `rimz message`, gated `done`. An idle agent takes it immediately, a running agent parks it for its next `done` boundary, and a missing session records `target gone` and removes the schedule, because that exact conversation cannot come back. `rimz gc` runs the same liveness check as a safety sweep for wake schedules whose pinned session left the rollup without the task ever firing.
+On fire, the runner resolves the recorded root, confirms the pinned root session still exists, and sends the prompt through the same path as `rimz message`, gated `done` and inheriting the `[harness] smart_compact` default. An idle agent takes it immediately, a running agent parks it for its next `done` boundary, and a missing session records `target gone` and removes the schedule, because that exact conversation cannot come back. `rimz gc` runs the same liveness check as a safety sweep for wake schedules whose pinned session left the rollup without the task ever firing.
 
 Self-paced loops are ordinary one-shots: an agent schedules its next `--in` wake at the end of the current one, and the instance row is removed before delivery, so the next one exists only while work remains.
 

--- a/docs/internals/harness/messaging.md
+++ b/docs/internals/harness/messaging.md
@@ -132,7 +132,7 @@ The raw-versus-effective distinction is load-bearing. Delivery gates read `effec
 
 [`dispatch()`](../../../crates/rimz/src/message/dispatch.rs) is the one entry point for an owned send. Its sequence:
 
-1. **Load what the decision needs.** Pending records (boundary mode only), and agent-context sidecars when the request carries `--smart-compact`, conditions, an agent sender, or `--wait`.
+1. **Load what the decision needs.** Pending records (boundary mode only), and agent-context sidecars when a smart-compact threshold applies, conditions, an agent sender, or `--wait`.
 2. **Choose a snapshot.** Producing a full resolution snapshot means talking to the multiplexer. When every target already parks (no live pane needed, no lazy-registering kind, no provisional id), `targets_all_park_without_live` proves the cached rollup is enough and dispatch skips the mux round trip entirely. This `rollup_only` path is a latency optimization; correctness never depends on it.
 3. **Resolve targets.** Live agents and live panes both, combined so one agent with a bound pane yields one target rather than two. When the live view finds nothing, the durable audit rollup is the fallback, with pane-shadowed co-resident sessions filtered out first. A multi-match without `--all` or `@all` is an ambiguity error listing the candidates.
 4. **Bind conditions.** Each `after` and `when` address resolves once and pins a card. A condition that is already satisfied gets its `met_at` stamped immediately, which is why upstream work must be queued *before* the message that waits on it.
@@ -248,7 +248,7 @@ The receiver's turn-start hook parses the prefix once and writes a first-class `
 
 A long turn can hit the context ceiling mid-message. Agents compact on their own only at the ceiling (Codex around 90%), so a prompt sent past it can be cut in half by a compaction that fires mid-turn. `--smart-compact` compacts *first*, so the prompt always lands against a fresh window.
 
-Thresholds parse as `70%` (a fraction of the window), `120000` (absolute occupied tokens), or `180k` / `1m` (suffixed counts). An omitted flag falls back to the [`[harness] smart_compact`](../../guide/configuration.md#smart-compaction) config default. An unknown fill never triggers: a missing reading is not a full window, so the text sends untouched.
+Thresholds parse as `70%` (a fraction of the window), `120000` (absolute occupied tokens), or `180k` / `1m` (suffixed counts). Domain dispatch resolves an omitted threshold from the [`[harness] smart_compact`](../../guide/configuration.md#smart-compaction) config default for every caller, including scheduled loop wakes. An unknown fill never triggers: a missing reading is not a full window, so the text sends untouched.
 
 A percent threshold reads the same fill gauge the sidebar card renders (`context_fill_pct`); a token threshold reads `occupied_context_tokens`, which prefers the folded statusline breakdown, then the per-call split (cache reads plus cache writes plus fresh input), then the carried `total_tokens` gauge.
 


### PR DESCRIPTION
## Context

Scheduled loop wakes never smart-compacted. `rimz loop --wake` fired dispatch with `auto_compact: None` hardcoded, so the `[harness] smart_compact` config default reached only `rimz message` sends. The docs promised otherwise: the README sells smart compaction as part of what makes a loop run hands-off, `docs/guide/loops.md` hosts the Smart compaction section, and `docs/internals/harness/loops.md` states that a wake fires "through the same path as `rimz message`". The wake path already rendered compaction outcomes via `report_dispatch(..., &result.compacted)` — dead code until now.

The root cause was the location of the fallback, not the wake handler. `smart_compact.or(machine_config.harness.smart_compact)` was resolved caller-side in the CLI layer, so every caller of `message::dispatch::dispatch` had to remember to apply it. The loop wake handler, a separate caller building its own `DispatchMode::Boundary` literal, did not.

## Design choices

**Resolve the fallback at the domain entry point, not at the missed call site.** `dispatch()` now folds the machine default into the request mode as its first statement, so every caller inherits it by construction. Patching `run.rs` would have fixed this instance and left the next caller free to repeat the omission.

**Keep `Option<AutoCompact>` as the request type** rather than introducing a tri-state enum. `Some` is an explicit override, `None` inherits. This is lossless because the send path has no explicit-off input: `--no-smart-compact` exists only on `message edit` and `message requeue`, both of which mutate the durable record through the store and bypass dispatch entirely. Record editing therefore remains the off switch it already was.

**Read the config through the established lenient, stamp-memoized loader** (`MachineConfig::load_lenient()`), precedented outside the CLI in `reload.rs` and `observability/reporting.rs`. A malformed config falls back to built-ins under the existing runtime contract, rather than making message delivery a new strict-config entry point. Both callers already load the config earlier in-process, so the memo is warm and the domain call adds no I/O.

**Resolution happens once, before anything reads the mode.** Deeper layers — `deliver`, `send`, the `/compact` command records, the claim-release clear in the store writer — keep operating on the resolved record value. A queued record stays send-time truth: config changes between send and delivery do not retroactively apply.

## Implementation

`DispatchMode::resolve_auto_compact` folds a default into both variants, and `dispatch()` applies it before the `needs_agent_context()` read that branches on `auto_compact.is_some()`. The CLI's `dispatch_mode()` drops its own `.or(...)` and passes the explicit flag value straight through; `machine_config` stays for `time_zone()`. The loop wake handler is unchanged apart from a comment — its `None` now inherits, and its existing compaction reporting comes alive.

Beyond the plan, the `HarnessConfig` field documentation and the generated `config.toml` template comment were widened too, since both still narrowed the default to message sends.

Docs widen the send-only wording in `docs/guide/configuration.md`, `docs/guide/setup.md`, `docs/guide/loops.md`, `docs/internals/harness/messaging.md`, and `docs/internals/harness/loops.md`, plus a changelog entry under Fixed.

Two subprocess integration tests: the loop wake regression test asserts the pending record carries `AutoCompact::Percent(70)` after `loop run wake` with only the machine default set, and a focused message test covers the plain-send inheritance whose resolution point moved. Both park on a running agent, so an unknown context fill never triggers compaction and the assertions stay deterministic.

## Review notes

Verified against the code: the removed CLI line sat before the steer early-return, so steer sends already inherited and their behavior is unchanged; `cli::machine_config()` is a direct call to the same `load_lenient()`, so the domain reads an identical value; the `/compact` command record is built from a `MessageDraft` with `auto_compact: None` and never re-enters dispatch; and no in-process test calls `dispatch()`, so none picks up an ambient machine config.

A wake against an idle, over-threshold agent can now return `CompactionPending`, which the loop maps to `TaskFireEffect::Delivered`. That matches the pre-existing parked case — both mean the record is durably queued for later delivery.

### Advisories

- `docs/guide/messaging.md:121` still reads "set it once and every message inherits the behavior". It is the canonical Land-against-a-fresh-window section that the updated loops and internals pages link to for mechanics, so it is the one remaining place that narrows the default to messages.
- `crates/rimz/src/cli/message/dispatch.rs:141` binds `machine_config` above the steer early-return, where its only remaining use is `time_zone()` on the boundary path. No observable cost, since the loader is memoized.

### Known limits

A scheduled wake has no per-task override for the inherited threshold; `--smart-compact` exists only on `rimz message`. This is a deliberate scope decision — no tri-state enum, no new CLI flags — and the updated docs describe the behavior accurately.

Gates run: `invariants`, `docs-links`, `lint`, `fmt --check`, plus the `loop_schedule` (30, including the rebased-in upstream trust tests), `message::` (109), and `auto_compact` (6) suites, all green.