### PR TITLE
feat(web): trusted-header auth and trusted-proxy gating for the shared ttyd daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ A follow-up to 0.4.0: one shared daemon serves browser access for Zellij and tmu
 
 ### Added
 
+- Browser rooms can delegate authentication to a reverse proxy through `[web] auth_header`, bind a configured IP through `[web] interface`, and restrict non-loopback clients to `[web] trusted_proxies` through a source-address gate. → [web](./docs/guide/web.md#behind-a-reverse-proxy)
 - Sidebar worktree PR badges open their pull request through terminal hyperlinks, including across SSH and browser attaches. → [sidebar](./docs/guide/sidebar.md#the-agent-cards)
 - First-run setup asks whether to enable auto-continue and automatic Codex reset-credit redemption together, defaulting yes. → [loops](./docs/guide/loops.md)
 - Browser rooms provision a verified JetBrainsMono or CaskaydiaCove Nerd Font, refresh xterm after the face loads so icons render instead of blocks, accept a local or HTTPS custom font, and use the active RimZ terminal colors. The browser cursor stays steady, Shift+Enter reaches agents as a soft newline, tmux copy-mode yanks and Shift-drag selections reach the system clipboard, disconnect and resize popups use a dark-glass style, and macOS Option chords reach tmux without leaking composed characters. → [web](./docs/guide/web.md#browser-appearance-and-input)

--- a/crates/rimz/src/cli/remote/web.rs
+++ b/crates/rimz/src/cli/remote/web.rs
@@ -461,6 +461,12 @@ fn parse_web_payload(
             payload.version
         );
     }
+    if let rimz::web::WebAuth::TrustedHeader { .. } = &payload.auth {
+        bail!(
+            "the remote serves browser access behind a reverse proxy (trusted-header auth) — open `{}` directly; no SSH tunnel applies",
+            payload.url
+        );
+    }
     let credential = payload
         .credential
         .clone()
@@ -602,6 +608,24 @@ fn report_web_tunnel_up(host: &str, reconnect: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn trusted_header_payload_refuses_an_ssh_tunnel() {
+        let bytes = br#"{
+            "version":"rimz.web.v2",
+            "url":"https://devbox.example/rimz/?arg=room",
+            "session":"room",
+            "port":8200,
+            "auth":{"mode":"trusted_header","header":"X-Forwarded-User"}
+        }"#;
+        let err = parse_web_payload(bytes).expect_err("trusted-header tunnel refusal");
+        let message = err.to_string();
+        assert!(message.contains("behind a reverse proxy"), "{message}");
+        assert!(
+            message.contains("open `https://devbox.example/rimz/?arg=room` directly"),
+            "{message}"
+        );
+    }
 
     #[test]
     fn web_exit_settlement_uses_master_or_port_establishment() {

--- a/crates/rimz/src/cli/render/mod.rs
+++ b/crates/rimz/src/cli/render/mod.rs
@@ -77,14 +77,20 @@ pub(crate) fn err() -> anstream::AutoStream<std::io::StderrLock<'static>> {
 pub(crate) fn web_warnings(warnings: &[rimz::web::WebWarning]) {
     let mut stderr = err();
     for warning in warnings {
-        let (surface, detail) = match warning {
+        let skipped = match warning {
             rimz::web::WebWarning::BrowserClientSkipped(detail) => {
-                ("browser terminal fixes", detail)
+                Some(("browser terminal fixes", detail))
             }
-            rimz::web::WebWarning::BrowserFontSkipped(detail) => ("browser font", detail),
-            rimz::web::WebWarning::BrowserThemeSkipped(detail) => ("browser theme", detail),
+            rimz::web::WebWarning::BrowserFontSkipped(detail) => Some(("browser font", detail)),
+            rimz::web::WebWarning::BrowserThemeSkipped(detail) => Some(("browser theme", detail)),
+            rimz::web::WebWarning::HeaderAuthUnprotected(detail) => {
+                let _ = writeln!(stderr, "rimz: warning: {detail}");
+                None
+            }
         };
-        let _ = writeln!(stderr, "rimz: skipping {surface}: {detail}");
+        if let Some((surface, detail)) = skipped {
+            let _ = writeln!(stderr, "rimz: skipping {surface}: {detail}");
+        }
     }
 }
 

--- a/crates/rimz/src/cli/snapshots/rimz__cli__surface_tests__cli_surface.snap
+++ b/crates/rimz/src/cli/snapshots/rimz__cli__surface_tests__cli_surface.snap
@@ -879,6 +879,8 @@ rimz help web
 
 rimz help web exec [hidden]
 
+rimz help web gate [hidden]
+
 rimz help web open
 
 rimz help web start
@@ -1978,9 +1980,22 @@ rimz web exec [hidden]
     --tmux  [action=set-true takes=0..=0 global]
     --zellij  [action=set-true takes=0..=0 global]
 
+rimz web gate [hidden]
+    --allow <ALLOW>  [action=append takes=1..=1 required]
+    --color <COLOR>  [action=set takes=1..=1 global default=auto values=auto|always|never]
+    -h, --help  [action=help takes=0..=0]
+    --listen <LISTEN>  [action=set takes=1..=1 required]
+    --mux <MUX>  [action=set takes=1..=1 global]
+    --root <ROOT>  [action=set takes=1..=1 global]
+    --tmux  [action=set-true takes=0..=0 global]
+    --upstream <UPSTREAM>  [action=set takes=1..=1 required]
+    --zellij  [action=set-true takes=0..=0 global]
+
 rimz web help
 
 rimz web help exec [hidden]
+
+rimz web help gate [hidden]
 
 rimz web help help
 

--- a/crates/rimz/src/cli/web.rs
+++ b/crates/rimz/src/cli/web.rs
@@ -1,6 +1,7 @@
 //! `rimz web` — browser access through the shared ttyd daemon.
 
 use std::io::Write as _;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
@@ -8,7 +9,7 @@ use clap::{Args, Subcommand};
 
 use super::{GlobalFlags, machine_config, open_browser_best_effort};
 use crate::cli::room;
-use rimz::web::WebCredential;
+use rimz::web::{WebAuth, WebCredential};
 
 #[derive(Debug, Args)]
 pub struct WebArgs {
@@ -38,6 +39,16 @@ enum WebSubcmd {
     Exec {
         #[arg(value_name = "SESSION")]
         session: Option<String>,
+    },
+    /// Restrict and forward connections to the shared ttyd daemon.
+    #[command(hide = true)]
+    Gate {
+        #[arg(long)]
+        listen: SocketAddr,
+        #[arg(long)]
+        upstream: SocketAddr,
+        #[arg(long = "allow", required = true)]
+        allow: Vec<String>,
     },
 }
 
@@ -119,6 +130,11 @@ pub fn run(args: WebArgs, globals: &GlobalFlags) -> Result<()> {
         WebSubcmd::Stop => stop(),
         WebSubcmd::Token { command } => token(command),
         WebSubcmd::Exec { session } => exec(session.as_deref()),
+        WebSubcmd::Gate {
+            listen,
+            upstream,
+            allow,
+        } => rimz::web::serve_gate(listen, upstream, &allow).map_err(Into::into),
     }
 }
 
@@ -143,13 +159,21 @@ fn open(args: WebOpenArgs, globals: &GlobalFlags) -> Result<()> {
         return crate::cli::render::json(&outcome.payload);
     }
     print_url(&outcome.payload.url)?;
-    write_web_credential(
-        outcome
-            .payload
-            .credential
-            .as_ref()
-            .context("shared ttyd daemon returned no credential")?,
-    );
+    match &outcome.payload.auth {
+        WebAuth::Basic => write_web_credential(
+            outcome
+                .payload
+                .credential
+                .as_ref()
+                .context("shared ttyd daemon returned no credential")?,
+        ),
+        WebAuth::TrustedHeader { header } => {
+            let _ = writeln!(
+                std::io::stderr().lock(),
+                "rimz: authentication is delegated to the reverse proxy (trusted header `{header}`)"
+            );
+        }
+    }
     if !args.print {
         open_browser_best_effort(&outcome.payload.url);
     }
@@ -180,11 +204,15 @@ fn status(args: WebStatusArgs) -> Result<()> {
     if let Some(pid) = status.pid {
         writeln!(
             stdout,
-            "ttyd: online on 127.0.0.1:{} (pid {pid})",
-            status.port
+            "ttyd: online on {} (pid {pid})",
+            listener_display(&status.interface, status.port)
         )?;
     } else {
-        writeln!(stdout, "ttyd: offline (configured port {})", status.port)?;
+        writeln!(
+            stdout,
+            "ttyd: offline (configured listener {})",
+            listener_display(&status.interface, status.port)
+        )?;
     }
     Ok(())
 }
@@ -194,8 +222,8 @@ fn start() -> Result<()> {
     crate::cli::render::web_warnings(&outcome.warnings);
     writeln!(
         std::io::stdout().lock(),
-        "ttyd: online on 127.0.0.1:{} (pid {})",
-        outcome.port,
+        "ttyd: online on {} (pid {})",
+        listener_display(&outcome.interface, outcome.port),
         outcome.pid
     )?;
     Ok(())
@@ -266,4 +294,11 @@ fn write_web_credential(credential: &WebCredential) {
 fn print_url(url: &str) -> Result<()> {
     writeln!(std::io::stdout().lock(), "{url}")?;
     Ok(())
+}
+
+fn listener_display(interface: &str, port: u16) -> String {
+    interface.parse::<std::net::IpAddr>().map_or_else(
+        |_| format!("{interface}:{port}"),
+        |ip| SocketAddr::new(ip, port).to_string(),
+    )
 }

--- a/crates/rimz/src/config/template_tests.rs
+++ b/crates/rimz/src/config/template_tests.rs
@@ -69,8 +69,12 @@ fn template_covers_serialized_default_leaves() {
         );
     }
 
-    let allowed_template_only =
-        BTreeSet::from(["web.base_url".to_owned(), "web.font_source".to_owned()]);
+    let allowed_template_only = BTreeSet::from([
+        "web.auth_header".to_owned(),
+        "web.base_url".to_owned(),
+        "web.font_source".to_owned(),
+        "web.trusted_proxies".to_owned(),
+    ]);
     for path in template.difference(&expected) {
         assert!(
             allowed_template_only.contains(path),

--- a/crates/rimz/src/config/templates/config.template.toml
+++ b/crates/rimz/src/config/templates/config.template.toml
@@ -77,10 +77,13 @@
 
 [web]
 # Browser access through one machine-wide ttyd daemon shared by every room.
-# The daemon listens on loopback; `rimz remote connect --web` forwards it over SSH.
+# The daemon listens on loopback by default; `rimz remote connect --web` forwards Basic Auth over SSH.
 # enabled = true                      # best-effort start the daemon with each room and allow rimz web / remote --web
-# port = 8200                         # exact loopback port for the shared daemon
+# port = 8200                         # exact port for the shared daemon
+# interface = "127.0.0.1"             # listener IP; use a non-loopback address only with a firewall or trusted_proxies
 ## base_url = "https://devbox.example/rimz" # public URL when a reverse proxy fronts ttyd
+## auth_header = "X-Authentik-Username" # delegate auth to a proxy that injects this trusted header; disables Basic Auth
+## trusted_proxies = ["172.18.0.0/16"] # source CIDRs allowed to reach ttyd; loopback is always allowed
 # font = "JetBrainsMono Nerd Font Mono" # browser terminal font; built-in JetBrainsMono and CaskaydiaCove Nerd Font Mono presets download automatically
 ## font_source = "/path/to/font.woff2" # optional local font file or https URL; declared under the configured font family
 # style_client = true                 # style ttyd from [theme] and provision the configured browser font

--- a/crates/rimz/src/config/tests.rs
+++ b/crates/rimz/src/config/tests.rs
@@ -104,6 +104,9 @@ fn assert_web_config(config: &MachineConfig) {
         Some("https://devbox.example/rimz")
     );
     assert_eq!(config.web.port, 9123);
+    assert_eq!(config.web.interface, "0.0.0.0");
+    assert_eq!(config.web.auth_header.as_deref(), Some("X-Forwarded-User"));
+    assert_eq!(config.web.trusted_proxies, ["10.0.0.0/8", "fd00::/8"]);
     assert_eq!(config.web.font, "FiraCode Nerd Font Mono");
     assert_eq!(config.web.font_source.as_deref(), Some("/tmp/font.woff2"));
     assert!(!config.web.style_client);
@@ -1613,6 +1616,9 @@ fn notifications_parse_per_machine_preferences() {
 fn web_enabled_defaults_on_and_parses_off() {
     assert!(WebPrefs::default().enabled);
     assert_eq!(WebPrefs::default().port, 8200);
+    assert_eq!(WebPrefs::default().interface, "127.0.0.1");
+    assert!(WebPrefs::default().auth_header.is_none());
+    assert!(WebPrefs::default().trusted_proxies.is_empty());
 
     let dir = tempdir().expect("tempdir");
     let config = load_no_fragments(&write(&dir, "[web]\nenabled = false\n")).expect("load");
@@ -1632,7 +1638,10 @@ fn scalar_sections_parse_non_default_values() {
             "[web]\n\
              enabled = false\n\
              port = 9123\n\
+             interface = \"0.0.0.0\"\n\
              base_url = \"https://devbox.example/rimz\"\n\
+             auth_header = \"X-Forwarded-User\"\n\
+             trusted_proxies = [\"10.0.0.0/8\", \"fd00::/8\"]\n\
              font = \"FiraCode Nerd Font Mono\"\n\
              font_source = \"/tmp/font.woff2\"\n\
              style_client = false\n",

--- a/crates/rimz/src/config/web.rs
+++ b/crates/rimz/src/config/web.rs
@@ -2,7 +2,8 @@ use serde::{Deserialize, Serialize};
 
 /// Browser-access preferences for the machine-wide ttyd daemon.
 ///
-/// These are per-machine preferences: the port selects the loopback listener,
+/// These are per-machine preferences: the interface and port select the
+/// listener, trusted-header authentication and proxy CIDRs constrain access,
 /// base URLs can name private hostnames or reverse-proxy paths, font sources
 /// name read-only paths or HTTPS URLs, and no field executes a command. The
 /// section therefore stays outside the project trust hash.
@@ -11,8 +12,13 @@ use serde::{Deserialize, Serialize};
 pub struct WebPrefs {
     pub enabled: bool,
     pub port: u16,
+    pub interface: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_header: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub trusted_proxies: Vec<String>,
     pub font: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_source: Option<String>,
@@ -24,7 +30,10 @@ impl Default for WebPrefs {
         Self {
             enabled: true,
             port: 8200,
+            interface: "127.0.0.1".to_owned(),
             base_url: None,
+            auth_header: None,
+            trusted_proxies: Vec::new(),
             font: "JetBrainsMono Nerd Font Mono".to_owned(),
             font_source: None,
             style_client: true,

--- a/crates/rimz/src/remote/web.rs
+++ b/crates/rimz/src/remote/web.rs
@@ -229,7 +229,13 @@ mod tests {
 
     #[test]
     fn local_url_percent_encodes_the_ttyd_session_argument() {
-        let payload = WebOpenPayload::for_session("rimz/a b", "https://remote", 8200, None);
+        let payload = WebOpenPayload::for_session(
+            "rimz/a b",
+            "https://remote",
+            8200,
+            crate::web::WebAuth::Basic,
+            None,
+        );
         assert_eq!(
             local_url(&payload, 8301),
             "http://127.0.0.1:8301/?arg=rimz%2Fa%20b"

--- a/crates/rimz/src/web/gate.rs
+++ b/crates/rimz/src/web/gate.rs
@@ -1,0 +1,189 @@
+//! Source-address gate for a shared ttyd listener behind a trusted proxy.
+
+use std::io;
+use std::net::{IpAddr, Shutdown, SocketAddr, TcpListener, TcpStream};
+use std::time::Duration;
+
+use super::{Result, WebErr};
+
+const UPSTREAM_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum Cidr {
+    V4 { network: u32, prefix: u8 },
+    V6 { network: u128, prefix: u8 },
+}
+
+impl Cidr {
+    pub(super) fn parse(value: &str) -> Result<Self> {
+        let (address, prefix) = value
+            .split_once('/')
+            .map_or((value, None), |(address, prefix)| (address, Some(prefix)));
+        let address = address
+            .parse::<IpAddr>()
+            .map_err(|err| invalid(value, err.to_string()))?;
+        match address {
+            IpAddr::V4(address) => {
+                let prefix = parse_prefix(value, prefix, 32)?;
+                Ok(Self::V4 {
+                    network: address.to_bits(),
+                    prefix,
+                })
+            }
+            IpAddr::V6(address) => {
+                let prefix = parse_prefix(value, prefix, 128)?;
+                Ok(Self::V6 {
+                    network: address.to_bits(),
+                    prefix,
+                })
+            }
+        }
+    }
+
+    pub(super) fn contains(&self, address: IpAddr) -> bool {
+        match (self, address) {
+            (Self::V4 { network, prefix }, IpAddr::V4(address)) => prefix_matches(
+                u128::from(*network),
+                u128::from(address.to_bits()),
+                *prefix,
+                32,
+            ),
+            (Self::V6 { network, prefix }, IpAddr::V6(address)) => {
+                prefix_matches(*network, address.to_bits(), *prefix, 128)
+            }
+            (Self::V4 { .. }, IpAddr::V6(_)) | (Self::V6 { .. }, IpAddr::V4(_)) => false,
+        }
+    }
+}
+
+fn parse_prefix(value: &str, prefix: Option<&str>, width: u8) -> Result<u8> {
+    let Some(prefix) = prefix else {
+        return Ok(width);
+    };
+    let prefix = prefix
+        .parse::<u8>()
+        .map_err(|err| invalid(value, format!("invalid prefix length: {err}")))?;
+    if prefix > width {
+        return Err(invalid(
+            value,
+            format!("prefix length {prefix} exceeds {width}"),
+        ));
+    }
+    Ok(prefix)
+}
+
+fn prefix_matches(network: u128, address: u128, prefix: u8, width: u8) -> bool {
+    if prefix == 0 {
+        return true;
+    }
+    let shift = u32::from(width - prefix);
+    network >> shift == address >> shift
+}
+
+fn invalid(value: &str, reason: String) -> WebErr {
+    WebErr::InvalidTrustedProxy {
+        value: value.to_owned(),
+        reason,
+    }
+}
+
+pub(super) fn peer_allowed(peer: IpAddr, allow: &[Cidr]) -> bool {
+    let peer = match peer {
+        IpAddr::V6(address) => address.to_ipv4_mapped().map_or(peer, IpAddr::V4),
+        IpAddr::V4(_) => peer,
+    };
+    peer.is_loopback() || allow.iter().any(|cidr| cidr.contains(peer))
+}
+
+pub(super) fn serve(listen: SocketAddr, upstream: SocketAddr, allow: Vec<Cidr>) -> Result<()> {
+    let listener = TcpListener::bind(listen).map_err(|source| WebErr::GateIo {
+        action: "binding its listener",
+        source,
+    })?;
+    loop {
+        let (client, peer) = match listener.accept() {
+            Ok(connection) => connection,
+            Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
+            Err(source) => {
+                return Err(WebErr::GateIo {
+                    action: "accepting a connection",
+                    source,
+                });
+            }
+        };
+        if !peer_allowed(peer.ip(), &allow) {
+            continue;
+        }
+        let Ok(upstream) = TcpStream::connect_timeout(&upstream, UPSTREAM_CONNECT_TIMEOUT) else {
+            continue;
+        };
+        splice(client, upstream);
+    }
+}
+
+fn splice(client: TcpStream, upstream: TcpStream) {
+    let _ = client.set_nodelay(true);
+    let _ = upstream.set_nodelay(true);
+    let (Ok(mut client_read), Ok(mut upstream_write)) = (client.try_clone(), upstream.try_clone())
+    else {
+        return;
+    };
+    std::thread::spawn(move || {
+        let _ = io::copy(&mut client_read, &mut upstream_write);
+        let _ = upstream_write.shutdown(Shutdown::Write);
+    });
+    std::thread::spawn(move || {
+        let mut upstream_read = upstream;
+        let mut client_write = client;
+        let _ = io::copy(&mut upstream_read, &mut client_write);
+        let _ = client_write.shutdown(Shutdown::Write);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(value: &str) -> Cidr {
+        Cidr::parse(value).expect("valid CIDR")
+    }
+
+    #[test]
+    fn cidrs_match_their_address_family_and_prefix() {
+        assert!(parse("10.20.0.0/16").contains("10.20.4.5".parse().expect("IP")));
+        assert!(!parse("10.20.0.0/16").contains("10.21.4.5".parse().expect("IP")));
+        assert!(parse("fd00::/8").contains("fd12::1".parse().expect("IP")));
+        assert!(!parse("fd00::/8").contains("fe80::1".parse().expect("IP")));
+        assert!(!parse("10.0.0.0/8").contains("::ffff:10.0.0.1".parse().expect("IP")));
+    }
+
+    #[test]
+    fn bare_ips_and_zero_prefixes_parse() {
+        assert!(parse("192.0.2.4").contains("192.0.2.4".parse().expect("IP")));
+        assert!(!parse("192.0.2.4").contains("192.0.2.5".parse().expect("IP")));
+        assert!(parse("2001:db8::1").contains("2001:db8::1".parse().expect("IP")));
+        assert!(parse("0.0.0.0/0").contains("203.0.113.2".parse().expect("IP")));
+        assert!(parse("::/0").contains("2001:db8::2".parse().expect("IP")));
+    }
+
+    #[test]
+    fn invalid_cidrs_return_typed_errors() {
+        for value in ["", "10.0.0.0/33", "2001:db8::/129", "10.0.0.0/nope"] {
+            assert!(matches!(
+                Cidr::parse(value),
+                Err(WebErr::InvalidTrustedProxy { value: actual, .. }) if actual == value
+            ));
+        }
+    }
+
+    #[test]
+    fn peers_require_a_match_except_for_loopback() {
+        let allow = [parse("10.0.0.0/8")];
+        assert!(peer_allowed("10.2.3.4".parse().expect("IP"), &allow));
+        assert!(!peer_allowed("192.0.2.1".parse().expect("IP"), &allow));
+        assert!(peer_allowed("127.0.0.1".parse().expect("IP"), &[]));
+        assert!(peer_allowed("::1".parse().expect("IP"), &[]));
+        assert!(peer_allowed("::ffff:127.0.0.1".parse().expect("IP"), &[]));
+        assert!(peer_allowed("::ffff:10.2.3.4".parse().expect("IP"), &allow));
+    }
+}

--- a/crates/rimz/src/web/mod.rs
+++ b/crates/rimz/src/web/mod.rs
@@ -1,6 +1,7 @@
 //! Browser access through one machine-wide ttyd daemon.
 
 use std::io;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -13,6 +14,7 @@ use crate::mux::CommandSpec;
 use crate::room::session::{LiveSessions, workspace_record_for_session};
 use crate::store::atomic;
 
+mod gate;
 mod ttyd;
 
 pub const WEB_SCHEMA_VERSION: &str = "rimz.web.v2";
@@ -45,10 +47,8 @@ pub enum WebErr {
         "the shared ttyd daemon credential is missing; run `rimz web token create`, then retry"
     )]
     TtydCredentialMissing,
-    #[error(
-        "the shared ttyd daemon did not accept connections on 127.0.0.1:{port} within 5 seconds"
-    )]
-    TtydStartTimeout { port: u16 },
+    #[error("the shared ttyd daemon did not accept connections on {address} within 5 seconds")]
+    TtydStartTimeout { address: SocketAddr },
     #[error(
         "[web] port {port} is already in use by another process; choose a free port in `rimz config path`"
     )]
@@ -57,6 +57,24 @@ pub enum WebErr {
         "ttyd read-only access is per process, not per credential; read-only credentials are not supported"
     )]
     TtydReadOnlyCredential,
+    #[error(
+        "credential rotation is disabled while `[web] auth_header` is set; unset it to return to Basic Auth"
+    )]
+    TrustedHeaderCredential,
+    #[error(
+        "[web] interface `{value}` is not an IP address; set it to an IPv4 or IPv6 address in `rimz config path`"
+    )]
+    InvalidInterface { value: String },
+    #[error(
+        "[web] trusted proxy `{value}` is invalid: {reason}; use an IP address or CIDR in `rimz config path`"
+    )]
+    InvalidTrustedProxy { value: String, reason: String },
+    #[error("web proxy gate failed while {action}: {source}")]
+    GateIo {
+        action: &'static str,
+        #[source]
+        source: io::Error,
+    },
     #[error("ttyd credential `{name}` does not exist (the single credential is `rimz`)")]
     TtydCredentialNotFound { name: String },
     #[error(
@@ -88,12 +106,24 @@ pub struct WebCredential {
     pub secret: String,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum WebAuth {
+    #[default]
+    Basic,
+    TrustedHeader {
+        header: String,
+    },
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WebOpenPayload {
     pub version: String,
     pub url: String,
     pub session: String,
     pub port: u16,
+    #[serde(default)]
+    pub auth: WebAuth,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub credential: Option<WebCredential>,
 }
@@ -103,6 +133,7 @@ impl WebOpenPayload {
         session: impl Into<String>,
         base_url: impl Into<String>,
         port: u16,
+        auth: WebAuth,
         credential: Option<WebCredential>,
     ) -> Self {
         let session = session.into();
@@ -113,6 +144,7 @@ impl WebOpenPayload {
             url,
             session,
             port,
+            auth,
             credential,
         }
     }
@@ -127,6 +159,7 @@ pub struct WebStatusPayload {
     pub version: String,
     pub online: bool,
     pub pid: Option<u32>,
+    pub interface: String,
     pub port: u16,
 }
 
@@ -135,6 +168,7 @@ pub enum WebWarning {
     BrowserClientSkipped(String),
     BrowserFontSkipped(String),
     BrowserThemeSkipped(String),
+    HeaderAuthUnprotected(String),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -146,6 +180,7 @@ pub struct WebAccessOutcome {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WebDaemonOutcome {
     pub pid: u32,
+    pub interface: String,
     pub port: u16,
     pub warnings: Vec<WebWarning>,
 }
@@ -185,7 +220,8 @@ pub fn open_session(
             session,
             base_url,
             daemon.port,
-            Some(daemon.credential),
+            daemon.auth,
+            daemon.credential,
         ),
         warnings: daemon.warnings,
     })
@@ -198,6 +234,7 @@ pub fn inspect_session(session: &str, config: &MachineConfig) -> Result<WebOpenP
         session,
         base_url,
         daemon.port,
+        daemon.auth,
         daemon.credential,
     ))
 }
@@ -206,6 +243,7 @@ pub fn ensure_daemon(config: &MachineConfig) -> Result<WebDaemonOutcome> {
     let daemon = ttyd::ensure_daemon(config)?;
     Ok(WebDaemonOutcome {
         pid: daemon.pid,
+        interface: daemon.interface,
         port: daemon.port,
         warnings: daemon.warnings,
     })
@@ -227,6 +265,14 @@ pub fn rotate_credential(config: &MachineConfig, read_only: bool) -> Result<Cred
     })
 }
 
+pub fn serve_gate(listen: SocketAddr, upstream: SocketAddr, allow: &[String]) -> Result<()> {
+    let allow = allow
+        .iter()
+        .map(|value| gate::Cidr::parse(value))
+        .collect::<Result<Vec<_>>>()?;
+    gate::serve(listen, upstream, allow)
+}
+
 pub fn revoke_credential(name: Option<&str>) -> Result<bool> {
     if let Some(name) = name
         && name != "rimz"
@@ -244,6 +290,10 @@ pub fn status(config: &MachineConfig) -> Result<WebStatusPayload> {
         version: WEB_SCHEMA_VERSION.to_owned(),
         online: daemon.is_some(),
         pid: daemon.as_ref().map(|record| record.pid),
+        interface: daemon.as_ref().map_or_else(
+            || config.web.interface.clone(),
+            |record| record.interface.clone(),
+        ),
         port: daemon.map_or(config.web.port, |record| record.port),
     })
 }
@@ -385,6 +435,7 @@ mod tests {
             "rimz-test-a1b2c3",
             "http://127.0.0.1:8200/",
             8200,
+            WebAuth::Basic,
             Some(WebCredential {
                 username: "rimz".to_owned(),
                 secret: "secret".to_owned(),
@@ -403,5 +454,12 @@ mod tests {
         let parsed: WebOpenPayload = serde_json::from_slice(&json).expect("parse");
         assert_eq!(parsed, payload);
         assert!(parsed.version_ok());
+        assert_eq!(parsed.auth, WebAuth::Basic);
+
+        let basic: WebOpenPayload = serde_json::from_str(
+            r#"{"version":"rimz.web.v2","url":"http://localhost","session":"rimz-test","port":8200}"#,
+        )
+        .expect("old v2 payload");
+        assert_eq!(basic.auth, WebAuth::Basic);
     }
 }

--- a/crates/rimz/src/web/ttyd.rs
+++ b/crates/rimz/src/web/ttyd.rs
@@ -450,11 +450,12 @@ fn start_daemon_with_profile(
         &profile.args,
     )?;
     let pid = spawn_detached(spec)?;
-    if !wait_for_address(ttyd_address, START_TIMEOUT) {
+    let ttyd_probe_address = probe_address(ttyd_address);
+    if !wait_for_address(ttyd_probe_address, START_TIMEOUT) {
         terminate_pids(&[pid]);
-        wait_for_address_close(ttyd_address, Duration::from_secs(1));
+        wait_for_address_close(ttyd_probe_address, Duration::from_secs(1));
         return Err(WebErr::TtydStartTimeout {
-            address: ttyd_address,
+            address: ttyd_probe_address,
         });
     }
     let gate = if gated {
@@ -579,6 +580,7 @@ fn daemon_status_locked() -> Result<Option<DaemonRecord>> {
     if ttyd_live && gate_live && listening {
         return Ok(Some(record));
     }
+    terminate_live_record(&record, ttyd_live, gate_live);
     remove_optional(&path)?;
     Ok(None)
 }
@@ -613,20 +615,27 @@ fn stop_record(record: &DaemonRecord) -> Result<()> {
 }
 
 fn terminate_record(record: &DaemonRecord) {
+    terminate_live_record(record, true, record.gate.is_some());
+}
+
+fn terminate_live_record(record: &DaemonRecord, ttyd_live: bool, gate_live: bool) {
     #[cfg(unix)]
     {
-        let mut pids = record
-            .gate
-            .as_ref()
-            .map(|gate| gate.pid)
-            .into_iter()
-            .collect::<Vec<_>>();
-        pids.push(record.pid);
+        let mut pids = Vec::new();
+        if gate_live && let Some(gate) = &record.gate {
+            pids.push(gate.pid);
+        }
+        if ttyd_live {
+            pids.push(record.pid);
+        }
+        let terminated = !pids.is_empty();
         terminate_pids(&pids);
-        if let Ok(address) = record_public_address(record) {
+        if terminated && let Ok(address) = record_public_address(record) {
             wait_for_address_close(address, Duration::from_secs(1));
         }
     }
+    #[cfg(not(unix))]
+    let _ = (record, ttyd_live, gate_live);
 }
 
 #[cfg(unix)]
@@ -778,14 +787,20 @@ fn socket_address(interface: &str, port: u16) -> Result<SocketAddr> {
 }
 
 fn record_public_address(record: &DaemonRecord) -> Result<SocketAddr> {
-    let mut address = socket_address(&record.interface, record.port)?;
+    Ok(probe_address(socket_address(
+        &record.interface,
+        record.port,
+    )?))
+}
+
+fn probe_address(mut address: SocketAddr) -> SocketAddr {
     if address.ip().is_unspecified() {
         address.set_ip(match address.ip() {
             IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::LOCALHOST),
             IpAddr::V6(_) => IpAddr::V6(Ipv6Addr::LOCALHOST),
         });
     }
-    Ok(address)
+    address
 }
 
 fn default_interface() -> String {
@@ -968,6 +983,18 @@ mod tests {
     fn ephemeral_port_is_bindable() {
         let port = choose_ephemeral_port().expect("ephemeral port");
         TcpListener::bind(("127.0.0.1", port)).expect("port released after selection");
+    }
+
+    #[test]
+    fn unspecified_listener_probes_use_the_matching_loopback_family() {
+        assert_eq!(
+            probe_address("0.0.0.0:8200".parse().expect("IPv4 socket")),
+            "127.0.0.1:8200".parse().expect("IPv4 loopback socket")
+        );
+        assert_eq!(
+            probe_address("[::]:8200".parse().expect("IPv6 socket")),
+            "[::1]:8200".parse().expect("IPv6 loopback socket")
+        );
     }
 
     #[test]

--- a/crates/rimz/src/web/ttyd.rs
+++ b/crates/rimz/src/web/ttyd.rs
@@ -2,7 +2,7 @@
 
 use std::fs;
 use std::io;
-use std::net::{TcpListener, TcpStream};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
@@ -14,7 +14,7 @@ use crate::config::MachineConfig;
 use crate::mux::CommandSpec;
 use crate::store::{atomic, paths};
 
-use super::{CredentialSummary, Result, WebCredential, WebErr, WebWarning};
+use super::{CredentialSummary, Result, WebAuth, WebCredential, WebErr, WebWarning, gate::Cidr};
 
 mod client;
 
@@ -38,17 +38,55 @@ pub(super) struct TtydCredential {
 pub(super) struct DaemonRecord {
     pub(super) pid: u32,
     pub(super) port: u16,
+    #[serde(default = "default_interface")]
+    pub(super) interface: String,
+    #[serde(default)]
+    pub(super) auth: WebAuth,
+    #[serde(default)]
+    pub(super) trusted_proxies: Vec<String>,
+    #[serde(default)]
+    pub(super) gate: Option<GateRecord>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct GateRecord {
+    pub(super) pid: u32,
+    pub(super) upstream_port: u16,
+}
+
+impl DaemonRecord {
+    pub(super) fn basic_loopback(pid: u32, port: u16) -> Self {
+        Self {
+            pid,
+            port,
+            interface: default_interface(),
+            auth: WebAuth::Basic,
+            trusted_proxies: Vec::new(),
+            gate: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct DaemonSpec {
+    port: u16,
+    interface: String,
+    auth: WebAuth,
+    trusted_proxies: Vec<String>,
 }
 
 pub(super) struct RunningDaemon {
     pub(super) pid: u32,
     pub(super) port: u16,
-    pub(super) credential: WebCredential,
+    pub(super) interface: String,
+    pub(super) auth: WebAuth,
+    pub(super) credential: Option<WebCredential>,
     pub(super) warnings: Vec<WebWarning>,
 }
 
 pub(super) struct DaemonInspection {
     pub(super) port: u16,
+    pub(super) auth: WebAuth,
     pub(super) credential: Option<WebCredential>,
 }
 
@@ -100,9 +138,7 @@ pub(super) fn open_daemon(config: &MachineConfig, may_start: bool) -> Result<Run
         let Some(record) = daemon_status_locked()? else {
             return Err(WebErr::TtydOffline);
         };
-        let Some(credential) = read_credential()? else {
-            return Err(WebErr::TtydCredentialMissing);
-        };
+        let credential = credential_for_auth(&record.auth)?;
         Ok(running_daemon(record, credential, Vec::new()))
     }
 }
@@ -110,9 +146,21 @@ pub(super) fn open_daemon(config: &MachineConfig, may_start: bool) -> Result<Run
 pub(super) fn inspect_daemon(config: &MachineConfig) -> Result<DaemonInspection> {
     let _guard = acquire_daemon_lock()?;
     let daemon = daemon_status_locked()?;
-    let port = daemon.map_or(config.web.port, |record| record.port);
-    let credential = read_credential()?.map(|credential| basic_auth(&credential));
-    Ok(DaemonInspection { port, credential })
+    let port = daemon
+        .as_ref()
+        .map_or(config.web.port, |record| record.port);
+    let auth = daemon
+        .as_ref()
+        .map_or_else(|| auth_from_config(config), |record| record.auth.clone());
+    let credential = match auth {
+        WebAuth::Basic => read_credential()?.map(|credential| basic_auth(&credential)),
+        WebAuth::TrustedHeader { .. } => None,
+    };
+    Ok(DaemonInspection {
+        port,
+        auth,
+        credential,
+    })
 }
 
 pub(super) fn credential_summary() -> Result<Option<CredentialSummary>> {
@@ -153,41 +201,117 @@ fn clear_credential() -> Result<bool> {
 }
 
 pub(super) fn ensure_daemon(config: &MachineConfig) -> Result<RunningDaemon> {
+    let desired = desired_spec(config)?;
+    let warnings = auth_warnings(&desired);
     let _guard = acquire_daemon_lock()?;
     reap_legacy_instances();
     let daemon = daemon_status_locked()?;
     if let Some(record) = &daemon
-        && record.port == config.web.port
-        && let Some(credential) = read_credential()?
+        && record_matches(record, &desired)
     {
-        return Ok(running_daemon(record.clone(), credential, Vec::new()));
+        let credential = credential_for_auth(&record.auth)?;
+        return Ok(running_daemon(record.clone(), credential, warnings));
     }
     let program = program()?;
-    if daemon
-        .as_ref()
-        .is_none_or(|record| record.port != config.web.port)
-    {
-        ensure_port_available(config.web.port)?;
+    let public_address = socket_address(&desired.interface, desired.port)?;
+    if daemon.as_ref().is_none_or(|record| {
+        socket_address(&record.interface, record.port).ok() != Some(public_address)
+    }) {
+        ensure_port_available(public_address)?;
     }
     if let Some(record) = daemon {
         stop_record(&record)?;
     }
-    let credential = ensure_credential()?;
+    ensure_port_available(public_address)?;
+    let credential = match &desired.auth {
+        WebAuth::Basic => Some(ensure_credential()?),
+        WebAuth::TrustedHeader { .. } => None,
+    };
     let profile = client::profile(config, &program);
-    let record = start_daemon_with_profile(&program, config.web.port, &credential, &profile)?;
-    Ok(running_daemon(record, credential, profile.warnings))
+    let record = start_daemon_with_profile(&program, &desired, credential.as_ref(), &profile)?;
+    let mut warnings = warnings;
+    warnings.extend(profile.warnings);
+    Ok(running_daemon(record, credential, warnings))
 }
 
 fn running_daemon(
     record: DaemonRecord,
-    credential: TtydCredential,
+    credential: Option<TtydCredential>,
     warnings: Vec<WebWarning>,
 ) -> RunningDaemon {
     RunningDaemon {
         pid: record.pid,
         port: record.port,
-        credential: basic_auth(&credential),
+        interface: record.interface,
+        auth: record.auth,
+        credential: credential.as_ref().map(basic_auth),
         warnings,
+    }
+}
+
+fn credential_for_auth(auth: &WebAuth) -> Result<Option<TtydCredential>> {
+    match auth {
+        WebAuth::Basic => read_credential()?
+            .map(Some)
+            .ok_or(WebErr::TtydCredentialMissing),
+        WebAuth::TrustedHeader { .. } => Ok(None),
+    }
+}
+
+fn auth_from_config(config: &MachineConfig) -> WebAuth {
+    config
+        .web
+        .auth_header
+        .as_deref()
+        .map(str::trim)
+        .filter(|header| !header.is_empty())
+        .map_or(WebAuth::Basic, |header| WebAuth::TrustedHeader {
+            header: header.to_owned(),
+        })
+}
+
+fn desired_spec(config: &MachineConfig) -> Result<DaemonSpec> {
+    let interface = config
+        .web
+        .interface
+        .parse::<IpAddr>()
+        .map_err(|_| WebErr::InvalidInterface {
+            value: config.web.interface.clone(),
+        })?
+        .to_string();
+    for value in &config.web.trusted_proxies {
+        Cidr::parse(value)?;
+    }
+    Ok(DaemonSpec {
+        port: config.web.port,
+        interface,
+        auth: auth_from_config(config),
+        trusted_proxies: config.web.trusted_proxies.clone(),
+    })
+}
+
+fn record_matches(record: &DaemonRecord, desired: &DaemonSpec) -> bool {
+    record.port == desired.port
+        && record.interface == desired.interface
+        && record.auth == desired.auth
+        && record.trusted_proxies == desired.trusted_proxies
+        && record.gate.is_some() == !desired.trusted_proxies.is_empty()
+}
+
+fn auth_warnings(desired: &DaemonSpec) -> Vec<WebWarning> {
+    let Ok(interface) = desired.interface.parse::<IpAddr>() else {
+        return Vec::new();
+    };
+    if matches!(desired.auth, WebAuth::TrustedHeader { .. })
+        && !interface.is_loopback()
+        && desired.trusted_proxies.is_empty()
+    {
+        vec![WebWarning::HeaderAuthUnprotected(format!(
+            "trusted-header auth is exposed on {interface}:{}; set `[web] trusted_proxies` or firewall the port so only the authenticating proxy can reach it",
+            desired.port
+        ))]
+    } else {
+        Vec::new()
     }
 }
 
@@ -259,7 +383,10 @@ fn terminate_legacy_instance(instance: &LegacyTtydInstance) {
             .and_then(|pid| kill(pid, Signal::SIGTERM).map_err(|err| err.to_string()));
         match result {
             Ok(()) => {
-                wait_for_port_close(instance.port, Duration::from_secs(1));
+                wait_for_address_close(
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), instance.port),
+                    Duration::from_secs(1),
+                );
                 tracing::debug!(
                     session = %instance.session,
                     pid = instance.pid,
@@ -290,27 +417,110 @@ fn remove_legacy_instance_dir(dir: &Path) {
 
 fn start_daemon_with_profile(
     program: &Path,
-    port: u16,
-    credential: &TtydCredential,
+    desired: &DaemonSpec,
+    credential: Option<&TtydCredential>,
     profile: &ClientProfile,
 ) -> Result<DaemonRecord> {
-    let spec = spawn_spec(program, port, &credential.secret, &profile.args)?;
+    let gated = !desired.trusted_proxies.is_empty();
+    let ttyd_port = if gated {
+        choose_ephemeral_port().map_err(|source| WebErr::GateIo {
+            action: "choosing the ttyd upstream port",
+            source,
+        })?
+    } else {
+        desired.port
+    };
+    let ttyd_interface = if gated {
+        IpAddr::V4(Ipv4Addr::LOCALHOST)
+    } else {
+        desired
+            .interface
+            .parse()
+            .map_err(|_| WebErr::InvalidInterface {
+                value: desired.interface.clone(),
+            })?
+    };
+    let ttyd_address = SocketAddr::new(ttyd_interface, ttyd_port);
+    let spec = spawn_spec(
+        program,
+        ttyd_interface,
+        ttyd_port,
+        &desired.auth,
+        credential,
+        &profile.args,
+    )?;
     let pid = spawn_detached(spec)?;
-    let record = DaemonRecord { pid, port };
-    if !wait_for_port(port, START_TIMEOUT) {
-        let _ = stop_record(&record);
-        return Err(WebErr::TtydStartTimeout { port });
+    if !wait_for_address(ttyd_address, START_TIMEOUT) {
+        terminate_pids(&[pid]);
+        wait_for_address_close(ttyd_address, Duration::from_secs(1));
+        return Err(WebErr::TtydStartTimeout {
+            address: ttyd_address,
+        });
     }
-    write_daemon(&record)?;
+    let gate = if gated {
+        let public_address = socket_address(&desired.interface, desired.port)?;
+        let gate_pid = match spawn_gate(public_address, ttyd_address, &desired.trusted_proxies) {
+            Ok(pid) => pid,
+            Err(err) => {
+                terminate_pids(&[pid]);
+                return Err(err);
+            }
+        };
+        Some(GateRecord {
+            pid: gate_pid,
+            upstream_port: ttyd_port,
+        })
+    } else {
+        None
+    };
+    let record = DaemonRecord {
+        pid,
+        port: desired.port,
+        interface: desired.interface.clone(),
+        auth: desired.auth.clone(),
+        trusted_proxies: desired.trusted_proxies.clone(),
+        gate,
+    };
+    let public_address = record_public_address(&record)?;
+    if !wait_for_address(public_address, START_TIMEOUT) {
+        let _ = stop_record(&record);
+        return Err(WebErr::TtydStartTimeout {
+            address: public_address,
+        });
+    }
+    if let Err(err) = write_daemon(&record) {
+        let _ = stop_record(&record);
+        return Err(err);
+    }
     Ok(record)
 }
 
+fn spawn_gate(listen: SocketAddr, upstream: SocketAddr, allow: &[String]) -> Result<u32> {
+    let exe = std::env::current_exe().map_err(|source| WebErr::Io {
+        path: PathBuf::from("/proc/self/exe"),
+        source,
+    })?;
+    let mut spec = CommandSpec::new(exe.display().to_string())
+        .args(["web", "gate", "--listen"])
+        .arg(listen.to_string())
+        .arg("--upstream")
+        .arg(upstream.to_string());
+    for cidr in allow {
+        spec = spec.arg("--allow").arg(cidr.clone());
+    }
+    spawn_detached(spec)
+}
+
 pub(super) fn rotate_credential(config: &MachineConfig) -> Result<CredentialRotation> {
+    if !matches!(auth_from_config(config), WebAuth::Basic) {
+        return Err(WebErr::TrustedHeaderCredential);
+    }
     let _guard = acquire_daemon_lock()?;
     rotate_credential_locked(config)
 }
 
 fn rotate_credential_locked(config: &MachineConfig) -> Result<CredentialRotation> {
+    let desired = desired_spec(config)?;
     let Some(daemon) = daemon_status_locked()? else {
         return Ok(CredentialRotation {
             credential: basic_auth(&mint_credential()?),
@@ -318,18 +528,22 @@ fn rotate_credential_locked(config: &MachineConfig) -> Result<CredentialRotation
             warnings: Vec::new(),
         });
     };
-    if daemon.port != config.web.port {
-        ensure_port_available(config.web.port)?;
+    let public_address = socket_address(&desired.interface, desired.port)?;
+    if socket_address(&daemon.interface, daemon.port).ok() != Some(public_address) {
+        ensure_port_available(public_address)?;
     }
     let program = program()?;
     let profile = client::profile(config, &program);
     let credential = mint_credential()?;
     stop_record(&daemon)?;
-    start_daemon_with_profile(&program, config.web.port, &credential, &profile)?;
+    ensure_port_available(public_address)?;
+    start_daemon_with_profile(&program, &desired, Some(&credential), &profile)?;
+    let mut warnings = auth_warnings(&desired);
+    warnings.extend(profile.warnings);
     Ok(CredentialRotation {
         credential: basic_auth(&credential),
         restarted: true,
-        warnings: profile.warnings,
+        warnings,
     })
 }
 
@@ -351,15 +565,32 @@ fn daemon_status_locked() -> Result<Option<DaemonRecord>> {
         return Ok(None);
     };
     let processes = crate::proc::list_processes();
-    if processes
+    let ttyd_live = processes
         .iter()
-        .any(|process| process.pid == record.pid && is_ttyd_process(process))
-        && TcpStream::connect(("127.0.0.1", record.port)).is_ok()
-    {
+        .any(|process| process.pid == record.pid && is_ttyd_process(process));
+    let gate_live = record.gate.as_ref().is_none_or(|gate| {
+        processes
+            .iter()
+            .any(|process| process.pid == gate.pid && is_gate_process(process))
+    });
+    let listening = record_public_address(&record)
+        .ok()
+        .is_some_and(|address| TcpStream::connect(address).is_ok());
+    if ttyd_live && gate_live && listening {
         return Ok(Some(record));
     }
     remove_optional(&path)?;
     Ok(None)
+}
+
+fn is_gate_process(process: &crate::proc::ProcInfo) -> bool {
+    crate::proc::command::program_label(&process.cmdline) == "rimz"
+        && process
+            .cmdline
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .windows(2)
+            .any(|args| args == ["web", "gate"])
 }
 
 pub(super) fn stop_daemon() -> Result<bool> {
@@ -384,64 +615,99 @@ fn stop_record(record: &DaemonRecord) -> Result<()> {
 fn terminate_record(record: &DaemonRecord) {
     #[cfg(unix)]
     {
-        use nix::sys::signal::{Signal, kill};
-        use nix::unistd::Pid;
-
-        let mut survivors = Vec::new();
-        if let Ok(raw) = i32::try_from(record.pid) {
-            let _ = kill(Pid::from_raw(raw), Signal::SIGTERM);
-            survivors.push(record.pid);
+        let mut pids = record
+            .gate
+            .as_ref()
+            .map(|gate| gate.pid)
+            .into_iter()
+            .collect::<Vec<_>>();
+        pids.push(record.pid);
+        terminate_pids(&pids);
+        if let Ok(address) = record_public_address(record) {
+            wait_for_address_close(address, Duration::from_secs(1));
         }
-        let deadline = Instant::now() + Duration::from_secs(1);
-        while !survivors.is_empty() && Instant::now() < deadline {
-            let processes = crate::proc::list_processes();
-            survivors.retain(|pid| processes.iter().any(|process| process.pid == *pid));
-            if !survivors.is_empty() {
-                std::thread::sleep(Duration::from_millis(25));
-            }
-        }
-        for pid in survivors {
-            if let Ok(raw) = i32::try_from(pid) {
-                let _ = kill(Pid::from_raw(raw), Signal::SIGKILL);
-            }
-        }
-        wait_for_port_close(record.port, Duration::from_secs(1));
     }
 }
 
+#[cfg(unix)]
+fn terminate_pids(pids: &[u32]) {
+    use nix::sys::signal::{Signal, kill};
+    use nix::unistd::Pid;
+
+    let mut survivors = Vec::new();
+    for pid in pids {
+        if let Ok(raw) = i32::try_from(*pid) {
+            let _ = kill(Pid::from_raw(raw), Signal::SIGTERM);
+            survivors.push(*pid);
+        }
+    }
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while !survivors.is_empty() && Instant::now() < deadline {
+        let processes = crate::proc::list_processes();
+        survivors.retain(|pid| processes.iter().any(|process| process.pid == *pid));
+        if !survivors.is_empty() {
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    }
+    for pid in survivors {
+        if let Ok(raw) = i32::try_from(pid) {
+            let _ = kill(Pid::from_raw(raw), Signal::SIGKILL);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn terminate_pids(_pids: &[u32]) {}
+
 fn spawn_spec(
     program: &Path,
+    interface: IpAddr,
     port: u16,
-    secret: &str,
+    auth: &WebAuth,
+    credential: Option<&TtydCredential>,
     extra_args: &[String],
 ) -> Result<CommandSpec> {
-    Ok(spawn_spec_for(
+    spawn_spec_for(
         program,
         &std::env::current_exe().map_err(|source| WebErr::Io {
             path: PathBuf::from("/proc/self/exe"),
             source,
         })?,
+        interface,
         port,
-        secret,
+        auth,
+        credential,
         extra_args,
-    ))
+    )
 }
 
 fn spawn_spec_for(
     program: &Path,
     rimz_exe: &Path,
+    interface: IpAddr,
     port: u16,
-    secret: &str,
+    auth: &WebAuth,
+    credential: Option<&TtydCredential>,
     extra_args: &[String],
-) -> CommandSpec {
-    CommandSpec::new(program.display().to_string())
-        .args(["-W", "-O", "-a", "-c"])
-        .arg(format!("rimz:{secret}"))
-        .args(["-i", "127.0.0.1", "-p"])
+) -> Result<CommandSpec> {
+    let mut spec = CommandSpec::new(program.display().to_string()).args(["-W", "-O", "-a"]);
+    match auth {
+        WebAuth::Basic => {
+            let secret = credential
+                .map(|credential| credential.secret.as_str())
+                .ok_or(WebErr::TtydCredentialMissing)?;
+            spec = spec.arg("-c").arg(format!("rimz:{secret}"));
+        }
+        WebAuth::TrustedHeader { header } => {
+            spec = spec.arg("-H").arg(header.clone());
+        }
+    }
+    Ok(spec
+        .args(["-i", &interface.to_string(), "-p"])
         .arg(port.to_string())
         .args(extra_args.iter().cloned())
         .arg(rimz_exe.display().to_string())
-        .args(["web", "exec"])
+        .args(["web", "exec"]))
 }
 
 fn spawn_detached(spec: CommandSpec) -> Result<u32> {
@@ -463,10 +729,12 @@ fn spawn_detached(spec: CommandSpec) -> Result<u32> {
     })
 }
 
-fn ensure_port_available(port: u16) -> Result<()> {
-    TcpListener::bind(("127.0.0.1", port))
+fn ensure_port_available(address: SocketAddr) -> Result<()> {
+    TcpListener::bind(address)
         .map(|_| ())
-        .map_err(|_| WebErr::ConfiguredPortInUse { port })
+        .map_err(|_| WebErr::ConfiguredPortInUse {
+            port: address.port(),
+        })
 }
 
 fn choose_ephemeral_port() -> io::Result<u16> {
@@ -475,9 +743,16 @@ fn choose_ephemeral_port() -> io::Result<u16> {
 }
 
 fn wait_for_port(port: u16, timeout: Duration) -> bool {
+    wait_for_address(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
+        timeout,
+    )
+}
+
+fn wait_for_address(address: SocketAddr, timeout: Duration) -> bool {
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
-        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+        if TcpStream::connect(address).is_ok() {
             return true;
         }
         std::thread::sleep(Duration::from_millis(50));
@@ -486,11 +761,35 @@ fn wait_for_port(port: u16, timeout: Duration) -> bool {
 }
 
 #[cfg(unix)]
-fn wait_for_port_close(port: u16, timeout: Duration) {
+fn wait_for_address_close(address: SocketAddr, timeout: Duration) {
     let deadline = Instant::now() + timeout;
-    while Instant::now() < deadline && TcpStream::connect(("127.0.0.1", port)).is_ok() {
+    while Instant::now() < deadline && TcpStream::connect(address).is_ok() {
         std::thread::sleep(Duration::from_millis(25));
     }
+}
+
+fn socket_address(interface: &str, port: u16) -> Result<SocketAddr> {
+    let interface = interface
+        .parse::<IpAddr>()
+        .map_err(|_| WebErr::InvalidInterface {
+            value: interface.to_owned(),
+        })?;
+    Ok(SocketAddr::new(interface, port))
+}
+
+fn record_public_address(record: &DaemonRecord) -> Result<SocketAddr> {
+    let mut address = socket_address(&record.interface, record.port)?;
+    if address.ip().is_unspecified() {
+        address.set_ip(match address.ip() {
+            IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V6(_) => IpAddr::V6(Ipv6Addr::LOCALHOST),
+        });
+    }
+    Ok(address)
+}
+
+fn default_interface() -> String {
+    "127.0.0.1".to_owned()
 }
 
 fn credential_path() -> PathBuf {
@@ -569,15 +868,26 @@ mod tests {
 
     use super::*;
 
+    fn credential() -> TtydCredential {
+        TtydCredential {
+            name: "rimz".to_owned(),
+            created_at: Timestamp::from_second(1_700_000_000).expect("timestamp"),
+            secret: "secret".to_owned(),
+        }
+    }
+
     #[test]
     fn argv_uses_loopback_auth_url_args_and_rimz_shim() {
         let spec = spawn_spec_for(
             Path::new("/tmp/ttyd"),
             Path::new("/opt/rimz/bin/rimz"),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
             8201,
-            "secret",
+            &WebAuth::Basic,
+            Some(&credential()),
             &["-t".to_owned(), "macOptionIsMeta=true".to_owned()],
-        );
+        )
+        .expect("spawn spec");
         assert_eq!(
             spec.args,
             [
@@ -600,6 +910,30 @@ mod tests {
     }
 
     #[test]
+    fn argv_uses_trusted_header_without_basic_auth() {
+        let spec = spawn_spec_for(
+            Path::new("/tmp/ttyd"),
+            Path::new("/opt/rimz/bin/rimz"),
+            "127.0.0.1".parse().expect("IP"),
+            8399,
+            &WebAuth::TrustedHeader {
+                header: "X-Authentik-Username".to_owned(),
+            },
+            None,
+            &[],
+        )
+        .expect("spawn spec");
+
+        assert!(
+            spec.args
+                .windows(2)
+                .any(|args| args == ["-H", "X-Authentik-Username"])
+        );
+        assert!(!spec.args.iter().any(|arg| arg == "-c"));
+        assert!(spec.args.windows(2).any(|args| args == ["-i", "127.0.0.1"]));
+    }
+
+    #[test]
     fn styled_argv_keeps_all_client_options_before_rimz_shim() {
         let extra = vec![
             "-t".to_owned(),
@@ -614,10 +948,13 @@ mod tests {
         let spec = spawn_spec_for(
             Path::new("/tmp/ttyd"),
             Path::new("/opt/rimz/bin/rimz"),
+            "127.0.0.1".parse().expect("IP"),
             8202,
-            "secret",
+            &WebAuth::Basic,
+            Some(&credential()),
             &extra,
-        );
+        )
+        .expect("spawn spec");
 
         let shim = spec
             .args
@@ -637,11 +974,7 @@ mod tests {
     fn credential_roundtrip_is_private() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("credential.json");
-        let credential = TtydCredential {
-            name: "rimz".to_owned(),
-            created_at: Timestamp::from_second(1_700_000_000).expect("timestamp"),
-            secret: "secret".to_owned(),
-        };
+        let credential = credential();
         write_credential_at(&path, &credential).expect("write");
         assert_eq!(read_json_optional(&path).expect("read"), Some(credential));
         assert_eq!(
@@ -657,9 +990,58 @@ mod tests {
         let daemon = DaemonRecord {
             pid: u32::MAX,
             port: 8200,
+            interface: "0.0.0.0".to_owned(),
+            auth: WebAuth::TrustedHeader {
+                header: "X-Forwarded-User".to_owned(),
+            },
+            trusted_proxies: vec!["10.0.0.0/8".to_owned()],
+            gate: Some(GateRecord {
+                pid: u32::MAX - 1,
+                upstream_port: 41820,
+            }),
         };
         write_daemon_at(&path, &daemon).expect("write daemon state");
         assert_eq!(read_json_optional(&path).expect("read state"), Some(daemon));
+    }
+
+    #[test]
+    fn old_daemon_state_defaults_to_basic_loopback_without_a_gate() {
+        let daemon: DaemonRecord =
+            serde_json::from_str(r#"{"pid":42,"port":8200}"#).expect("old record");
+        assert_eq!(daemon, DaemonRecord::basic_loopback(42, 8200));
+    }
+
+    #[test]
+    fn desired_spec_validates_listener_and_proxy_cidrs() {
+        let mut config = MachineConfig::default();
+        config.web.interface = "localhost".to_owned();
+        assert!(matches!(
+            desired_spec(&config),
+            Err(WebErr::InvalidInterface { value }) if value == "localhost"
+        ));
+
+        config.web.interface = "127.0.0.1".to_owned();
+        config.web.trusted_proxies = vec!["10.0.0.0/33".to_owned()];
+        assert!(matches!(
+            desired_spec(&config),
+            Err(WebErr::InvalidTrustedProxy { value, .. }) if value == "10.0.0.0/33"
+        ));
+    }
+
+    #[test]
+    fn exposed_trusted_header_auth_warns_without_a_gate() {
+        let spec = DaemonSpec {
+            port: 8200,
+            interface: "0.0.0.0".to_owned(),
+            auth: WebAuth::TrustedHeader {
+                header: "X-Forwarded-User".to_owned(),
+            },
+            trusted_proxies: Vec::new(),
+        };
+        assert!(matches!(
+            auth_warnings(&spec).as_slice(),
+            [WebWarning::HeaderAuthUnprotected(message)] if message.contains("trusted_proxies")
+        ));
     }
 
     #[test]
@@ -673,5 +1055,9 @@ mod tests {
         assert!(is_ttyd_process(&process("/usr/bin/ttyd -p 8200 sh")));
         assert!(!is_ttyd_process(&process("/usr/bin/ttyd-trace -p 8200")));
         assert!(!is_ttyd_process(&process("sh -c ttyd -p 8200")));
+        assert!(is_gate_process(&process(
+            "/opt/rimz/bin/rimz web gate --listen 0.0.0.0:8200"
+        )));
+        assert!(!is_gate_process(&process("/opt/rimz/bin/rimz web start")));
     }
 }

--- a/crates/rimz/src/web/ttyd/client.rs
+++ b/crates/rimz/src/web/ttyd/client.rs
@@ -136,7 +136,7 @@ fn fetch_stock_index(program: &Path) -> Result<String, String> {
         .arg(port.to_string())
         .arg("sh");
     let pid = spawn_detached(spec).map_err(|err| err.to_string())?;
-    let record = DaemonRecord { pid, port };
+    let record = DaemonRecord::basic_loopback(pid, port);
     if !wait_for_port(port, START_TIMEOUT) {
         terminate_record(&record);
         return Err(format!(

--- a/crates/rimz/tests/integration/web.rs
+++ b/crates/rimz/tests/integration/web.rs
@@ -1,3 +1,4 @@
+use std::io::{Read as _, Write as _};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
@@ -472,6 +473,178 @@ fn two_rooms_reuse_one_shared_daemon_and_rotate_restarts_it() {
         String::from_utf8_lossy(&stop.stdout),
         "revoked ttyd credential and stopped 1 daemon(s)\n"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn trusted_header_open_omits_basic_auth_and_config_drift_restarts() {
+    let _guard = daemon_test_guard();
+    let fixture = WebFixture::new("ttyd-trusted-header.log");
+    write_machine_config(
+        &fixture.env,
+        &format!(
+            "[web]\nport = {}\nauth_header = \"X-Authentik-Username\"\nstyle_client = false\n",
+            fixture.web_port
+        ),
+    );
+
+    let human = fixture
+        .command()
+        .args(["--mux", "tmux", "web", "open", "--session"])
+        .arg(&fixture.workspace.session_name)
+        .args(["--print"])
+        .bounded_output()
+        .expect("open trusted-header daemon");
+    assert_success(&human, "trusted-header web open");
+    let stderr = String::from_utf8_lossy(&human.stderr);
+    assert!(
+        stderr.contains(
+            "authentication is delegated to the reverse proxy (trusted header `X-Authentik-Username`)"
+        ),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("password"), "{stderr}");
+
+    let json = fixture
+        .command()
+        .args(["--mux", "tmux", "web", "open", "--session"])
+        .arg(&fixture.workspace.session_name)
+        .args(["--print", "--json"])
+        .bounded_output()
+        .expect("inspect trusted-header daemon");
+    let payload = success_json(&json, "trusted-header JSON open");
+    assert_eq!(payload["auth"]["mode"], "trusted_header");
+    assert_eq!(payload["auth"]["header"], "X-Authentik-Username");
+    assert!(payload.get("credential").is_none());
+    assert!(
+        !fixture
+            .env
+            .state_root()
+            .join("rimz/web-ttyd-credential.json")
+            .exists(),
+        "trusted-header mode minted a Basic-Auth credential"
+    );
+
+    let log = std::fs::read_to_string(&fixture.ttyd_log).expect("read trusted-header log");
+    let daemon_argv = log
+        .lines()
+        .find(|line| line.contains("\tweb\texec"))
+        .expect("trusted-header daemon argv");
+    assert!(
+        daemon_argv.contains("\t-H\tX-Authentik-Username\t"),
+        "{daemon_argv}"
+    );
+    assert!(!daemon_argv.contains("\t-c\t"), "{daemon_argv}");
+
+    let token = fixture
+        .command()
+        .args(["web", "token", "create"])
+        .bounded_output()
+        .expect("refuse trusted-header credential rotation");
+    assert!(!token.status.success());
+    let stderr = String::from_utf8_lossy(&token.stderr);
+    assert!(
+        stderr.contains("credential rotation is disabled"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("unset it to return to Basic Auth"),
+        "{stderr}"
+    );
+
+    let daemon_path = fixture.env.state_root().join("rimz/web-ttyd.json");
+    let before: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&daemon_path).expect("trusted-header daemon record"))
+            .expect("trusted-header daemon JSON");
+    write_machine_config(
+        &fixture.env,
+        &format!("[web]\nport = {}\nstyle_client = false\n", fixture.web_port),
+    );
+    let basic = fixture
+        .command()
+        .args(["--mux", "tmux", "web", "open", "--session"])
+        .arg(&fixture.workspace.session_name)
+        .args(["--print", "--json"])
+        .bounded_output()
+        .expect("restart daemon in Basic-Auth mode");
+    let payload = success_json(&basic, "Basic-Auth restart");
+    assert_eq!(payload["auth"]["mode"], "basic");
+    assert_eq!(payload["credential"]["username"], "rimz");
+    let after: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&daemon_path).expect("Basic daemon record"))
+            .expect("Basic daemon JSON");
+    assert_ne!(before["pid"], after["pid"], "auth drift reused the daemon");
+
+    let stop = fixture
+        .command()
+        .args(["web", "stop"])
+        .bounded_output()
+        .expect("stop restarted daemon");
+    assert_success(&stop, "stop restarted daemon");
+}
+
+#[cfg(unix)]
+#[test]
+fn trusted_proxy_gate_forwards_loopback_and_stops_both_processes() {
+    let _guard = daemon_test_guard();
+    let fixture = WebFixture::new("ttyd-trusted-proxy.log");
+    write_machine_config(
+        &fixture.env,
+        &format!(
+            "[web]\nport = {}\ntrusted_proxies = [\"192.0.2.0/24\"]\nstyle_client = false\n",
+            fixture.web_port
+        ),
+    );
+
+    let start = fixture
+        .command()
+        .args(["web", "start"])
+        .bounded_output()
+        .expect("start trusted-proxy gate");
+    assert_success(&start, "trusted-proxy gate start");
+
+    let daemon_path = fixture.env.state_root().join("rimz/web-ttyd.json");
+    let record: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&daemon_path).expect("gated daemon record"))
+            .expect("gated daemon JSON");
+    let ttyd_pid = record["pid"].as_u64().expect("ttyd pid") as u32;
+    let gate_pid = record["gate"]["pid"].as_u64().expect("gate pid") as u32;
+    let upstream_port = record["gate"]["upstream_port"]
+        .as_u64()
+        .expect("upstream port") as u16;
+    assert_ne!(upstream_port, fixture.web_port);
+
+    let log = std::fs::read_to_string(&fixture.ttyd_log).expect("read gated ttyd log");
+    let daemon_argv = log
+        .lines()
+        .find(|line| line.contains("\tweb\texec"))
+        .expect("gated daemon argv");
+    assert!(daemon_argv.contains("\t-i\t127.0.0.1\t"), "{daemon_argv}");
+    assert!(
+        daemon_argv.contains(&format!("\t-p\t{upstream_port}\t")),
+        "{daemon_argv}"
+    );
+
+    let mut stream = std::net::TcpStream::connect(("127.0.0.1", fixture.web_port))
+        .expect("connect through gate");
+    stream
+        .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .expect("write through gate");
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .expect("read through gate");
+    assert!(response.starts_with("HTTP/1.1 200 OK"), "{response:?}");
+
+    let stop = fixture
+        .command()
+        .args(["web", "stop"])
+        .bounded_output()
+        .expect("stop gated daemon");
+    assert_success(&stop, "stop gated daemon");
+    let live = rimz::proc::list_processes();
+    assert!(!live.iter().any(|process| process.pid == ttyd_pid));
+    assert!(!live.iter().any(|process| process.pid == gate_pid));
 }
 
 #[cfg(unix)]

--- a/crates/rimz/tests/integration/web.rs
+++ b/crates/rimz/tests/integration/web.rs
@@ -649,6 +649,83 @@ fn trusted_proxy_gate_forwards_loopback_and_stops_both_processes() {
 
 #[cfg(unix)]
 #[test]
+fn stale_gated_daemon_terminates_its_surviving_gate_and_can_restart() {
+    use nix::sys::signal::{Signal, kill};
+    use nix::unistd::Pid;
+
+    let _guard = daemon_test_guard();
+    let fixture = WebFixture::new("ttyd-stale-gate.log");
+    write_machine_config(
+        &fixture.env,
+        &format!(
+            "[web]\nport = {}\ntrusted_proxies = [\"192.0.2.0/24\"]\nstyle_client = false\n",
+            fixture.web_port
+        ),
+    );
+    let start = fixture
+        .command()
+        .args(["web", "start"])
+        .bounded_output()
+        .expect("start gated daemon");
+    assert_success(&start, "initial gated daemon start");
+
+    let daemon_path = fixture.env.state_root().join("rimz/web-ttyd.json");
+    let record: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&daemon_path).expect("gated daemon record"))
+            .expect("gated daemon JSON");
+    let ttyd_pid = record["pid"].as_u64().expect("ttyd pid") as u32;
+    let gate_pid = record["gate"]["pid"].as_u64().expect("gate pid") as u32;
+    kill(
+        Pid::from_raw(i32::try_from(ttyd_pid).expect("test pid fits i32")),
+        Signal::SIGKILL,
+    )
+    .expect("kill ttyd fixture");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    while rimz::proc::list_processes()
+        .iter()
+        .any(|process| process.pid == ttyd_pid)
+        && std::time::Instant::now() < deadline
+    {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(
+        !rimz::proc::list_processes()
+            .iter()
+            .any(|process| process.pid == ttyd_pid),
+        "killed ttyd fixture remained live"
+    );
+
+    let status = fixture
+        .command()
+        .args(["web", "status", "--json"])
+        .bounded_output()
+        .expect("reconcile stale gated daemon");
+    let status = success_json(&status, "stale gated daemon status");
+    assert_eq!(status["online"], false);
+    assert!(!daemon_path.exists(), "stale daemon record survived");
+    assert!(
+        !rimz::proc::list_processes()
+            .iter()
+            .any(|process| process.pid == gate_pid),
+        "gate survived stale-record reconciliation"
+    );
+
+    let restart = fixture
+        .command()
+        .args(["web", "start"])
+        .bounded_output()
+        .expect("restart after partial daemon death");
+    assert_success(&restart, "restart after partial daemon death");
+    let stop = fixture
+        .command()
+        .args(["web", "stop"])
+        .bounded_output()
+        .expect("stop recovered gated daemon");
+    assert_success(&stop, "stop recovered gated daemon");
+}
+
+#[cfg(unix)]
+#[test]
 fn concurrent_start_calls_create_one_shared_daemon() {
     let _guard = daemon_test_guard();
     let fixture = WebFixture::new("ttyd-concurrent.log");

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -202,15 +202,18 @@ Remote control is the bridge the providers' official mobile apps drive: with a h
 [web]
 enabled = true
 port = 8200
+interface = "127.0.0.1"
 base_url = "https://devbox.example/rimz"
+# auth_header = "X-Authentik-Username"
+# trusted_proxies = ["172.18.0.0/16"]
 font = "JetBrainsMono Nerd Font Mono"
 # font_source = "/path/to/font.woff2"
 style_client = true
 ```
 
-`[web] enabled` defaults to true and gates `rimz web open` plus `rimz remote connect --web`. A normal `rimz start` best-effort starts one loopback ttyd daemon for every Zellij and tmux room on the machine; a missing ttyd or occupied port warns without blocking the room. When disabled, web commands fail before any room change and tell you to change the config on the machine serving the room.
+`[web] enabled` defaults to true and gates `rimz web open` plus `rimz remote connect --web`. A normal `rimz start` best-effort starts one ttyd daemon for every Zellij and tmux room on the machine; a missing ttyd or occupied port warns without blocking the room. When disabled, web commands fail before any room change and tell you to change the config on the machine serving the room.
 
-`port` is the daemon's exact loopback port and defaults to `8200`; choose another fixed port when it is occupied. `base_url` is the URL prefix RimZ prints for `rimz web open` and `rimz web url`, useful when a reverse proxy serves the daemon under a public host or path. `style_client` passes the active theme and `font` family to the browser terminal. The built-in `JetBrainsMono Nerd Font Mono` and `CaskaydiaCove Nerd Font Mono` families download and cache verified regular and bold faces automatically; `font_source` instead names one local font file or HTTPS font URL, while an unrecognized `font` with no source passes through for browser-local resolution. Install ttyd with `brew install ttyd` or `apt install ttyd`. These fields execute nothing, so the section stays outside the trust hash. Command detail is in [web.md](../reference/cli/web.md), and remote browser tunnels in [remote.md](../internals/remote.md#web-tunnels).
+`interface` and `port` select the daemon's exact listener and default to `127.0.0.1:8200`; `interface` accepts an IPv4 or IPv6 address. `base_url` is the URL prefix RimZ prints for `rimz web open` and `rimz web url`, useful when a reverse proxy serves the daemon under a public host or path. A non-empty `auth_header` delegates authentication to a proxy-injected header and disables Basic Auth. A non-empty `trusted_proxies` list accepts bare IPs or IPv4 and IPv6 CIDRs and starts a source-address gate; loopback peers remain allowed. `style_client` passes the active theme and `font` family to the browser terminal. The built-in `JetBrainsMono Nerd Font Mono` and `CaskaydiaCove Nerd Font Mono` families download and cache verified regular and bold faces automatically; `font_source` instead names one local font file or HTTPS font URL, while an unrecognized `font` with no source passes through for browser-local resolution. Install ttyd with `brew install ttyd` or `apt install ttyd`. These fields execute nothing, so the section stays outside the trust hash. Command detail is in [web.md](../reference/cli/web.md), and remote browser tunnels in [remote.md](../internals/remote.md#web-tunnels).
 
 ### Daemon view
 

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -56,6 +56,16 @@ On Zellij, RimZ loads a small presence plugin into each session so the sidebar l
 
 The plugin's code, argv, and configuration are all RimZ-owned, never your `config.kdl`, and it ships no pane content anywhere. The grant lives in Zellij's own permission store, where its plugin manager can revoke it; revoking stops pane discovery until you restore it, and `rimz doctor` names the fix.
 
+### Browser listener
+
+Browser access defaults to a loopback ttyd listener with one machine-wide Basic-Auth credential. That credential reaches every live RimZ room on the machine and grants a shell as the serving user, so handle it like a machine-wide SSH key.
+
+`[web] auth_header` delegates the decision to an authenticating reverse proxy. ttyd treats any non-empty value in that header as authenticated; the proxy strips client-supplied copies, injects its own value after authentication, and remains the only non-loopback source that can reach the listener.
+
+`[web] trusted_proxies` places a TCP source-address gate before ttyd for this boundary. The gate admits matching IPv4 or IPv6 CIDRs and always admits loopback, then forwards raw TCP to a loopback ttyd process. Pair the CIDRs with the host firewall, and account for the source address produced by container or host networking. On a multi-user host, loopback remains inside the trusted boundary, so use host-level user isolation when another local user must not present the configured header.
+
+The [web guide](./web.md#behind-a-reverse-proxy) configures Traefik and Authentik for this path.
+
 ## What leaves your machine
 
 RimZ keeps your work local. Your prompts, transcripts, pane text, file paths, and credentials stay on the box. The network calls RimZ makes reuse logins you already hold and reach only services you already use:

--- a/docs/guide/web.md
+++ b/docs/guide/web.md
@@ -48,6 +48,41 @@ rimz web stop
 rimz web start
 ```
 
+## Behind a reverse proxy
+
+A reverse proxy can terminate HTTPS and let an Authentik forward-auth decision identify the user, but ttyd must trust that decision instead of showing its own Basic-Auth prompt. Set Authentik's Traefik forward-auth middleware to return `X-Authentik-Username` in its auth response headers, attach that middleware to the router serving RimZ, and make the proxy overwrite or remove any client-supplied copy of that header before forwarding.
+
+Point RimZ at the public URL and name the header the proxy injects:
+
+```toml
+[web]
+base_url = "https://shell.example.com/rimz"
+auth_header = "X-Authentik-Username"
+```
+
+When Traefik runs on the same host and reaches the host through a Docker bridge, expose the listener and admit only that bridge CIDR:
+
+```toml
+[web]
+base_url = "https://shell.example.com/rimz"
+auth_header = "X-Authentik-Username"
+interface = "0.0.0.0"
+trusted_proxies = ["172.18.0.0/16"]
+```
+
+RimZ starts ttyd on an ephemeral loopback port, starts a small TCP gate on `0.0.0.0:8200`, and forwards only loopback or configured source CIDRs. Use the proxy host's address or subnet for a proxy on another LAN or VPC host. Keep the host firewall restricted to the same sources; `trusted_proxies` sees the TCP peer address, so configure the CIDR for the address that actually reaches RimZ after container and host networking.
+
+Restart after changing the auth or listener shape:
+
+```sh
+rimz web stop
+rimz web start
+```
+
+ttyd accepts any non-empty value in the configured header. A client that reaches ttyd can forge it and receive a shell, so make the authenticating proxy the only non-loopback source that can reach the port. The gate always admits loopback, and header auth on a multi-user host therefore lets another local user present the header; use host-level user isolation when local users are outside the trust boundary.
+
+`rimz remote connect --web` stops with the public URL in this mode because an SSH tunnel cannot inject the trusted header. Open the `base_url` route through the authenticating proxy instead.
+
 ## Open a remote room
 
 ```sh
@@ -55,7 +90,7 @@ rimz remote connect dev --web
 rimz remote connect dev --web --web-port 8443
 ```
 
-RimZ uses one SSH prep call to birth or resume the remote room, ensure its shared daemon, and return the Basic-Auth credential. It then forwards a local loopback port to the remote configured port and opens `http://127.0.0.1:<local-port>/?arg=<session>`.
+With Basic Auth, RimZ uses one SSH prep call to birth or resume the remote room, ensure its shared daemon, and return the credential. It then forwards a local loopback port to the remote configured port and opens `http://127.0.0.1:<local-port>/?arg=<session>`. Trusted-header rooms use their reverse-proxy URL instead, as described above.
 
 The tunnel stays in the foreground and follows the normal remote recovery policy. Recovery repeats prep, so a stopped daemon comes back and a rotated credential is printed again; the local URL stays stable. Without `--web-port`, the local port derives from the session in 8300–8399 and scans forward when busy.
 
@@ -72,6 +107,8 @@ One credential named `rimz` serves the whole machine. `create` rotates it and re
 
 ttyd read-only mode belongs to the whole process, so `rimz web token create --read-only` is rejected rather than presenting a misleading per-user permission.
 
+Trusted-header mode leaves the credential file idle. `token create` refuses and names the `auth_header` setting to unset; list and revoke remain available, and revoke still stops the daemon and clears an existing credential file.
+
 Treat the password like an SSH private key. It stays out of the URL, logs, events, and workspace records.
 
 ## Configuration
@@ -80,24 +117,27 @@ Treat the password like an SSH private key. It stays out of the URL, logs, event
 [web]
 enabled = true
 port = 8200
+interface = "127.0.0.1"
 # base_url = "https://devbox.example/rimz"
+# auth_header = "X-Authentik-Username"
+# trusted_proxies = ["172.18.0.0/16"]
 font = "JetBrainsMono Nerd Font Mono"
 # font_source = "/path/to/font.woff2"
 style_client = true
 ```
 
-`port` is the exact loopback port for the shared daemon. `base_url` changes the prefix RimZ prints when a reverse proxy fronts ttyd; the `/?arg=<session>` query remains.
+`interface` and `port` select the exact listener. `base_url` changes the prefix RimZ prints when a reverse proxy fronts ttyd; the `/?arg=<session>` query remains. `auth_header` replaces Basic Auth with a proxy-injected identity header, and non-empty `trusted_proxies` restricts source addresses through the TCP gate.
 
 ## Security boundary
 
-RimZ invokes ttyd with write access, origin checks, mandatory Basic Auth, and an explicit loopback bind.
+By default, RimZ invokes ttyd with write access, origin checks, mandatory Basic Auth, and an explicit loopback bind.
 
 The one machine credential authenticates the shared listener, so it grants access to every live RimZ room on that machine rather than only the room named in the first URL. An authenticated client can submit another session argument, and a missing or rejected argument lists the live RimZ rooms. A remote `--web` tunnel forwards this same machine-wide surface through its local port.
 
-The browser session is shell access as the serving user, and terminal output can contain secrets. Treat the credential as machine-wide shell access. Put HTTPS and rate limiting in front before exposing the listener beyond loopback:
+The browser session is shell access as the serving user, and terminal output can contain secrets. Treat either the credential or trusted-header boundary as machine-wide shell access. Put HTTPS and rate limiting in front before exposing the listener beyond loopback:
 
 ```text
-browser -> HTTPS reverse proxy with rate limiting -> 127.0.0.1:8200
+browser -> HTTPS authenticating proxy -> source-address gate -> loopback ttyd
 ```
 
 ## See also

--- a/docs/internals/web.md
+++ b/docs/internals/web.md
@@ -2,7 +2,7 @@
 
 > See [DESIGN.md](../../DESIGN.md) and [multiplexers.md](./multiplexers.md) for the commitments this doc extends.
 
-RimZ serves every local Zellij and tmux room through one authenticated ttyd daemon bound to the machine loopback interface.
+RimZ serves every local Zellij and tmux room through one authenticated ttyd daemon, with a loopback listener by default and an optional source-address gate for reverse proxies.
 
 ## Contract
 
@@ -10,37 +10,45 @@ The daemon owns browser transport and rendering; RimZ owns room birth, session v
 
 The store, hooks, sidebar, and wake paths are unchanged for a browser client, and RimZ proxies no pane I/O.
 
-`[web] port` selects one exact listener, default `8200`. A live daemon serves every room on both backends, so mux choice affects only the attach command selected after a browser connects.
+`[web] interface` and `port` select one exact listener, default `127.0.0.1:8200`. A live daemon serves every room on both backends, so mux choice affects only the attach command selected after a browser connects.
 
 ## Daemon
 
-The structurally fixed argv is:
+Basic Auth uses this structurally fixed argv:
 
 ```text
 ttyd -W -O -a -c rimz:<secret> -i 127.0.0.1 -p <port> [-t <client-option>...] [-I <custom-index>] <current-rimz-exe> web exec
 ```
 
-`-W` enables input, `-O` enforces origin checks, `-a` appends URL `arg` values to the command, `-c` requires Basic Auth, and `-i` keeps the listener on loopback.
+Trusted-header auth replaces `-c rimz:<secret>` with `-H <header>`. `-W` enables input, `-O` enforces origin checks, `-a` appends URL `arg` values to the command, and `-i` selects the configured IP listener.
+
+An empty `trusted_proxies` list binds ttyd directly to `<interface>:<port>`. A non-empty list starts ttyd first on `127.0.0.1:<ephemeral>`, waits for that upstream, starts the hidden detached `rimz web gate` process on the configured listener, waits for the public listener, and only then writes daemon state. Startup tears down every process already started when a later step fails.
+
+The gate parses the configured bare IPs and IPv4 or IPv6 CIDRs before any process change. It accepts loopback peers and peers inside a matching same-family CIDR, drops every other connection, and splices accepted TCP streams to ttyd without parsing HTTP or reading pane data.
 
 Room URLs have the shape `<base>/?arg=<percent-encoded-session>`. ttyd appends the decoded session to the hidden shim as `rimz web exec <session>`.
 
 The shim accepts only a session with a durable RimZ workspace record and a matching live mux session. It never treats the browser argument as an argv fragment. A valid tmux target execs `tmux -S <managed-socket> attach -t <session>`; a valid Zellij target execs `zellij attach <session>`. A missing, unknown, or stopped target prints the currently live RimZ sessions and exits 1.
 
-The ttyd binary resolves from `RIMZ_TTYD_BIN`, then `PATH`. A missing binary reports the Homebrew and apt install fix. A configured port held by a process outside the recorded daemon returns a typed error that points to `[web] port`.
+The ttyd binary resolves from `RIMZ_TTYD_BIN`, then `PATH`. A missing binary reports the Homebrew and apt install fix. `interface` must parse as an IP address, each trusted proxy must parse as an IP or CIDR, and an occupied configured listener returns a typed error that points to `[web] port`.
 
-RimZ spawns ttyd with null stdio and its own process group, waits up to five seconds for the configured port, then writes `$XDG_STATE_HOME/rimz/web-ttyd.json` as `{pid, port}`. The record is live only while the pid exists and its loopback port accepts a connection; readers remove stale records.
+RimZ spawns ttyd and the optional gate with null stdio and their own process groups, then writes `$XDG_STATE_HOME/rimz/web-ttyd.json` with `pid`, `port`, `interface`, `auth`, `trusted_proxies`, and optional `gate: {pid, upstream_port}`. Old `{pid, port}` records deserialize as Basic Auth on loopback without a gate. The record is live only while ttyd is the recorded process, the optional gate is a recorded `rimz web gate` process, and the configured listener accepts a connection; readers remove stale records.
+
+The desired listener, auth mode, and proxy list participate in daemon reuse. Any drift stops the old processes and starts the desired shape; Basic mode also requires the credential file before reuse.
 
 State transitions hold `$XDG_STATE_HOME/rimz/web-ttyd.lock`, so concurrent room starts converge on one process and credential rotation cannot race stale-record cleanup.
 
 The first shared-daemon start after an upgrade consumes the old `$XDG_STATE_HOME/rimz/web-ttyd/` per-session records. RimZ sends SIGTERM only when a recorded pid still names `ttyd`, then removes the legacy directory; malformed records, recycled pids, and cleanup errors are debug diagnostics and do not block the new daemon.
 
-`rimz web stop` sends SIGTERM, waits one second while refreshing the process table, uses SIGKILL for a survivor, and removes the record.
+`rimz web stop` sends SIGTERM to the gate and ttyd, waits one second while refreshing the process table, uses SIGKILL for a survivor, waits for the public listener to close, and removes the record.
 
 ## Credential and browser client
 
-The one credential named `rimz` lives at `$XDG_STATE_HOME/rimz/web-ttyd-credential.json`, mode 0600, with `name`, `created_at`, and `secret`.
+In Basic mode, the one credential named `rimz` lives at `$XDG_STATE_HOME/rimz/web-ttyd-credential.json`, mode 0600, with `name`, `created_at`, and `secret`.
 
 Rotation stops and restarts the one live daemon so the old secret stops working immediately. Revocation stops the daemon and removes the credential. ttyd read-only mode is process-wide, so RimZ rejects read-only credential creation.
+
+Trusted-header mode neither reads nor mints the credential, and its JSON payload omits `credential`. `rimz web token create` refuses while `auth_header` is set and tells the user to unset it to return to Basic Auth; list and revoke retain their normal file behavior.
 
 The daemon always passes `macOptionIsMeta=true` and `cursorBlink=false`. With `style_client = true`, it also projects the shared theme into xterm.js options and resolves the configured font.
 
@@ -52,7 +60,7 @@ The bootstrap refreshes xterm after fonts load, keeps the cursor steady across r
 
 ## Commands and room start
 
-`rimz web open` resolves or births the room, confirms the session is addressable, ensures the shared daemon, and returns its URL and credential. `--no-start` requires an already-live daemon.
+`rimz web open` resolves or births the room, confirms the session is addressable, ensures the shared daemon, and returns its URL and auth mode plus a credential in Basic mode. `--no-start` requires an already-live daemon.
 
 `rimz web url` reads the room identity, existing credential, and live daemon state without changing the daemon or credential. It uses the live port when the daemon runs and the configured port otherwise; its v2 JSON omits `credential` when none exists. `start`, `status`, and `stop` act on the one machine daemon and need no room target.
 
@@ -60,23 +68,29 @@ After a normal `rimz start` makes the room ready, `[web] enabled = true` asks Ri
 
 ## Configuration
 
-`[web]` carries `enabled`, `port`, `base_url`, `font`, `font_source`, and `style_client`.
+`[web]` carries `enabled`, `interface`, `port`, `base_url`, `auth_header`, `trusted_proxies`, `font`, `font_source`, and `style_client`.
 
-`enabled` defaults to true, `port` defaults to 8200, and an absent `base_url` resolves to `http://127.0.0.1:<port>`. A reverse proxy can set `base_url` to its public prefix; RimZ appends `/?arg=<session>`.
+`enabled` defaults to true, `interface` defaults to `127.0.0.1`, `port` defaults to 8200, and an absent `base_url` resolves to `http://127.0.0.1:<port>`. A reverse proxy can set `base_url` to its public prefix; RimZ appends `/?arg=<session>`.
+
+A non-empty trimmed `auth_header` selects trusted-header auth, while an empty or absent value selects Basic Auth. `trusted_proxies` is empty by default; setting it enables the gate even in Basic mode. Trusted-header auth on a non-loopback interface without the gate returns a warning that names the CIDR or firewall fixes.
 
 The section is per-machine and stays outside the trust hash because no field executes a command. `font_source` is a read-only local path or HTTPS URL.
 
 ## Remote rooms
 
-Remote prep is one non-PTY `rimz web open --print --json` call. Its `rimz.web.v2` payload is `{version, url, session, port, credential: {username, secret}}`.
+Remote prep is one non-PTY `rimz web open --print --json` call. Its additive `rimz.web.v2` payload includes `auth: {mode: "basic"}` or `auth: {mode: "trusted_header", header: "<name>"}`; missing `auth` defaults to Basic for older v2 peers, and Basic payloads include `credential: {username, secret}`.
 
-The local side checks the exact schema, prints the returned Basic-Auth credential, chooses a local port, and forwards it to `127.0.0.1:<remote-port>`. There is no second token-provisioning SSH call.
+The local side checks the exact schema, prints the returned Basic-Auth credential, chooses a local port, and forwards it to `127.0.0.1:<remote-port>`. There is no second token-provisioning SSH call. A trusted-header payload fails before tunnel setup and directs the user to its reverse-proxy URL because an SSH port forward cannot inject the required header.
 
 The local port derives from the session in 8300–8399 and scans on collision. Recovery repeats prep so it can rebirth the room, restart the daemon, discover a changed port, and print a changed secret while keeping the local URL stable. Version skew uses the existing remote-upgrade diagnostic; v1 payloads are not accepted.
 
 ## Security
 
-The production listener binds to loopback and requires authentication.
+The default listener binds to loopback and requires Basic Auth.
+
+ttyd treats a configured auth header as proof of authentication when it is present and non-empty; it does not validate the value or filter source addresses. Any client that reaches an ungated listener can spoof the header and receive a shell, so a non-loopback trusted-header listener uses `trusted_proxies` or an equivalent firewall boundary that admits only the authenticating proxy.
+
+The gate always trusts loopback because local processes can already reach its loopback ttyd upstream. On a multi-user host, any local user who can connect and supply the configured header can reach the shell as the RimZ-serving user; use host-level user isolation when that boundary matters.
 
 Credentials stay out of URLs, logs, store events, and workspace records. The v2 credential appears only in explicit JSON output that reports a saved credential and the human stderr relay.
 

--- a/docs/reference/cli/web.md
+++ b/docs/reference/cli/web.md
@@ -16,7 +16,7 @@ rimz web token revoke-all
 
 `rimz web` is `rimz web open`.
 
-`open` resolves or births the room, verifies that its session is addressable on the selected backend, ensures the shared daemon, prints the URL and credential, and opens the browser.
+`open` resolves or births the room, verifies that its session is addressable on the selected backend, ensures the shared daemon, prints the URL and Basic credential or trusted-header proxy note, and opens the browser.
 
 | Flag | Effect |
 | --- | --- |
@@ -24,23 +24,25 @@ rimz web token revoke-all
 | `--print` | Skip the browser launch. |
 | `--no-start` | Require the shared daemon to already be online. |
 | `--no-resume` | Skip recovering the room's prior agents. |
-| `--json` | Emit the `rimz.web.v2` payload on stdout; `open` includes the credential. |
+| `--json` | Emit the `rimz.web.v2` payload on stdout; Basic `open` includes the credential. |
 
 `url` requires an existing workspace record and inspects its route without birthing a room, starting the daemon, or creating a credential. A live daemon's port wins over a changed configured port; offline inspection uses `[web] port`. JSON output includes the saved credential when one exists and omits `credential` otherwise.
 
-`start`, `status`, and `stop` act on the one machine daemon and do not need a room. The port comes from `[web] port`; command-line listener and TLS overrides are not supported.
+`start`, `status`, and `stop` act on the one machine daemon and do not need a room. Human status prints the configured `[web] interface` and `port`; command-line listener and TLS overrides are not supported.
 
 The JSON `open` payload is:
 
 ```json
-{"version":"rimz.web.v2","url":"http://127.0.0.1:8200/?arg=rimz-project-a1b2c3","session":"rimz-project-a1b2c3","port":8200,"credential":{"username":"rimz","secret":"..."}}
+{"version":"rimz.web.v2","url":"http://127.0.0.1:8200/?arg=rimz-project-a1b2c3","session":"rimz-project-a1b2c3","port":8200,"auth":{"mode":"basic"},"credential":{"username":"rimz","secret":"..."}}
 ```
 
-The `url --json` payload has the same fields, with optional `credential`.
+The `url --json` payload has the same fields, with optional `credential`. Trusted-header payloads use `"auth":{"mode":"trusted_header","header":"X-Authentik-Username"}` and omit `credential`.
 
 `status --json` emits `version`, `online`, `pid`, and `port`.
 
 The one credential is named `rimz`. `create` rotates it and restarts the live daemon, `list` prints its creation time, and either revoke verb stops the daemon before clearing it.
+
+`create` refuses while `[web] auth_header` is set and tells you to unset that field to return to Basic Auth. `list` and both revoke forms continue to manage any saved Basic credential; revoke still stops a trusted-header daemon.
 
 `--read-only` is rejected because ttyd's read-only setting belongs to the whole process.
 


### PR DESCRIPTION
## Context

The shared ttyd daemon that serves browser access to every RimZ room only supported Basic Auth on a hard-coded loopback bind. Hosting the web terminal remotely behind a reverse proxy that performs forward-auth (Traefik + Authentik, for example) requires ttyd to trust a proxy-injected identity header instead of showing its own auth prompt. ttyd 1.7.7 supports this via `-H/--auth-header`, but it is a pure header-presence check with no source-IP filtering: anyone who can reach the listener can spoof the header and get a shell. RimZ therefore has to supply the network boundary itself.

This change adds three per-machine `[web]` fields — `auth_header` (trusted-header mode), `interface` (configurable bind IP, default `127.0.0.1`), and `trusted_proxies` (source-IP CIDR allowlist) — and a small RimZ-owned TCP gate that enforces the allowlist in front of ttyd.

## Design choices

- **Exclusive auth mode.** A non-empty `auth_header` switches the daemon argv to `-H <name>` and drops `-c`; no credential is minted, read, or printed. `rimz web token create` fails fast with the fix, mirroring the read-only-credential refusal; `token list`/`revoke` keep working.
- **Gate only when filtering is configured.** Empty `trusted_proxies` binds ttyd directly to `<interface>:<port>`, one process as before. A non-empty list binds ttyd to `127.0.0.1:<ephemeral>` and starts a hidden detached `rimz web gate` on `<interface>:<port>` that admits a peer only when it is loopback or inside a trusted CIDR, then splices raw TCP to ttyd — no HTTP parsing and no pane I/O in RimZ, so the "daemon owns browser transport" contract holds.
- **Loopback is always trusted by the gate.** Local processes can already reach ttyd's loopback upstream directly, so admitting loopback loses nothing and keeps liveness probes and same-host use working. The consequence — on a multi-user host any local user can present the header and get a shell — is stated plainly in the security guide.
- **Config drift restarts the daemon.** The daemon record grows `interface`, auth mode, `trusted_proxies`, and an optional gate pid/upstream port; a live daemon is reused only when its record matches the desired spec. Old two-field `{pid, port}` records parse via serde defaults as basic/loopback/no-gate.
- **`interface` is an IP address, not a device name** — liveness probing needs a dialable address. It is validated with `IpAddr::parse` at daemon start, and unspecified addresses map to the matching loopback family for probes.
- **Remote `--web` fails fast under header auth.** A tunneled browser cannot inject the header, so the tunnel would be a dead end. The `rimz.web.v2` payload gains an additive optional `auth` field (serde-default Basic, no version bump); a trusted-header payload makes `rimz remote … --web` bail with the reverse-proxy URL.
- **Spoofing risk is surfaced.** Header auth plus a non-loopback interface plus empty `trusted_proxies` emits a warning at start; the security and web guides describe the model.
- **Hand-rolled CIDR matcher, no new dependency** — roughly forty lines of `std::net` bit-prefix comparison, avoiding a supply-chain add for `ipnet`. Bare IPs parse as full-length host prefixes, matches are same-family, and IPv4-mapped IPv6 peers are normalized to IPv4 first.
- **New fields stay outside the trust hash** — none executes a command.

## Implementation

- Config: `[web] interface`, `auth_header`, `trusted_proxies` with template, default, round-trip, and trust-boundary coverage.
- `web/gate.rs`: the `Cidr` parser and matcher, `peer_allowed` (loopback-always plus same-family CIDR), and a thread-per-connection TCP splice with `TCP_NODELAY` and half-close propagation.
- `web/ttyd.rs`: `WebAuth`-derived argv, the extended `DaemonRecord`, two-process start with full teardown-on-failure, gate-aware liveness and stop, interface validation, and the exposure warning.
- Public API and payload: new `WebErr` variants, the tagged `WebAuth` enum, the additive `auth` payload field, and header-mode credential omission.
- CLI: a hidden `web gate` subcommand, `open` printing the proxy note instead of a credential under header auth, and `status`/`start` printing the configured listener.
- Remote: `parse_web_payload` bails on trusted-header auth for both the initial prep and the recovery re-prep paths.
- Docs: internals/web, guide/web (Traefik + Authentik walkthrough), guide/configuration, guide/security, reference/cli/web, and the changelog.

Deviations from the plan, each reviewed and correct:
- The daemon record reuses the public `WebAuth` type rather than a duplicate internal `DaemonAuth`, so one type governs both record and wire compatibility with identical serialized and default behavior.
- The `gate` module stays private; a narrow `serve_gate` domain entry point is exposed instead of the whole module, keeping the CIDR parser internal.
- The header-auth remote bail lives in `parse_web_payload`, which both prep paths already call, rather than in a separate helper.
- Real ttyd 1.7.7 returns HTTP 407 (not the plan's assumed 401) when the header is absent; no RimZ behavior depends on the denial status.

## Review

The blind review raised two findings, both fixed in a follow-up commit and re-reviewed clean:
- Stale-record reconciliation removed the daemon record on partial process death without terminating the surviving sibling. That could orphan the gate on the public port — blocking the next `web start` with a port-in-use error and no RimZ recovery path — and, if the ephemeral upstream port were later reused, forward trusted-proxy traffic to an unrelated local process. Reconciliation now terminates each surviving sibling, verified by pid and command identity so the recycled-pid safety invariant holds, before removing the record; this also reaps the alive-but-unresponsive case the single-process design left orphaned. A new integration test kills ttyd under a live gate and asserts the gate and record are reaped and the daemon restarts on the same port.
- The non-gated readiness probe dialed the raw interface, including the unspecified `0.0.0.0`/`::` addresses that are not portable to connect to off Linux. It now normalizes to the matching loopback family, reusing the record-liveness helper.

## Advisories and weak spots

- The gate is raw TCP with two detached pump threads per connection — appropriate for terminal-server scale; an async or bounded-worker design is the upgrade path if connection scale demands it.
- Source-IP allowlisting matches the observed TCP peer address, so deployments behind Docker or NAT must configure the address that actually reaches RimZ and keep a matching host firewall.
- The ephemeral upstream port uses bind-then-release selection, so a small port-selection race remains; startup detects the loss and tears the processes down.

Verification: `cargo xtask gate` passes (fmt, invariants, docs-links, lint, fast nextest); `cargo xtask test web` reports 61 passed; a real ttyd 1.7.7 sandbox smoke confirmed header-present 200 and header-absent 407 in direct mode and 200 through the gate in gated mode.