### PR TITLE
fix(message): open the delivery gate for turns parked on background work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ RimZ is alpha software on the 0.x line. Commands, flags, config keys, and output
 ### Fixed
 
 - Homebrew upgrades through `rimz update` and the install script refresh formula data first, so a stale tap no longer skips a released build. → [installation](./docs/guide/installation.md)
+- Queued `done`-gated messages deliver when an agent's clean turn parks on background work instead of waiting for the background process to exit. → [messaging](./docs/guide/messaging.md)
 
 ## [0.4.1] (2026-07-21)
 

--- a/crates/rimz/src/agents/state.rs
+++ b/crates/rimz/src/agents/state.rs
@@ -795,9 +795,10 @@ impl AgentState {
     /// share. A live turn with an active provider park certificate reads as
     /// `paused` even when the lifecycle rollup is still `running`; native-input
     /// markers raise `waiting`, provider completion markers settle falsely-running
-    /// rows to `success`, and interruption markers settle falsely-running or
-    /// waiting rows to `idle`, which opens message delivery gates. Budget-aware
-    /// callers may still upgrade a paused projection to `failed`.
+    /// rows to `success`, interruption markers settle falsely-running or waiting
+    /// rows to `idle`, and a clean turn parked on background work reads as
+    /// `success`, which opens message delivery gates. Budget-aware callers may
+    /// still upgrade a paused projection to `failed`.
     pub fn effective_status(&self) -> AgentStatus {
         let settled = settled_outcome(self.status, self.context.as_ref(), self.last_activity);
         if settled == Some(TurnSettleOutcome::NativeWait) {
@@ -823,8 +824,16 @@ impl AgentState {
             Some(TurnSettleOutcome::PlanProposed) => AgentStatus::Waiting,
             Some(TurnSettleOutcome::Complete) => AgentStatus::Success,
             Some(TurnSettleOutcome::Interrupted) => AgentStatus::Idle,
-            // A native wait already returned above.
-            Some(TurnSettleOutcome::NativeWait) | None => self.status,
+            // A native wait already returned above. A clean turn end parked on
+            // still-in-flight background work reads as success: the verdict was
+            // earned, only the chore hums on (mirrors the sidebar's parked settle).
+            Some(TurnSettleOutcome::NativeWait) | None => {
+                if self.phase == TurnPhase::Parked {
+                    AgentStatus::Success
+                } else {
+                    self.status
+                }
+            }
         }
     }
 

--- a/crates/rimz/src/agents/state/tests.rs
+++ b/crates/rimz/src/agents/state/tests.rs
@@ -298,6 +298,16 @@ fn effective_status_keeps_raw_status_without_active_park() {
 }
 
 #[test]
+fn effective_status_settles_background_park_to_success() {
+    let mut parked = test_agent(AgentStatus::Running, 1_000);
+    parked.phase = TurnPhase::Parked;
+    assert_eq!(parked.effective_status(), AgentStatus::Success);
+
+    parked.phase = TurnPhase::Reasoning;
+    assert_eq!(parked.effective_status(), AgentStatus::Running);
+}
+
+#[test]
 fn waiting_and_interruption_outrank_a_budget_park() {
     let mut waiting = test_agent(AgentStatus::Waiting, 1_000);
     waiting.budget_park = Some(crate::harness::budget::BudgetPark {

--- a/crates/rimz/src/message.rs
+++ b/crates/rimz/src/message.rs
@@ -866,10 +866,8 @@ pub fn parse_schedule_at(raw: &str, now: &jiff::Zoned) -> Result<Timestamp, Stri
 pub fn delivery_checkpoint(signal: &LifecycleSignal) -> bool {
     matches!(
         signal,
-        LifecycleSignal::TurnEnded {
-            parked_on_background: false,
-            ..
-        } | LifecycleSignal::TurnInterrupted
+        LifecycleSignal::TurnEnded { .. }
+            | LifecycleSignal::TurnInterrupted
             | LifecycleSignal::CompactionEnded { .. }
     )
 }

--- a/crates/rimz/src/message/deliver.rs
+++ b/crates/rimz/src/message/deliver.rs
@@ -1024,6 +1024,14 @@ mod tests {
         assert_eq!(check.gate.status, Some(AgentStatus::Running));
         assert!(!check.gate.open);
 
+        let mut parked = receiver.clone();
+        parked.status = AgentStatus::Running;
+        parked.phase = crate::agents::TurnPhase::Parked;
+        let parked = snapshot(parked, true, now);
+        let check = explain(&candidate, std::slice::from_ref(&candidate), &parked, now);
+        assert_eq!(check.gate.status, Some(AgentStatus::Success));
+        assert!(check.gate.open);
+
         let mut waiting = receiver.clone();
         waiting.status = AgentStatus::Waiting;
         waiting.waiting_since = Some(waiting.last_activity);

--- a/crates/rimz/src/message/tests.rs
+++ b/crates/rimz/src/message/tests.rs
@@ -64,6 +64,18 @@ fn delivery_gates_follow_agent_lifecycle() {
     ));
     assert!(gate_open_for_agent(DeliveryGate::Any, &running, false, now));
 
+    let mut parked = agent("sess-parked", None);
+    parked.status = AgentStatus::Running;
+    parked.phase = crate::agents::TurnPhase::Parked;
+    assert!(gate_open_for_agent(DeliveryGate::Done, &parked, false, now));
+    assert!(gate_open_for_agent(DeliveryGate::Any, &parked, false, now));
+    assert!(!gate_open_for_agent(
+        DeliveryGate::Resume,
+        &parked,
+        false,
+        now
+    ));
+
     let mut plan = agent("sess-plan", None);
     plan.status = AgentStatus::Running;
     plan.phase = crate::agents::TurnPhase::Reasoning;
@@ -189,7 +201,7 @@ fn when_parser_accepts_literal_statuses_and_duration_units() {
 }
 
 #[test]
-fn delivery_checkpoint_requires_unparked_turn_end() {
+fn delivery_checkpoint_recognizes_turn_boundaries() {
     assert!(delivery_checkpoint(&LifecycleSignal::TurnInterrupted));
     assert!(delivery_checkpoint(&LifecycleSignal::TurnEnded {
         errored: false,
@@ -199,7 +211,7 @@ fn delivery_checkpoint_requires_unparked_turn_end() {
         errored: true,
         parked_on_background: false,
     }));
-    assert!(!delivery_checkpoint(&LifecycleSignal::TurnEnded {
+    assert!(delivery_checkpoint(&LifecycleSignal::TurnEnded {
         errored: false,
         parked_on_background: true,
     }));

--- a/docs/internals/agents/model.md
+++ b/docs/internals/agents/model.md
@@ -188,7 +188,7 @@ A compaction signal for a session the rollup has never seen folds to nothing. Co
 
 The rollup keeps the agent-owned truth. `snapshot.agents`, as `rimz sidebar snapshot` reports it, always holds the true lifecycle status; the *displayed* status is a projection over it, and two layers compute it.
 
-[`effective_status`](../../../crates/rimz/src/agents/state.rs) is the cheap shared projection every read path uses, so `rimz pane list` and message delivery agree with the sidebar about hookless state: a still-`running` turn with an active park marker reads as `paused`, a hookless plan proposal reads as `waiting`, and a hookless completion or interruption reads as `success` or `idle`.
+[`effective_status`](../../../crates/rimz/src/agents/state.rs) is the cheap shared projection every read path uses, so `rimz pane list` and message delivery agree with the sidebar about hookless state: a still-`running` turn with an active park marker reads as `paused`, a hookless plan proposal reads as `waiting`, a hookless completion or interruption reads as `success` or `idle`, and a clean end parked on background work reads as `success`.
 
 The sidebar row projection ([`project_display_status`](../../../crates/rimz/src/store/snapshot/view/aggregate/status.rs)) adds liveness and budget-aware refinements on top. The order is a pinned contract, top rung wins:
 

--- a/docs/internals/harness/messaging.md
+++ b/docs/internals/harness/messaging.md
@@ -126,7 +126,7 @@ Two flags add cross-agent gates to the boundary mode, and they compose with each
 - `--after <ADDR>` holds until that agent finishes its queued work. Each address must resolve to exactly one durable card; repeats form an all-of set. Naming the recipient itself is rejected, and so is a fan-out address.
 - `--when '@handle <status> <duration>'` holds until one agent stays continuously in a **raw** lifecycle status for the dwell. Self-reference is valid here, which is what makes keep-warm messages (`@codex --when '@codex idle 58m'`) work.
 
-The raw-versus-effective distinction is load-bearing. Delivery gates read `effective_status()`, which projects budget parks to `Paused` and settles hookless turns. `when` conditions read the stored `status` field directly, so a projection never trips a dwell the event log cannot justify.
+The raw-versus-effective distinction is load-bearing. Delivery gates read `effective_status()`, which projects budget parks to `Paused`, settles hookless turns, and reads a clean turn parked on background work as `Success` while the background chore runs. `when` conditions read the stored `status` field directly, so a projection never trips a dwell the event log cannot justify.
 
 ### The dispatch walk
 
@@ -180,7 +180,7 @@ Records that are scheduled, condition-blocked, or `Resume`-gated are filtered ou
 
 Three paths, all converging on the same one-message helper:
 
-**Lifecycle hooks.** [`delivery_checkpoint`](../../../crates/rimz/src/message.rs) admits an unparked root `TurnEnded`, `TurnInterrupted`, and `CompactionEnded`. On one of those the hook finds the FIFO head for the agent's card and spawns a detached `rimz message deliver --message-id <id>` with nulled stdio. `Registered`, subagent stops, compaction starts, and turn ends parked on background work do not check the queue.
+**Lifecycle hooks.** [`delivery_checkpoint`](../../../crates/rimz/src/message.rs) admits every root `TurnEnded`, plus `TurnInterrupted` and `CompactionEnded`. On one of those the hook finds the FIFO head for the agent's card and spawns a detached `rimz message deliver --message-id <id>` with nulled stdio. `Registered`, subagent stops, and compaction starts do not check the queue.
 
 The same hook separately nudges the sweep when this agent is *referenced* by an unmet condition: `after` conditions on delivery checkpoints, `when` conditions on a wider set that includes `Registered`, `TurnStarted`, `AwaitingInput`, and the subagent edges, because a dwell can start or break on any of them.
 


### PR DESCRIPTION
## Context

A queued `done`-gated message stayed `queued` even though its receiver's agent card already showed `success`. In the field, an agent finished its turn cleanly but had a long-running background shell still active; the card read `success`, yet `rimz message show` reported `gate: closed (status running, gate done)` and the message never delivered until the background process exited — which for a long-lived process may be never.

The root cause is a disagreement between two projections of the same lifecycle shape. Claude Code (v2.1.145+) reports a clean turn end with still-in-flight background work as `TurnEnded { parked_on_background: true }`; the rollup keeps `status = Running` with `phase = TurnPhase::Parked`. The sidebar card projection settled that shape to `Success`, but the shared `AgentState::effective_status()` projection — which message delivery reads through its gate — ignored `phase` and returned `Running`, so the `done` gate stayed closed. Separately, `delivery_checkpoint()` excluded the parked turn end, so even once the gate could open, the boundary spawned no delivery attempt.

## Design choices

- **Fix in `effective_status()`, not in the message gate.** It is the one shared projection every hookless read path uses, so the message gate, `--after` conditions, `rimz pane` status, `rimz agents` list, shell completion, and the sidebar fallback all inherit the rule and agree with the card. `docs/internals/agents/model.md` names this agreement as an invariant; the parked settle was the missing rung.
- **Leave the sidebar's explicit parked settle in place.** That branch sits before the stall check, so a row parked longer than the stall threshold still reads `success` rather than flipping to `failed`. Removing it in favor of the shared fallback would regress long parks through the stall rung.
- **Broaden `delivery_checkpoint` rather than add a parked-only branch.** The detached `message deliver` helper it spawns performs the full ordered gate check, so admitting every root `TurnEnded` can only prompt an immediate, safe re-evaluation instead of waiting for the elder sweep's retry wake.

## Implementation

- `AgentState::effective_status()` projects `Running + TurnPhase::Parked` to `Success`, placed after the native-wait, budget-park, non-running, and turn-error precedence checks — so a parked row carrying a budget park or an active turn error keeps its stronger verdict. The arm is reachable only for a running row with no other settled outcome, which is exactly the parked-idle window; any new turn, tool, or subagent moves the phase off `Parked` in the reducer, so it never reports a false success during live work.
- `delivery_checkpoint()` treats every root `TurnEnded` (plus `TurnInterrupted` and `CompactionEnded`) as a delivery boundary, so a clean end parked on background work immediately spawns the normal re-checking delivery helper.
- Docs updated: the agent-model effective-status enumeration, the messaging raw-versus-effective sentence, and the messaging do-not-check list.
- `CHANGELOG.md` gains an Unreleased/Fixed entry (beyond the plan's two internals docs) because the contributor contract requires user-visible changes to accrue under Unreleased.

Four regression tests pin the behavior: the shared projection settling `Running + Parked` to `Success`, the `Done`/`Any`/`Resume` gate outcomes for a parked agent, the flipped `delivery_checkpoint` recognizing a parked turn end, and the user-facing delivery explanation reproducing the exact field state (`gate.status == Success`, `gate.open == true`).

## Advisories

- Coverage stops at unit tests over the exact durable `Running + Parked` state and the delivery explanation; there is no live-agent test launching a real background shell. Acceptable here — the change is provider-neutral downstream projection logic, and the provider adapters already cover their parked lifecycle mapping.