### PR TITLE
Auto-tune `rimz sidebar gallery` column count to terminal width

### DIFF
--- a/crates/rimz/src/sidebar_pane/app/demo.rs
+++ b/crates/rimz/src/sidebar_pane/app/demo.rs
@@ -49,12 +49,21 @@ pub fn serve_fixture(snapshot: SidebarSnapshot, refresh_ms: u16) -> super::Resul
     Ok(())
 }
 
-pub fn serve_gallery(columns: Vec<(SidebarSnapshot, usize)>, refresh_ms: u16) -> super::Result<()> {
+pub fn serve_gallery(
+    mut columns: Vec<(SidebarSnapshot, usize)>,
+    refresh_ms: u16,
+) -> super::Result<()> {
     let refresh_ms = refresh_ms.max(1);
     let _input_mode = TerminalModeGuard::enable(MouseCapture::Stdout, Screen::Main)?;
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::new(backend)?;
     terminal.clear()?;
+
+    let cap = terminal
+        .size()
+        .map(|size| render::gallery_column_cap(size.width))
+        .unwrap_or(3);
+    columns.truncate(cap);
 
     let (caps, wrap_pixels) = detect_pixel_render_env();
     let id_base = PixelPainter::runtime_id_base();

--- a/crates/rimz/src/sidebar_pane/render/mod.rs
+++ b/crates/rimz/src/sidebar_pane/render/mod.rs
@@ -201,6 +201,18 @@ pub struct GalleryColumn<'a> {
     pub ui: &'a mut UiState,
 }
 
+/// Terminal width above which the gallery packs a fourth fixture column.
+const GALLERY_FOUR_COLUMN_MIN_WIDTH: u16 = 240;
+
+/// Returns the number of gallery columns that fit at the launch width.
+pub fn gallery_column_cap(width: u16) -> usize {
+    if width > GALLERY_FOUR_COLUMN_MIN_WIDTH {
+        4
+    } else {
+        3
+    }
+}
+
 pub fn draw_gallery_to_terminal<B: Backend>(
     terminal: &mut Terminal<B>,
     columns: &mut [GalleryColumn<'_>],

--- a/crates/rimz/src/sidebar_pane/render/tests/gallery.rs
+++ b/crates/rimz/src/sidebar_pane/render/tests/gallery.rs
@@ -4,6 +4,14 @@ use ratatui::backend::TestBackend;
 use super::*;
 
 #[test]
+fn gallery_column_cap_uses_launch_width_boundary() {
+    assert_eq!(gallery_column_cap(0), 3);
+    assert_eq!(gallery_column_cap(240), 3);
+    assert_eq!(gallery_column_cap(241), 4);
+    assert_eq!(gallery_column_cap(300), 4);
+}
+
+#[test]
 fn render_gallery_draws_delimiters_between_columns() {
     let alpha = gallery_snapshot("alpha-room", "agent-alpha", "claude");
     let bravo = gallery_snapshot("bravo-room", "agent-bravo", "codex");

--- a/docs/contributing/sidebar-screenshots.md
+++ b/docs/contributing/sidebar-screenshots.md
@@ -33,7 +33,7 @@ The task fails at entry when `freeze`, `rsvg-convert`, or JetBrainsMono Nerd Fon
 
 `cargo xtask screenshot state <empty|fleet|provider|cockpit|focus|economy|reach> [--width W] [--height H] [--output PATH]` renders deterministic fixture frames through the same headless sidebar renderer used by tests. `cockpit` (fleet breadth), `focus` (expanded team cards and the remote footer), `economy` and `reach` (provider spend; pets appear in the gallery with `--pets`) are packed gallery states for review.
 
-`rimz sidebar gallery [--pets]` opens one frameless compositor pane in the current room with those packed states side by side, split by thin `│` delimiter rules and no real sidebar dock; outside any mux session, the same command renders the compositor inline in the current terminal. `--pets` turns the dashboard companion on in every column.
+`rimz sidebar gallery [--pets]` opens one frameless compositor pane in the current room with those packed states side by side, split by thin `│` delimiter rules and no real sidebar dock; outside any mux session, the same command renders the compositor inline in the current terminal. The compositor chooses four columns when the terminal is wider than 240 columns and three at or below that width, decided once at launch. `--pets` turns the dashboard companion on in every column.
 
 Set `RIMZ_BIN=/path/to/rimz` to capture with a specific binary. Without it, `xtask` runs the current checkout through `cargo run --quiet -p rimz --bin rimz -- ...`.
 


### PR DESCRIPTION
## Context

`rimz sidebar gallery` opens a frameless compositor pane that packs several fixture sidebar states side by side for review and screenshots. It always showed four columns (Focus, Cockpit, Reach, Economy). On terminals narrower than ~240 columns, four columns squeeze each state too thin to read. This change shows four columns only on terminals wider than 240 columns, and three otherwise.

Column *widths* already reflowed on resize (recomputed every frame in `gallery_layout`); only the column *count* was fixed at four for the process lifetime. This change is entirely about that count.

## Design choices

- **Count is decided once, at launch.** Widths keep reflowing on resize; the count does not. This matches the pre-existing resize-is-noop behavior for count and avoids tearing down and rebuilding the per-column pixel-pet painters mid-loop, which would risk image ghosting. Resizing wider after launch does not add the fourth column back until relaunch — an accepted limitation.
- **Strict threshold `> 240`:** width 241 and up gives four columns; width 240 and below gives three.
- **Capping to three drops Economy,** keeping Focus, Cockpit, and Reach in their defined order via a plain "take the first three" truncation. This preserves fixture order and still keeps one provider-spend state on screen.
- **The width-to-count policy lives in the render module** beside `gallery_layout`, as a pure `width -> count` helper next to the existing width thresholds, so it is unit-testable without a terminal. The compositor applies it against the terminal it already owns, keeping a single authoritative width source (`terminal.size()`).
- **The CLI still builds the full four-fixture catalog;** the compositor shows as many as fit. Building four cheap fixture snapshots when three are shown is negligible and keeps the fixture catalog defined in one place.

## Implementation

- `render/mod.rs`: added `GALLERY_FOUR_COLUMN_MIN_WIDTH = 240` and a pure `pub fn gallery_column_cap(width) -> usize` returning four when `width > 240`, else three.
- `app/demo.rs`: `serve_gallery` queries `terminal.size()` once after acquiring the terminal and truncates the column list to the cap before building per-column UI and pixel-painter state. A failed size probe defaults to the narrow-safe three-column layout. Truncation keeps the first N fixtures; the downstream `enumerate` rebinds indices, so pixel-pet id-base offsets stay correct.
- `render/tests/gallery.rs`: boundary unit test for `gallery_column_cap` covering 0, 240, 241, and 300.
- `docs/contributing/sidebar-screenshots.md`: documents the launch-time threshold.

No deviations from the plan. `gallery_layout` already renders whatever column count it is given, so it needed no change.

## Advisories

- The constant `GALLERY_FOUR_COLUMN_MIN_WIDTH = 240` is used with a strict `>`, so width 240 yields three columns, not four. The name reads like "minimum width for four columns" while the value is the last three-column width. The doc comment ("width above which…") and the strict-`>240` decision make the behavior correct and intentional; left as-is.
- `serve_gallery` owns a live terminal and has no unit-test seam, so its one-line truncation is covered indirectly by the pure policy test plus sandboxed interactive runs (verified: 240 columns renders three fixtures, 241 renders four) rather than a dedicated unit test.
- The full `cargo xtask gate` run showed four unrelated `web::*` integration failures caused by a pre-existing external `ttyd` process already holding `127.0.0.1:8200`; every code-quality stage and all other gate tests passed. Not related to this change.