### PR TITLE
fix(web): pin the browser cursor steady against blink escape sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ RimZ is alpha software on the 0.x line. Commands, flags, config keys, and output
 
 ### Fixed
 
+- Browser cursors stay steady when terminal apps request a blinking cursor. → [web](./docs/guide/web.md#browser-appearance-and-input)
 - Homebrew upgrades through `rimz update` and the install script refresh formula data first, so a stale tap no longer skips a released build. → [installation](./docs/guide/installation.md)
 - Queued `done`-gated messages deliver when an agent's clean turn parks on background work instead of waiting for the background process to exit. → [messaging](./docs/guide/messaging.md)
 

--- a/crates/rimz/src/web/ttyd/client.rs
+++ b/crates/rimz/src/web/ttyd/client.rs
@@ -23,7 +23,7 @@ use crate::web::WebWarning;
 const STOCK_INDEX_TIMEOUT: Duration = Duration::from_secs(5);
 const STOCK_INDEX_MAX_BYTES: u64 = 16 * 1024 * 1024;
 const INDEX_CACHE_DIR: &str = "rimz/web-ttyd";
-const CUSTOM_INDEX_SCHEMA: &str = "rimz.ttyd-index.v3";
+const CUSTOM_INDEX_SCHEMA: &str = "rimz.ttyd-index.v4";
 
 const OFFLINE_ENV: &str = "RIMZ_WEB_FONTS_OFFLINE";
 const FONT_CACHE_DIR: &str = "rimz/web-fonts";
@@ -290,6 +290,17 @@ waitForTerminal().then(term=>{{
     }}catch(_){{}}
     return true;
   }});
+  const steadyStyles={{0:"block",1:"block",2:"block",3:"underline",4:"underline",5:"bar",6:"bar"}};
+  term.parser.registerCsiHandler({{intermediates:" ",final:"q"}},params=>{{
+    const style=steadyStyles[params[0]||0];
+    if(!style)return true;
+    if(term.options.cursorStyle!==style)term.options.cursorStyle=style;
+    if(term.options.cursorBlink)term.options.cursorBlink=false;
+    return true;
+  }});
+  const swallowBlinkMode=params=>params.length===1&&params[0]===12;
+  term.parser.registerCsiHandler({{prefix:"?",final:"h"}},swallowBlinkMode);
+  term.parser.registerCsiHandler({{prefix:"?",final:"l"}},swallowBlinkMode);
   term.onSelectionChange(()=>writeClipboard(term.getSelection()));
   const updateOverlay=node=>{{
     const element=node.nodeType===Node.ELEMENT_NODE?node:node.parentElement;
@@ -816,6 +827,7 @@ mod tests {
             .expect("document markers");
         assert!(rendered.contains("rimz-web-client"));
         assert!(rendered.contains("term.options.cursorBlink=false"));
+        assert!(rendered.contains("registerCsiHandler({intermediates:\" \",final:\"q\"}"));
         assert!(!rendered.contains("@font-face"));
     }
 
@@ -827,6 +839,7 @@ mod tests {
             weight: 400,
         }];
         let family = "RimZ \"Font\" </style></script>\n";
+        assert_eq!(CUSTOM_INDEX_SCHEMA, "rimz.ttyd-index.v4");
         let key = custom_index_key("ttyd 1.7.7", Some(family), &faces);
         assert_eq!(key, custom_index_key("ttyd 1.7.7", Some(family), &faces));
         assert_ne!(key, custom_index_key("ttyd 1.7.8", Some(family), &faces));
@@ -849,6 +862,19 @@ mod tests {
             )
         );
         assert!(rendered.contains("term.options.cursorBlink=false"));
+        assert!(rendered.contains(
+            "const steadyStyles={0:\"block\",1:\"block\",2:\"block\",3:\"underline\",4:\"underline\",5:\"bar\",6:\"bar\"}"
+        ));
+        assert!(rendered.contains("registerCsiHandler({intermediates:\" \",final:\"q\"}"));
+        assert!(
+            rendered.contains("if(term.options.cursorStyle!==style)term.options.cursorStyle=style")
+        );
+        assert!(rendered.contains("if(term.options.cursorBlink)term.options.cursorBlink=false"));
+        assert!(
+            rendered.contains("const swallowBlinkMode=params=>params.length===1&&params[0]===12")
+        );
+        assert!(rendered.contains("registerCsiHandler({prefix:\"?\",final:\"h\"}"));
+        assert!(rendered.contains("registerCsiHandler({prefix:\"?\",final:\"l\"}"));
         assert!(rendered.contains("term.attachCustomKeyEventHandler(keyHandler)"));
         assert!(rendered.contains("registerOscHandler(52"));
         assert!(rendered.contains("onSelectionChange"));

--- a/docs/guide/web.md
+++ b/docs/guide/web.md
@@ -39,7 +39,7 @@ RimZ gives ttyd the active theme and configured browser font when the daemon sta
 
 Set `font_source` to a local `.ttf`, `.otf`, `.woff`, or `.woff2` file, or to an HTTPS URL. A family with no preset and no source asks the browser to resolve an installed font. `style_client = false` keeps ttyd's browser colors while retaining keyboard, cursor, clipboard, and reconnect fixes.
 
-The compatibility layer keeps the cursor steady, preserves Shift+Enter and macOS Option-as-Meta input, sends tmux copy-mode yanks and Shift-drag selections to the clipboard, and refreshes xterm after a downloaded font loads. Missing font bytes warn and fall back to monospace.
+The compatibility layer keeps the cursor steady when terminal apps request blinking while preserving their requested cursor shapes, preserves Shift+Enter and macOS Option-as-Meta input, sends tmux copy-mode yanks and Shift-drag selections to the clipboard, and refreshes xterm after a downloaded font loads. Missing font bytes warn and fall back to monospace.
 
 Appearance is fixed when the shared daemon starts. After changing `[theme]` or web styling, run:
 

--- a/docs/internals/web.md
+++ b/docs/internals/web.md
@@ -48,7 +48,7 @@ The built-in Nerd Font families use SHA-256-pinned regular and bold faces. HTTPS
 
 ttyd serves no additional static route, so RimZ caches a generated index under `$XDG_CACHE_HOME/rimz/web-ttyd`. A cache miss starts a throwaway loopback ttyd on an ephemeral port, fetches its stock `/` page with temporary Basic Auth, stops it, and injects the font faces plus the compatibility bootstrap.
 
-The bootstrap refreshes xterm after fonts load, keeps the cursor steady across reconnects, preserves Shift+Enter and macOS Meta chords, bridges OSC 52 and browser selections to the clipboard, and restyles disconnect and resize overlays. A font or index failure warns and falls back without blocking the daemon.
+The bootstrap refreshes xterm after fonts load, keeps the cursor steady across reconnects and app-emitted blink sequences while preserving requested cursor shapes, preserves Shift+Enter and macOS Meta chords, bridges OSC 52 and browser selections to the clipboard, and restyles disconnect and resize overlays. It guards blinking DECSCUSR styles and DEC mode 12 at the xterm parser. A font or index failure warns and falls back without blocking the daemon.
 
 ## Commands and room start
 


### PR DESCRIPTION
## Context

Users saw the ttyd browser cursor blinking fast and erratically — worst while typing, occasionally stable. The client already requested a steady cursor twice (the daemon passes `-t cursorBlink=false`, and the injected bootstrap re-asserts `term.options.cursorBlink=false` after every `term.reset`), yet the blink returned.

Root cause: xterm.js has two runtime escape-sequence paths that flip `cursorBlink` back on behind the option, and nothing in the client guarded them:

- **DECSCUSR** (`CSI Ps SP q`): the blinking styles 1/3/5 (block/underline/bar) turn blink on inside xterm.js's input handler.
- **DEC private mode 12** (`CSI ?12h` / `?12l`): att610 start/stop cursor blinking, also honored by xterm.js.

Any inner program can emit these (shell plugins, TUIs entering a blinking bar for insert mode, or the mux forwarding the focused pane's cursor state). TUIs re-send the cursor style every redraw and typing redraws per keystroke, so the blink state churned at keystroke rate — the observed flicker. "Sometimes stable" was simply no app having sent a blinking style yet that session.

## Design choices

- **Fix at the xterm.js parser chokepoint**, in the injected bootstrap. One place covers every emitter and both mux backends, with no server or mux-config change.
- **Honor cursor shape, strip only blink.** Apps legitimately switch block/underline/bar (e.g. vi insert mode); the browser invariant is "never blinks", not "never changes shape". The guard maps each blinking DECSCUSR style to its steady counterpart and force-clears `cursorBlink`.
- **Register the guards once, outside `install()`.** Parser handlers survive `term.reset()`, so registering them in the one-time `waitForTerminal().then` body avoids stacking duplicate handlers on every reset; `install()` keeps its own `cursorBlink=false` reset for the option-state restore path.
- **No mode-2026 synchronized-output shim** — rejected as fragile stateful stream-scanning in injected JS that fights ttyd flow control for a tmux-only benefit. Revisit only if flicker survives this fix.

The fix relies on xterm.js parser-dispatch semantics: custom CSI handlers registered at runtime run before the built-ins registered at construction, and returning `true` breaks the dispatch chain so the built-in never runs. The DECSCUSR guard returns `true` to fully replace the built-in (setting the shape itself, minus blink); the mode-12 guard returns `true` only for a lone mode 12 and `false` for every other DEC private mode, letting DECTCEM, alt-screen, mouse modes, and the rest fall through untouched. The in-repo OSC 52 clipboard handler already depends on the same "return true swallows" chain.

## Implementation

All code lives in `crates/rimz/src/web/ttyd/client.rs`.

- Three parser guards added to the bootstrap: a DECSCUSR handler (`{intermediates:" ",final:"q"}`) mapping styles 0-6 to steady block/underline/bar and clearing blink, plus `?h`/`?l` handlers swallowing a lone mode 12. Equality checks guard the option writes to avoid options-service churn when TUIs re-send the same style every frame.
- `CUSTOM_INDEX_SCHEMA` bumped `rimz.ttyd-index.v3` → `v4`; the constant is hashed into the index cache key, so existing installs regenerate the cached index with the new bootstrap.
- Unit tests extended in the existing rendered-content style to assert the style map, handler registrations, guarded option writes, the lone-mode-12 predicate, and the schema bump.
- Docs updated: `docs/guide/web.md`, `docs/internals/web.md`, and an unreleased `CHANGELOG.md` entry.

No deviations from the plan.

Verification: `cargo xtask gate` passes (fmt, invariants, docs-links, lint, fast nextest); `cargo xtask test web::ttyd` green. In a real sandboxed ttyd daemon, the generated `index-*.html` was loaded and its registered DECSCUSR/DECSET callbacks fired — styles 1/4/5 produced steady block/underline/bar, a lone mode 12 was handled, and `?12;25`/`?25` fell through.

## Advisories

- **Multi-param mode 12 falls through (known, accepted).** A combined DECSET such as `CSI ?12;25h` has more than one parameter, so the guard returns `false` and the built-in re-enables blink. Custom handlers cannot mutate params before fallthrough; real-world emitters send mode 12 alone. Documented tradeoff, not a defect.
- **Tests assert rendered text, not runtime JS.** The unit tests check the bootstrap string contains the handlers; they do not execute the JS (no browser/JS harness in nextest). Runtime behavior is covered by the manual sandbox callback exercise above. A visual browser pass against ttyd's bundled xterm.js is the one check not run in this environment (no browser binary).