### PR TITLE
feat(web): render pixel pets in ttyd browser rooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ RimZ is alpha software on the 0.x line. Commands, flags, config keys, and output
 ### Fixed
 
 - Browser cursors stay steady when terminal apps request a blinking cursor. → [web](./docs/guide/web.md#browser-appearance-and-input)
+- Pixel pets and the pixel context meter render as true pixels in ttyd browser attaches for qualifying tmux rooms, while mixed or unsupported clients continue to fall back to sextant cell art. → [pets](./docs/guide/pets.md#crisp-pixels-and-cell-art)
 - Homebrew upgrades through `rimz update` and the install script refresh formula data first, so a stale tap no longer skips a released build. → [installation](./docs/guide/installation.md)
 - Queued `done`-gated messages deliver when an agent's clean turn parks on background work instead of waiting for the background process to exit. → [messaging](./docs/guide/messaging.md)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ RimZ is alpha software on the 0.x line. Commands, flags, config keys, and output
 ### Fixed
 
 - Browser cursors stay steady when terminal apps request a blinking cursor. → [web](./docs/guide/web.md#browser-appearance-and-input)
-- Pixel pets and the pixel context meter render as true pixels in ttyd browser attaches for qualifying tmux rooms, while mixed or unsupported clients continue to fall back to sextant cell art. → [pets](./docs/guide/pets.md#crisp-pixels-and-cell-art)
+- Pixel pets and the pixel context meter render as true pixels in ttyd browser attaches for qualifying tmux rooms; pets keep their native proportions without leaking placement glyphs, while mixed or unsupported clients continue to fall back to sextant cell art. → [pets](./docs/guide/pets.md#crisp-pixels-and-cell-art)
 - Homebrew upgrades through `rimz update` and the install script refresh formula data first, so a stale tap no longer skips a released build. → [installation](./docs/guide/installation.md)
 - Queued `done`-gated messages deliver when an agent's clean turn parks on background work instead of waiting for the background process to exit. → [messaging](./docs/guide/messaging.md)
 

--- a/crates/rimz/src/sidebar_pane/app/loop_state.rs
+++ b/crates/rimz/src/sidebar_pane/app/loop_state.rs
@@ -410,7 +410,16 @@ impl LoopState {
             // idle backstop interval elapsed. It carries no state of its own —
             // the frame phase below advances the spin and paints, and the
             // backstop poll runs there too.
-            Wakeup::Tick => Ok(LoopFlow::Continue),
+            Wakeup::Tick => {
+                if self.paint.refresh_caps_if_stale(
+                    config.mux,
+                    &config.session_name,
+                    Instant::now(),
+                ) {
+                    self.dirty = true;
+                }
+                Ok(LoopFlow::Continue)
+            }
             Wakeup::Resize => {
                 let settled_width = terminal.size().map(|s| s.width).ok();
                 self.on_resize(config, fetch, terminal, settled_width, anim_start, diag)?;
@@ -908,6 +917,18 @@ impl LoopState {
         detect: impl FnOnce(MuxName, &str, PixelRenderCaps) -> PixelRenderCaps,
     ) {
         self.paint.refresh_caps_with(mux, session_name, detect);
+    }
+
+    #[cfg(test)]
+    fn refresh_pet_render_caps_if_stale_with(
+        &mut self,
+        mux: MuxName,
+        session_name: &str,
+        now: Instant,
+        detect: impl FnOnce(MuxName, &str, PixelRenderCaps) -> PixelRenderCaps,
+    ) -> bool {
+        self.paint
+            .refresh_caps_if_stale_with(mux, session_name, now, detect)
     }
 
     pub(super) fn on_input(

--- a/crates/rimz/src/sidebar_pane/app/loop_state/tests/paint.rs
+++ b/crates/rimz/src/sidebar_pane/app/loop_state/tests/paint.rs
@@ -313,7 +313,7 @@ fn empty_close_suppresses_widened_paint_until_exit() {
 fn resize_reprobe_adopts_probed_pet_render_caps() {
     let enabled = PixelRenderCaps {
         pixel_transport: true,
-        kitty_term: true,
+        kitty_clients: true,
     };
 
     for (label, initial, probed) in [
@@ -348,4 +348,34 @@ fn resize_reprobe_adopts_probed_pet_render_caps() {
         );
         assert_eq!(rig.state.paint.caps(), probed, "{label}");
     }
+}
+
+#[test]
+fn stale_tmux_caps_reprobe_is_bounded_and_adopts_changes() {
+    let mut rig = Rig::new();
+    let enabled = PixelRenderCaps {
+        pixel_transport: true,
+        kitty_clients: true,
+    };
+    let stale = std::time::Instant::now() + std::time::Duration::from_secs(11);
+
+    assert!(rig.state.refresh_pet_render_caps_if_stale_with(
+        crate::MuxName::Tmux,
+        "rimz-test",
+        stale,
+        |_, _, _| enabled,
+    ));
+    assert_eq!(rig.state.paint.caps(), enabled);
+    assert!(!rig.state.refresh_pet_render_caps_if_stale_with(
+        crate::MuxName::Tmux,
+        "rimz-test",
+        stale,
+        |_, _, _| panic!("fresh caps must not re-probe"),
+    ));
+    assert!(!rig.state.refresh_pet_render_caps_if_stale_with(
+        crate::MuxName::Zellij,
+        "rimz-test",
+        stale + std::time::Duration::from_secs(11),
+        |_, _, _| panic!("Zellij caps must not re-probe"),
+    ));
 }

--- a/crates/rimz/src/sidebar_pane/app/paint.rs
+++ b/crates/rimz/src/sidebar_pane/app/paint.rs
@@ -1,6 +1,7 @@
 //! Paint one sidebar frame, including pixel-pet image residency.
 
 use std::io::{self, Write};
+use std::time::{Duration, Instant};
 
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
@@ -15,11 +16,14 @@ use crate::sidebar_pane::pixel::meter::{MeterPainter, MeterPixels};
 use crate::sidebar_pane::pixel::{BEGIN_SYNC, END_SYNC, PixelRenderCaps, detect_pixel_render_caps};
 use crate::sidebar_pane::render::{self, UiState};
 
+const CAPS_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
+
 pub(super) struct FramePainter {
     assets: PetAssets,
     painter: PixelPainter,
     meter_painter: MeterPainter,
     caps: PixelRenderCaps,
+    last_caps_refresh: Instant,
     probed_aspect: Option<CellAspect>,
 }
 
@@ -32,6 +36,7 @@ impl FramePainter {
             painter,
             meter_painter,
             caps,
+            last_caps_refresh: Instant::now(),
             probed_aspect: probe_cell_aspect(),
         }
     }
@@ -42,6 +47,7 @@ impl FramePainter {
             painter: PixelPainter::with_id_base(id_base, pixel_wrap),
             meter_painter: MeterPainter::new(pixel_wrap),
             caps,
+            last_caps_refresh: Instant::now(),
             probed_aspect: probe_cell_aspect(),
         }
     }
@@ -53,6 +59,7 @@ impl FramePainter {
             painter: PixelPainter::with_id_base(0x120000, pixel_wrap),
             meter_painter: MeterPainter::new(pixel_wrap),
             caps,
+            last_caps_refresh: Instant::now(),
             probed_aspect: None,
         }
     }
@@ -79,6 +86,34 @@ impl FramePainter {
         detect: impl FnOnce(MuxName, &str, PixelRenderCaps) -> PixelRenderCaps,
     ) {
         self.caps = detect(mux, session_name, self.caps);
+        self.last_caps_refresh = Instant::now();
+    }
+
+    pub(super) fn refresh_caps_if_stale(
+        &mut self,
+        mux: MuxName,
+        session_name: &str,
+        now: Instant,
+    ) -> bool {
+        self.refresh_caps_if_stale_with(mux, session_name, now, detect_pixel_render_caps)
+    }
+
+    pub(super) fn refresh_caps_if_stale_with(
+        &mut self,
+        mux: MuxName,
+        session_name: &str,
+        now: Instant,
+        detect: impl FnOnce(MuxName, &str, PixelRenderCaps) -> PixelRenderCaps,
+    ) -> bool {
+        if mux != MuxName::Tmux
+            || now.saturating_duration_since(self.last_caps_refresh) < CAPS_REFRESH_INTERVAL
+        {
+            return false;
+        }
+        let previous = self.caps;
+        self.caps = detect(mux, session_name, previous);
+        self.last_caps_refresh = now;
+        self.caps != previous
     }
 
     pub(super) fn refresh_view(
@@ -129,7 +164,7 @@ impl FramePainter {
             self.painter.release_process_payload();
         }
         let meter_enabled = self.caps.pixel_transport
-            && self.caps.kitty_term
+            && self.caps.kitty_clients
             && snapshot.theme.display.pixel == PixelMode::Auto;
         if meter_enabled {
             ui.meter_pixels

--- a/crates/rimz/src/sidebar_pane/app/tests.rs
+++ b/crates/rimz/src/sidebar_pane/app/tests.rs
@@ -361,7 +361,7 @@ fn refresh_view_gates_pixel_meter_frame_with_caps_and_master_switch() {
     let mut painter = paint::FramePainter::new(
         PixelRenderCaps {
             pixel_transport: true,
-            kitty_term: true,
+            kitty_clients: true,
         },
         false,
     );

--- a/crates/rimz/src/sidebar_pane/pets/mod.rs
+++ b/crates/rimz/src/sidebar_pane/pets/mod.rs
@@ -82,7 +82,7 @@ pub fn resolve_render_tier(mode: PetsGlyphMode, caps: PixelRenderCaps) -> PetRen
     match mode {
         PetsGlyphMode::Sextant => PetRenderTier::Cell,
         PetsGlyphMode::Pixel if caps.pixel_transport => PetRenderTier::Pixel,
-        PetsGlyphMode::Auto if caps.pixel_transport && caps.kitty_term => PetRenderTier::Pixel,
+        PetsGlyphMode::Auto if caps.pixel_transport && caps.kitty_clients => PetRenderTier::Pixel,
         _ => PetRenderTier::Cell,
     }
 }

--- a/crates/rimz/src/sidebar_pane/pets/tests.rs
+++ b/crates/rimz/src/sidebar_pane/pets/tests.rs
@@ -39,9 +39,9 @@ fn cell_frame(action: PetAction, phase: u64) -> PetViewFrame {
 #[test]
 fn render_tier_resolves_mode_caps_and_paintability() {
     use PetsGlyphMode::{Auto, Pixel, Sextant};
-    let caps = |pixel_transport, kitty_term| PixelRenderCaps {
+    let caps = |pixel_transport, kitty_clients| PixelRenderCaps {
         pixel_transport,
-        kitty_term,
+        kitty_clients,
     };
 
     for (mode, caps, pixel_paintable, tier) in [

--- a/crates/rimz/src/sidebar_pane/pixel/mod.rs
+++ b/crates/rimz/src/sidebar_pane/pixel/mod.rs
@@ -18,7 +18,7 @@ pub(crate) const BEGIN_SYNC: &[u8] = b"\x1b[?2026h";
 pub(crate) const END_SYNC: &[u8] = b"\x1b[?2026l";
 const CHUNK_SIZE: usize = 4096;
 pub(crate) const IMAGE_ID_COLOR_MASK: u32 = 0x00ff_ffff;
-const PLACEHOLDER: char = '\u{10eeee}';
+pub(crate) const PLACEHOLDER: char = '\u{10eeee}';
 pub(crate) const RESIDENT_REFRESH_MS: u64 = 2000;
 pub(crate) const MIN_RESEND_SPACING_MS: u64 = 250;
 
@@ -206,7 +206,7 @@ pub(crate) struct ImageRequest<K, C> {
 }
 
 // Kitty's complete rowcolumn-diacritics list, derived from Unicode 6.0.
-const ROW_COLUMN_DIACRITICS: [char; 297] = [
+pub(crate) const ROW_COLUMN_DIACRITICS: [char; 297] = [
     '\u{0305}',
     '\u{030d}',
     '\u{030e}',

--- a/crates/rimz/src/sidebar_pane/pixel/probe.rs
+++ b/crates/rimz/src/sidebar_pane/pixel/probe.rs
@@ -11,7 +11,13 @@ const COMMAND_TIMEOUT: Duration = Duration::from_millis(500);
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct PixelRenderCaps {
     pub pixel_transport: bool,
-    pub kitty_term: bool,
+    pub kitty_clients: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RenderingClient {
+    termname: String,
+    pid: u32,
 }
 
 pub(crate) fn detect(mux: MuxName, session_name: &str, prev: PixelRenderCaps) -> PixelRenderCaps {
@@ -26,8 +32,10 @@ trait Probe {
     fn tmux_version(&self) -> io::Result<String>;
     fn tmux_allow_passthrough(&self, target: &str) -> io::Result<String>;
     fn tmux_set_pane_passthrough_all(&self, pane: &str) -> io::Result<()>;
-    fn tmux_client_termnames(&self, session_name: &str) -> io::Result<Vec<String>>;
+    fn tmux_rendering_clients(&self, session_name: &str) -> io::Result<Vec<RenderingClient>>;
     fn tmux_session_name(&self) -> io::Result<String>;
+    fn processes(&self) -> Vec<crate::proc::ProcInfo>;
+    fn pixel_daemon_record(&self) -> Option<(u32, u32)>;
     fn env_var(&self, key: &str) -> Option<String>;
 }
 
@@ -72,9 +80,9 @@ fn detect_env_with(probe: &impl Probe) -> (PixelRenderCaps, bool) {
 }
 
 fn detect_tmux(session_name: &str, probe: &impl Probe, prev: PixelRenderCaps) -> PixelRenderCaps {
-    let kitty_term = match probe.tmux_client_termnames(session_name) {
-        Ok(termnames) if !termnames.is_empty() => termnames_allowed(&termnames),
-        _ => prev.kitty_term,
+    let kitty_clients = match probe.tmux_rendering_clients(session_name) {
+        Ok(clients) if !clients.is_empty() => rendering_clients_allowed(&clients, probe),
+        _ => prev.kitty_clients,
     };
     let passthrough_target = probe
         .env_var("TMUX_PANE")
@@ -94,7 +102,7 @@ fn detect_tmux(session_name: &str, probe: &impl Probe, prev: PixelRenderCaps) ->
     };
     PixelRenderCaps {
         pixel_transport,
-        kitty_term,
+        kitty_clients,
     }
 }
 
@@ -105,7 +113,7 @@ fn detect_zellij(_probe: &impl Probe) -> PixelRenderCaps {
 fn detect_standalone(probe: &impl Probe) -> PixelRenderCaps {
     PixelRenderCaps {
         pixel_transport: true,
-        kitty_term: standalone_term_allowed(probe),
+        kitty_clients: standalone_term_allowed(probe),
     }
 }
 
@@ -141,19 +149,27 @@ impl Probe for LiveProbe {
         run_tmux(["set-option", "-p", "-t", pane, "allow-passthrough", "all"]).map(|_| ())
     }
 
-    fn tmux_client_termnames(&self, session_name: &str) -> io::Result<Vec<String>> {
+    fn tmux_rendering_clients(&self, session_name: &str) -> io::Result<Vec<RenderingClient>> {
         run_tmux([
             "list-clients",
             "-t",
             session_name,
             "-F",
-            "#{client_control_mode} #{client_termname}",
+            "#{client_control_mode} #{client_termname} #{client_pid}",
         ])
-        .map(|out| rendering_termnames(&out))
+        .map(|out| rendering_clients(&out))
     }
 
     fn tmux_session_name(&self) -> io::Result<String> {
         run_tmux(["display-message", "-p", "#{session_name}"])
+    }
+
+    fn processes(&self) -> Vec<crate::proc::ProcInfo> {
+        crate::proc::list_processes()
+    }
+
+    fn pixel_daemon_record(&self) -> Option<(u32, u32)> {
+        crate::web::pixel_daemon_record()
     }
 
     fn env_var(&self, key: &str) -> Option<String> {
@@ -169,16 +185,59 @@ fn run_tmux<const N: usize>(args: [&str; N]) -> io::Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
 }
 
-fn termnames_allowed(termnames: &[String]) -> bool {
-    termnames.iter().all(|termname| termname_allowed(termname))
+fn rendering_clients_allowed(clients: &[RenderingClient], probe: &impl Probe) -> bool {
+    if clients
+        .iter()
+        .all(|client| termname_allowed(&client.termname))
+    {
+        return true;
+    }
+    let Some((daemon_pid, protocol)) = probe.pixel_daemon_record() else {
+        return false;
+    };
+    if protocol != crate::web::TTYD_PIXEL_PROTOCOL {
+        return false;
+    }
+    let processes = probe.processes();
+    let daemon_live = processes.iter().any(|process| {
+        process.pid == daemon_pid && crate::proc::command::program_label(&process.cmdline) == "ttyd"
+    });
+    daemon_live
+        && clients.iter().all(|client| {
+            termname_allowed(&client.termname) || descends_from(client.pid, daemon_pid, &processes)
+        })
 }
 
-fn rendering_termnames(list_clients_output: &str) -> Vec<String> {
+fn descends_from(pid: u32, ancestor: u32, processes: &[crate::proc::ProcInfo]) -> bool {
+    let mut current = pid;
+    for _ in 0..4 {
+        let Some(process) = processes.iter().find(|process| process.pid == current) else {
+            return false;
+        };
+        if process.ppid == ancestor {
+            return true;
+        }
+        if process.ppid == current {
+            return false;
+        }
+        current = process.ppid;
+    }
+    false
+}
+
+fn rendering_clients(list_clients_output: &str) -> Vec<RenderingClient> {
     list_clients_output
         .lines()
         .filter_map(|line| {
-            let (control_mode, termname) = line.split_once(' ')?;
-            (control_mode.trim() != "1").then(|| termname.trim().to_owned())
+            let mut fields = line.split_whitespace();
+            let control_mode = fields.next()?;
+            if control_mode == "1" {
+                return None;
+            }
+            Some(RenderingClient {
+                termname: fields.next().unwrap_or_default().to_owned(),
+                pid: fields.next().and_then(|pid| pid.parse().ok()).unwrap_or(0),
+            })
         })
         .collect()
 }
@@ -191,467 +250,4 @@ fn termname_allowed(termname: &str) -> bool {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::cell::RefCell;
-    use std::collections::BTreeMap;
-
-    const TEST_SESSION: &str = "rimz-test";
-
-    struct FakeProbe {
-        version: Option<String>,
-        allow_passthrough: Option<String>,
-        expected_session: String,
-        termnames: Option<Vec<String>>,
-        session_name: Option<String>,
-        env: BTreeMap<String, String>,
-        passthrough_targets: RefCell<Vec<String>>,
-        passthrough_all_panes: RefCell<Vec<String>>,
-    }
-
-    impl FakeProbe {
-        fn ok() -> Self {
-            Self {
-                version: Some("tmux 3.6b".to_owned()),
-                allow_passthrough: Some("on".to_owned()),
-                expected_session: TEST_SESSION.to_owned(),
-                termnames: Some(vec!["xterm-ghostty".to_owned()]),
-                session_name: Some(TEST_SESSION.to_owned()),
-                env: BTreeMap::new(),
-                passthrough_targets: RefCell::new(Vec::new()),
-                passthrough_all_panes: RefCell::new(Vec::new()),
-            }
-        }
-
-        fn with_env(mut self, key: &str, value: &str) -> Self {
-            self.env.insert(key.to_owned(), value.to_owned());
-            self
-        }
-    }
-
-    impl Probe for FakeProbe {
-        fn tmux_version(&self) -> io::Result<String> {
-            self.version
-                .clone()
-                .ok_or_else(|| io::Error::other("tmux version unavailable"))
-        }
-
-        fn tmux_allow_passthrough(&self, target: &str) -> io::Result<String> {
-            self.passthrough_targets
-                .borrow_mut()
-                .push(target.to_owned());
-            self.allow_passthrough
-                .clone()
-                .ok_or_else(|| io::Error::other("tmux passthrough unavailable"))
-        }
-
-        fn tmux_set_pane_passthrough_all(&self, pane: &str) -> io::Result<()> {
-            self.passthrough_all_panes
-                .borrow_mut()
-                .push(pane.to_owned());
-            Ok(())
-        }
-
-        fn tmux_client_termnames(&self, session_name: &str) -> io::Result<Vec<String>> {
-            assert_eq!(session_name, self.expected_session);
-            self.termnames
-                .clone()
-                .ok_or_else(|| io::Error::other("tmux termnames unavailable"))
-        }
-
-        fn tmux_session_name(&self) -> io::Result<String> {
-            self.session_name
-                .clone()
-                .ok_or_else(|| io::Error::other("tmux session unavailable"))
-        }
-
-        fn env_var(&self, key: &str) -> Option<String> {
-            self.env.get(key).cloned()
-        }
-    }
-
-    #[test]
-    fn tmux_passthrough_probe_targets_own_pane_then_session() {
-        let own_pane = FakeProbe::ok().with_env("TMUX_PANE", "%7");
-        detect_with(
-            MuxName::Tmux,
-            TEST_SESSION,
-            PixelRenderCaps::default(),
-            &own_pane,
-        );
-        assert_eq!(&*own_pane.passthrough_targets.borrow(), &["%7"]);
-
-        let session = FakeProbe::ok();
-        detect_with(
-            MuxName::Tmux,
-            TEST_SESSION,
-            PixelRenderCaps::default(),
-            &session,
-        );
-        assert_eq!(
-            &*session.passthrough_targets.borrow(),
-            &[TEST_SESSION.to_owned()]
-        );
-    }
-
-    #[test]
-    fn tmux_sidebar_escalates_own_inherited_passthrough() {
-        let probe = FakeProbe::ok().with_env("TMUX_PANE", "%7");
-
-        escalate_with(&probe).expect("escalation");
-
-        assert_eq!(&*probe.passthrough_targets.borrow(), &["%7"]);
-        assert_eq!(&*probe.passthrough_all_panes.borrow(), &["%7"]);
-    }
-
-    #[test]
-    fn tmux_sidebar_preserves_all_off_and_missing_pane() {
-        for allow_passthrough in ["all", "off"] {
-            let probe = FakeProbe {
-                allow_passthrough: Some(allow_passthrough.to_owned()),
-                ..FakeProbe::ok().with_env("TMUX_PANE", "%7")
-            };
-
-            escalate_with(&probe).expect("no-op");
-
-            assert_eq!(&*probe.passthrough_targets.borrow(), &["%7"]);
-            assert!(probe.passthrough_all_panes.borrow().is_empty());
-        }
-
-        let missing_pane = FakeProbe::ok();
-        escalate_with(&missing_pane).expect("no-op");
-        assert!(missing_pane.passthrough_targets.borrow().is_empty());
-        assert!(missing_pane.passthrough_all_panes.borrow().is_empty());
-    }
-
-    #[test]
-    fn tmux_pixel_gate_requires_version_passthrough_and_allowed_termname() {
-        assert_eq!(
-            detect_with(
-                MuxName::Tmux,
-                TEST_SESSION,
-                PixelRenderCaps::default(),
-                &FakeProbe::ok()
-            ),
-            PixelRenderCaps {
-                pixel_transport: true,
-                kitty_term: true,
-            }
-        );
-
-        assert_eq!(
-            detect_with(
-                MuxName::Zellij,
-                TEST_SESSION,
-                PixelRenderCaps::default(),
-                &FakeProbe::ok().with_env("TERM", "xterm-ghostty")
-            ),
-            PixelRenderCaps::default()
-        );
-
-        let old = FakeProbe {
-            version: Some("tmux 3.5a".to_owned()),
-            ..FakeProbe::ok()
-        };
-        assert_eq!(
-            detect_with(
-                MuxName::Tmux,
-                TEST_SESSION,
-                PixelRenderCaps::default(),
-                &old
-            ),
-            PixelRenderCaps {
-                pixel_transport: false,
-                kitty_term: true,
-            }
-        );
-
-        let off = FakeProbe {
-            allow_passthrough: Some("off".to_owned()),
-            ..FakeProbe::ok()
-        };
-        assert_eq!(
-            detect_with(
-                MuxName::Tmux,
-                TEST_SESSION,
-                PixelRenderCaps::default(),
-                &off
-            ),
-            PixelRenderCaps {
-                pixel_transport: false,
-                kitty_term: true,
-            }
-        );
-
-        let all = FakeProbe {
-            allow_passthrough: Some("all\n".to_owned()),
-            ..FakeProbe::ok()
-        };
-        assert_eq!(
-            detect_with(
-                MuxName::Tmux,
-                TEST_SESSION,
-                PixelRenderCaps::default(),
-                &all
-            ),
-            PixelRenderCaps {
-                pixel_transport: true,
-                kitty_term: true,
-            }
-        );
-
-        let unsupported_term = FakeProbe {
-            termnames: Some(vec!["screen-256color".to_owned()]),
-            ..FakeProbe::ok()
-        };
-        assert_eq!(
-            detect_with(
-                MuxName::Tmux,
-                TEST_SESSION,
-                PixelRenderCaps::default(),
-                &unsupported_term
-            ),
-            PixelRenderCaps {
-                pixel_transport: true,
-                kitty_term: false,
-            }
-        );
-
-        let unattached = FakeProbe {
-            termnames: Some(Vec::new()),
-            ..FakeProbe::ok()
-        };
-        assert_eq!(
-            detect_with(
-                MuxName::Tmux,
-                TEST_SESSION,
-                PixelRenderCaps::default(),
-                &unattached
-            ),
-            PixelRenderCaps {
-                pixel_transport: true,
-                kitty_term: false,
-            }
-        );
-    }
-
-    #[test]
-    fn tmux_probe_failures_keep_previous_fact_values() {
-        let prev = PixelRenderCaps {
-            pixel_transport: true,
-            kitty_term: true,
-        };
-
-        let version_error = FakeProbe {
-            version: None,
-            termnames: Some(vec!["screen-256color".to_owned()]),
-            ..FakeProbe::ok()
-        };
-        assert_eq!(
-            detect_with(MuxName::Tmux, TEST_SESSION, prev, &version_error),
-            PixelRenderCaps {
-                pixel_transport: true,
-                kitty_term: false,
-            }
-        );
-
-        let passthrough_error = FakeProbe {
-            allow_passthrough: None,
-            ..FakeProbe::ok()
-        };
-        assert_eq!(
-            detect_with(MuxName::Tmux, TEST_SESSION, prev, &passthrough_error),
-            prev
-        );
-
-        let term_error = FakeProbe {
-            termnames: None,
-            allow_passthrough: Some("off".to_owned()),
-            ..FakeProbe::ok()
-        };
-        assert_eq!(
-            detect_with(MuxName::Tmux, TEST_SESSION, prev, &term_error),
-            PixelRenderCaps {
-                pixel_transport: false,
-                kitty_term: true,
-            }
-        );
-    }
-
-    #[test]
-    fn tmux_empty_rendering_client_list_keeps_previous_kitty_fact() {
-        let prev = PixelRenderCaps {
-            pixel_transport: false,
-            kitty_term: true,
-        };
-        let unattached = FakeProbe {
-            termnames: Some(Vec::new()),
-            ..FakeProbe::ok()
-        };
-
-        assert_eq!(
-            detect_with(MuxName::Tmux, TEST_SESSION, prev, &unattached),
-            PixelRenderCaps {
-                pixel_transport: true,
-                kitty_term: true,
-            }
-        );
-    }
-
-    #[test]
-    fn tmux_successful_probe_overrides_previous_facts() {
-        let prev = PixelRenderCaps {
-            pixel_transport: true,
-            kitty_term: true,
-        };
-        let unsupported = FakeProbe {
-            version: Some("tmux 3.5a".to_owned()),
-            allow_passthrough: Some("off".to_owned()),
-            termnames: Some(vec!["screen-256color".to_owned()]),
-            ..FakeProbe::ok()
-        };
-
-        assert_eq!(
-            detect_with(MuxName::Tmux, TEST_SESSION, prev, &unsupported),
-            PixelRenderCaps::default()
-        );
-        assert_eq!(
-            detect_with(
-                MuxName::Tmux,
-                TEST_SESSION,
-                PixelRenderCaps::default(),
-                &FakeProbe::ok()
-            ),
-            PixelRenderCaps {
-                pixel_transport: true,
-                kitty_term: true,
-            }
-        );
-    }
-
-    #[test]
-    fn termname_gate_filters_control_clients_and_requires_all_to_match() {
-        for termname in [
-            "xterm-ghostty",
-            "ghostty",
-            "xterm-kitty",
-            "kitty",
-            "XTERM-KITTY",
-        ] {
-            let probe = FakeProbe {
-                termnames: Some(vec![termname.to_owned()]),
-                ..FakeProbe::ok()
-            };
-
-            assert!(
-                detect_with(
-                    MuxName::Tmux,
-                    TEST_SESSION,
-                    PixelRenderCaps::default(),
-                    &probe
-                )
-                .kitty_term,
-                "{termname} should enable pixels"
-            );
-        }
-
-        let allowed = FakeProbe {
-            termnames: Some(vec!["xterm-ghostty".to_owned(), "kitty".to_owned()]),
-            ..FakeProbe::ok()
-        };
-        assert!(
-            detect_with(
-                MuxName::Tmux,
-                TEST_SESSION,
-                PixelRenderCaps::default(),
-                &allowed
-            )
-            .kitty_term
-        );
-
-        let mixed = FakeProbe {
-            termnames: Some(vec![
-                "xterm-ghostty".to_owned(),
-                "screen-256color".to_owned(),
-            ]),
-            ..FakeProbe::ok()
-        };
-        assert!(
-            !detect_with(
-                MuxName::Tmux,
-                TEST_SESSION,
-                PixelRenderCaps::default(),
-                &mixed
-            )
-            .kitty_term
-        );
-
-        assert_eq!(
-            rendering_termnames("0 xterm-ghostty\n1 tmux-256color"),
-            vec!["xterm-ghostty".to_owned()]
-        );
-
-        let probe = FakeProbe {
-            termnames: Some(rendering_termnames("0 xterm-ghostty\n1 tmux-256color")),
-            ..FakeProbe::ok()
-        };
-        assert!(
-            detect_with(
-                MuxName::Tmux,
-                TEST_SESSION,
-                PixelRenderCaps::default(),
-                &probe
-            )
-            .kitty_term
-        );
-    }
-
-    #[test]
-    fn standalone_env_detects_native_kitty_and_wrap_mode() {
-        let plain = FakeProbe::ok().with_env("TERM", "xterm-kitty");
-        assert_eq!(
-            detect_env_with(&plain),
-            (
-                PixelRenderCaps {
-                    pixel_transport: true,
-                    kitty_term: true,
-                },
-                false
-            )
-        );
-
-        let tmux = FakeProbe::ok()
-            .with_env("TMUX", "/tmp/tmux-1000/default,123,0")
-            .with_env("TERM", "screen-256color");
-        assert_eq!(
-            detect_env_with(&tmux),
-            (
-                PixelRenderCaps {
-                    pixel_transport: true,
-                    kitty_term: true,
-                },
-                true
-            )
-        );
-
-        let zellij = FakeProbe::ok()
-            .with_env("ZELLIJ", "1")
-            .with_env("TERM", "xterm-kitty");
-        assert_eq!(
-            detect_env_with(&zellij),
-            (PixelRenderCaps::default(), false)
-        );
-
-        let unsupported = FakeProbe::ok().with_env("TERM", "xterm-256color");
-        assert_eq!(
-            detect_env_with(&unsupported),
-            (
-                PixelRenderCaps {
-                    pixel_transport: true,
-                    kitty_term: false,
-                },
-                false
-            )
-        );
-    }
-}
+mod tests;

--- a/crates/rimz/src/sidebar_pane/pixel/probe/tests.rs
+++ b/crates/rimz/src/sidebar_pane/pixel/probe/tests.rs
@@ -1,0 +1,627 @@
+use super::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+
+const TEST_SESSION: &str = "rimz-test";
+
+fn process(pid: u32, ppid: u32, cmdline: &str) -> crate::proc::ProcInfo {
+    crate::proc::ProcInfo {
+        pid,
+        ppid,
+        real_uid: 1000,
+        cmdline: cmdline.to_owned(),
+    }
+}
+
+struct FakeProbe {
+    version: Option<String>,
+    allow_passthrough: Option<String>,
+    expected_session: String,
+    termnames: Option<Vec<String>>,
+    session_name: Option<String>,
+    processes: Vec<crate::proc::ProcInfo>,
+    daemon_record: Option<(u32, u32)>,
+    env: BTreeMap<String, String>,
+    passthrough_targets: RefCell<Vec<String>>,
+    passthrough_all_panes: RefCell<Vec<String>>,
+}
+
+impl FakeProbe {
+    fn ok() -> Self {
+        Self {
+            version: Some("tmux 3.6b".to_owned()),
+            allow_passthrough: Some("on".to_owned()),
+            expected_session: TEST_SESSION.to_owned(),
+            termnames: Some(vec!["xterm-ghostty".to_owned()]),
+            session_name: Some(TEST_SESSION.to_owned()),
+            processes: Vec::new(),
+            daemon_record: None,
+            env: BTreeMap::new(),
+            passthrough_targets: RefCell::new(Vec::new()),
+            passthrough_all_panes: RefCell::new(Vec::new()),
+        }
+    }
+
+    fn with_env(mut self, key: &str, value: &str) -> Self {
+        self.env.insert(key.to_owned(), value.to_owned());
+        self
+    }
+}
+
+impl Probe for FakeProbe {
+    fn tmux_version(&self) -> io::Result<String> {
+        self.version
+            .clone()
+            .ok_or_else(|| io::Error::other("tmux version unavailable"))
+    }
+
+    fn tmux_allow_passthrough(&self, target: &str) -> io::Result<String> {
+        self.passthrough_targets
+            .borrow_mut()
+            .push(target.to_owned());
+        self.allow_passthrough
+            .clone()
+            .ok_or_else(|| io::Error::other("tmux passthrough unavailable"))
+    }
+
+    fn tmux_set_pane_passthrough_all(&self, pane: &str) -> io::Result<()> {
+        self.passthrough_all_panes
+            .borrow_mut()
+            .push(pane.to_owned());
+        Ok(())
+    }
+
+    fn tmux_rendering_clients(&self, session_name: &str) -> io::Result<Vec<RenderingClient>> {
+        assert_eq!(session_name, self.expected_session);
+        self.termnames
+            .clone()
+            .map(|termnames| {
+                termnames
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, termname)| RenderingClient {
+                        termname,
+                        pid: 100 + index as u32,
+                    })
+                    .collect()
+            })
+            .ok_or_else(|| io::Error::other("tmux termnames unavailable"))
+    }
+
+    fn tmux_session_name(&self) -> io::Result<String> {
+        self.session_name
+            .clone()
+            .ok_or_else(|| io::Error::other("tmux session unavailable"))
+    }
+
+    fn processes(&self) -> Vec<crate::proc::ProcInfo> {
+        self.processes.clone()
+    }
+
+    fn pixel_daemon_record(&self) -> Option<(u32, u32)> {
+        self.daemon_record
+    }
+
+    fn env_var(&self, key: &str) -> Option<String> {
+        self.env.get(key).cloned()
+    }
+}
+
+#[test]
+fn tmux_passthrough_probe_targets_own_pane_then_session() {
+    let own_pane = FakeProbe::ok().with_env("TMUX_PANE", "%7");
+    detect_with(
+        MuxName::Tmux,
+        TEST_SESSION,
+        PixelRenderCaps::default(),
+        &own_pane,
+    );
+    assert_eq!(&*own_pane.passthrough_targets.borrow(), &["%7"]);
+
+    let session = FakeProbe::ok();
+    detect_with(
+        MuxName::Tmux,
+        TEST_SESSION,
+        PixelRenderCaps::default(),
+        &session,
+    );
+    assert_eq!(
+        &*session.passthrough_targets.borrow(),
+        &[TEST_SESSION.to_owned()]
+    );
+}
+
+#[test]
+fn tmux_sidebar_escalates_own_inherited_passthrough() {
+    let probe = FakeProbe::ok().with_env("TMUX_PANE", "%7");
+
+    escalate_with(&probe).expect("escalation");
+
+    assert_eq!(&*probe.passthrough_targets.borrow(), &["%7"]);
+    assert_eq!(&*probe.passthrough_all_panes.borrow(), &["%7"]);
+}
+
+#[test]
+fn tmux_sidebar_preserves_all_off_and_missing_pane() {
+    for allow_passthrough in ["all", "off"] {
+        let probe = FakeProbe {
+            allow_passthrough: Some(allow_passthrough.to_owned()),
+            ..FakeProbe::ok().with_env("TMUX_PANE", "%7")
+        };
+
+        escalate_with(&probe).expect("no-op");
+
+        assert_eq!(&*probe.passthrough_targets.borrow(), &["%7"]);
+        assert!(probe.passthrough_all_panes.borrow().is_empty());
+    }
+
+    let missing_pane = FakeProbe::ok();
+    escalate_with(&missing_pane).expect("no-op");
+    assert!(missing_pane.passthrough_targets.borrow().is_empty());
+    assert!(missing_pane.passthrough_all_panes.borrow().is_empty());
+}
+
+#[test]
+fn tmux_pixel_gate_requires_version_passthrough_and_allowed_termname() {
+    assert_eq!(
+        detect_with(
+            MuxName::Tmux,
+            TEST_SESSION,
+            PixelRenderCaps::default(),
+            &FakeProbe::ok()
+        ),
+        PixelRenderCaps {
+            pixel_transport: true,
+            kitty_clients: true,
+        }
+    );
+
+    assert_eq!(
+        detect_with(
+            MuxName::Zellij,
+            TEST_SESSION,
+            PixelRenderCaps::default(),
+            &FakeProbe::ok().with_env("TERM", "xterm-ghostty")
+        ),
+        PixelRenderCaps::default()
+    );
+
+    let old = FakeProbe {
+        version: Some("tmux 3.5a".to_owned()),
+        ..FakeProbe::ok()
+    };
+    assert_eq!(
+        detect_with(
+            MuxName::Tmux,
+            TEST_SESSION,
+            PixelRenderCaps::default(),
+            &old
+        ),
+        PixelRenderCaps {
+            pixel_transport: false,
+            kitty_clients: true,
+        }
+    );
+
+    let off = FakeProbe {
+        allow_passthrough: Some("off".to_owned()),
+        ..FakeProbe::ok()
+    };
+    assert_eq!(
+        detect_with(
+            MuxName::Tmux,
+            TEST_SESSION,
+            PixelRenderCaps::default(),
+            &off
+        ),
+        PixelRenderCaps {
+            pixel_transport: false,
+            kitty_clients: true,
+        }
+    );
+
+    let all = FakeProbe {
+        allow_passthrough: Some("all\n".to_owned()),
+        ..FakeProbe::ok()
+    };
+    assert_eq!(
+        detect_with(
+            MuxName::Tmux,
+            TEST_SESSION,
+            PixelRenderCaps::default(),
+            &all
+        ),
+        PixelRenderCaps {
+            pixel_transport: true,
+            kitty_clients: true,
+        }
+    );
+
+    let unsupported_term = FakeProbe {
+        termnames: Some(vec!["screen-256color".to_owned()]),
+        ..FakeProbe::ok()
+    };
+    assert_eq!(
+        detect_with(
+            MuxName::Tmux,
+            TEST_SESSION,
+            PixelRenderCaps::default(),
+            &unsupported_term
+        ),
+        PixelRenderCaps {
+            pixel_transport: true,
+            kitty_clients: false,
+        }
+    );
+
+    let unattached = FakeProbe {
+        termnames: Some(Vec::new()),
+        ..FakeProbe::ok()
+    };
+    assert_eq!(
+        detect_with(
+            MuxName::Tmux,
+            TEST_SESSION,
+            PixelRenderCaps::default(),
+            &unattached
+        ),
+        PixelRenderCaps {
+            pixel_transport: true,
+            kitty_clients: false,
+        }
+    );
+}
+
+#[test]
+fn tmux_probe_failures_keep_previous_fact_values() {
+    let prev = PixelRenderCaps {
+        pixel_transport: true,
+        kitty_clients: true,
+    };
+
+    let version_error = FakeProbe {
+        version: None,
+        termnames: Some(vec!["screen-256color".to_owned()]),
+        ..FakeProbe::ok()
+    };
+    assert_eq!(
+        detect_with(MuxName::Tmux, TEST_SESSION, prev, &version_error),
+        PixelRenderCaps {
+            pixel_transport: true,
+            kitty_clients: false,
+        }
+    );
+
+    let passthrough_error = FakeProbe {
+        allow_passthrough: None,
+        ..FakeProbe::ok()
+    };
+    assert_eq!(
+        detect_with(MuxName::Tmux, TEST_SESSION, prev, &passthrough_error),
+        prev
+    );
+
+    let term_error = FakeProbe {
+        termnames: None,
+        allow_passthrough: Some("off".to_owned()),
+        ..FakeProbe::ok()
+    };
+    assert_eq!(
+        detect_with(MuxName::Tmux, TEST_SESSION, prev, &term_error),
+        PixelRenderCaps {
+            pixel_transport: false,
+            kitty_clients: true,
+        }
+    );
+}
+
+#[test]
+fn tmux_empty_rendering_client_list_keeps_previous_kitty_fact() {
+    let prev = PixelRenderCaps {
+        pixel_transport: false,
+        kitty_clients: true,
+    };
+    let unattached = FakeProbe {
+        termnames: Some(Vec::new()),
+        ..FakeProbe::ok()
+    };
+
+    assert_eq!(
+        detect_with(MuxName::Tmux, TEST_SESSION, prev, &unattached),
+        PixelRenderCaps {
+            pixel_transport: true,
+            kitty_clients: true,
+        }
+    );
+}
+
+#[test]
+fn tmux_successful_probe_overrides_previous_facts() {
+    let prev = PixelRenderCaps {
+        pixel_transport: true,
+        kitty_clients: true,
+    };
+    let unsupported = FakeProbe {
+        version: Some("tmux 3.5a".to_owned()),
+        allow_passthrough: Some("off".to_owned()),
+        termnames: Some(vec!["screen-256color".to_owned()]),
+        ..FakeProbe::ok()
+    };
+
+    assert_eq!(
+        detect_with(MuxName::Tmux, TEST_SESSION, prev, &unsupported),
+        PixelRenderCaps::default()
+    );
+    assert_eq!(
+        detect_with(
+            MuxName::Tmux,
+            TEST_SESSION,
+            PixelRenderCaps::default(),
+            &FakeProbe::ok()
+        ),
+        PixelRenderCaps {
+            pixel_transport: true,
+            kitty_clients: true,
+        }
+    );
+}
+
+#[test]
+fn termname_gate_filters_control_clients_and_requires_all_to_match() {
+    for termname in [
+        "xterm-ghostty",
+        "ghostty",
+        "xterm-kitty",
+        "kitty",
+        "XTERM-KITTY",
+    ] {
+        let probe = FakeProbe {
+            termnames: Some(vec![termname.to_owned()]),
+            ..FakeProbe::ok()
+        };
+
+        assert!(
+            detect_with(
+                MuxName::Tmux,
+                TEST_SESSION,
+                PixelRenderCaps::default(),
+                &probe
+            )
+            .kitty_clients,
+            "{termname} should enable pixels"
+        );
+    }
+
+    let allowed = FakeProbe {
+        termnames: Some(vec!["xterm-ghostty".to_owned(), "kitty".to_owned()]),
+        ..FakeProbe::ok()
+    };
+    assert!(
+        detect_with(
+            MuxName::Tmux,
+            TEST_SESSION,
+            PixelRenderCaps::default(),
+            &allowed
+        )
+        .kitty_clients
+    );
+
+    let mixed = FakeProbe {
+        termnames: Some(vec![
+            "xterm-ghostty".to_owned(),
+            "screen-256color".to_owned(),
+        ]),
+        ..FakeProbe::ok()
+    };
+    assert!(
+        !detect_with(
+            MuxName::Tmux,
+            TEST_SESSION,
+            PixelRenderCaps::default(),
+            &mixed
+        )
+        .kitty_clients
+    );
+
+    assert_eq!(
+        rendering_clients("0 xterm-ghostty 42\n1 tmux-256color 7"),
+        vec![RenderingClient {
+            termname: "xterm-ghostty".to_owned(),
+            pid: 42,
+        }]
+    );
+
+    let probe = FakeProbe {
+        termnames: Some(vec!["xterm-ghostty".to_owned()]),
+        ..FakeProbe::ok()
+    };
+    assert!(
+        detect_with(
+            MuxName::Tmux,
+            TEST_SESSION,
+            PixelRenderCaps::default(),
+            &probe
+        )
+        .kitty_clients
+    );
+}
+
+#[test]
+fn ttyd_descendant_client_requires_live_matching_protocol_daemon() {
+    let capable = FakeProbe {
+        termnames: Some(vec!["xterm-256color".to_owned()]),
+        processes: vec![
+            process(10, 1, "/usr/bin/ttyd -p 8200"),
+            process(100, 10, "tmux attach -t rimz-test"),
+        ],
+        daemon_record: Some((10, crate::web::TTYD_PIXEL_PROTOCOL)),
+        ..FakeProbe::ok()
+    };
+    assert!(
+        detect_with(
+            MuxName::Tmux,
+            TEST_SESSION,
+            PixelRenderCaps::default(),
+            &capable,
+        )
+        .kitty_clients
+    );
+
+    for rejected in [
+        FakeProbe {
+            termnames: Some(vec!["xterm-256color".to_owned()]),
+            processes: capable.processes.clone(),
+            daemon_record: None,
+            ..FakeProbe::ok()
+        },
+        FakeProbe {
+            termnames: Some(vec!["xterm-256color".to_owned()]),
+            processes: capable.processes.clone(),
+            daemon_record: Some((10, crate::web::TTYD_PIXEL_PROTOCOL + 1)),
+            ..FakeProbe::ok()
+        },
+        FakeProbe {
+            termnames: Some(vec!["xterm-256color".to_owned()]),
+            processes: vec![process(100, 10, "tmux attach -t rimz-test")],
+            daemon_record: Some((10, crate::web::TTYD_PIXEL_PROTOCOL)),
+            ..FakeProbe::ok()
+        },
+        FakeProbe {
+            termnames: Some(vec!["xterm-256color".to_owned()]),
+            processes: vec![
+                process(10, 1, "sleep 60"),
+                process(100, 10, "tmux attach -t rimz-test"),
+            ],
+            daemon_record: Some((10, crate::web::TTYD_PIXEL_PROTOCOL)),
+            ..FakeProbe::ok()
+        },
+    ] {
+        assert!(
+            !detect_with(
+                MuxName::Tmux,
+                TEST_SESSION,
+                PixelRenderCaps::default(),
+                &rejected,
+            )
+            .kitty_clients
+        );
+    }
+}
+
+#[test]
+fn ttyd_ancestry_walk_is_bounded_to_four_hops() {
+    let probe = FakeProbe {
+        termnames: Some(vec!["xterm-256color".to_owned()]),
+        processes: vec![
+            process(10, 1, "ttyd -p 8200"),
+            process(100, 20, "tmux attach"),
+            process(20, 21, "rimz web exec"),
+            process(21, 22, "sh"),
+            process(22, 23, "sh"),
+            process(23, 10, "sh"),
+        ],
+        daemon_record: Some((10, crate::web::TTYD_PIXEL_PROTOCOL)),
+        ..FakeProbe::ok()
+    };
+
+    assert!(
+        !detect_with(
+            MuxName::Tmux,
+            TEST_SESSION,
+            PixelRenderCaps::default(),
+            &probe,
+        )
+        .kitty_clients
+    );
+}
+
+#[test]
+fn native_and_ttyd_clients_share_the_all_clients_gate() {
+    let capable = FakeProbe {
+        termnames: Some(vec!["kitty".to_owned(), "xterm-256color".to_owned()]),
+        processes: vec![
+            process(10, 1, "ttyd -p 8200"),
+            process(101, 10, "tmux attach"),
+        ],
+        daemon_record: Some((10, crate::web::TTYD_PIXEL_PROTOCOL)),
+        ..FakeProbe::ok()
+    };
+    assert!(
+        detect_with(
+            MuxName::Tmux,
+            TEST_SESSION,
+            PixelRenderCaps::default(),
+            &capable,
+        )
+        .kitty_clients
+    );
+
+    let foreign = FakeProbe {
+        termnames: Some(vec![
+            "kitty".to_owned(),
+            "xterm-256color".to_owned(),
+            "screen-256color".to_owned(),
+        ]),
+        processes: capable.processes.clone(),
+        daemon_record: capable.daemon_record,
+        ..FakeProbe::ok()
+    };
+    assert!(
+        !detect_with(
+            MuxName::Tmux,
+            TEST_SESSION,
+            PixelRenderCaps::default(),
+            &foreign,
+        )
+        .kitty_clients
+    );
+}
+
+#[test]
+fn standalone_env_detects_native_kitty_and_wrap_mode() {
+    let plain = FakeProbe::ok().with_env("TERM", "xterm-kitty");
+    assert_eq!(
+        detect_env_with(&plain),
+        (
+            PixelRenderCaps {
+                pixel_transport: true,
+                kitty_clients: true,
+            },
+            false
+        )
+    );
+
+    let tmux = FakeProbe::ok()
+        .with_env("TMUX", "/tmp/tmux-1000/default,123,0")
+        .with_env("TERM", "screen-256color");
+    assert_eq!(
+        detect_env_with(&tmux),
+        (
+            PixelRenderCaps {
+                pixel_transport: true,
+                kitty_clients: true,
+            },
+            true
+        )
+    );
+
+    let zellij = FakeProbe::ok()
+        .with_env("ZELLIJ", "1")
+        .with_env("TERM", "xterm-kitty");
+    assert_eq!(
+        detect_env_with(&zellij),
+        (PixelRenderCaps::default(), false)
+    );
+
+    let unsupported = FakeProbe::ok().with_env("TERM", "xterm-256color");
+    assert_eq!(
+        detect_env_with(&unsupported),
+        (
+            PixelRenderCaps {
+                pixel_transport: true,
+                kitty_clients: false,
+            },
+            false
+        )
+    );
+}

--- a/crates/rimz/src/web/mod.rs
+++ b/crates/rimz/src/web/mod.rs
@@ -18,6 +18,11 @@ mod gate;
 mod ttyd;
 
 pub const WEB_SCHEMA_VERSION: &str = "rimz.web.v2";
+pub(crate) const TTYD_PIXEL_PROTOCOL: u32 = 1;
+
+pub(crate) fn pixel_daemon_record() -> Option<(u32, u32)> {
+    ttyd::pixel_daemon_record()
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum WebErr {

--- a/crates/rimz/src/web/mod.rs
+++ b/crates/rimz/src/web/mod.rs
@@ -18,7 +18,7 @@ mod gate;
 mod ttyd;
 
 pub const WEB_SCHEMA_VERSION: &str = "rimz.web.v2";
-pub(crate) const TTYD_PIXEL_PROTOCOL: u32 = 1;
+pub(crate) const TTYD_PIXEL_PROTOCOL: u32 = 2;
 
 pub(crate) fn pixel_daemon_record() -> Option<(u32, u32)> {
     ttyd::pixel_daemon_record()

--- a/crates/rimz/src/web/ttyd.rs
+++ b/crates/rimz/src/web/ttyd.rs
@@ -46,6 +46,8 @@ pub(super) struct DaemonRecord {
     pub(super) trusted_proxies: Vec<String>,
     #[serde(default)]
     pub(super) gate: Option<GateRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) pixel_protocol: Option<u32>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -63,6 +65,7 @@ impl DaemonRecord {
             auth: WebAuth::Basic,
             trusted_proxies: Vec::new(),
             gate: None,
+            pixel_protocol: None,
         }
     }
 }
@@ -481,6 +484,7 @@ fn start_daemon_with_profile(
         auth: desired.auth.clone(),
         trusted_proxies: desired.trusted_proxies.clone(),
         gate,
+        pixel_protocol: profile.pixel_protocol,
     };
     let public_address = record_public_address(&record)?;
     if !wait_for_address(public_address, START_TIMEOUT) {
@@ -558,6 +562,12 @@ pub(super) fn revoke_credential() -> Result<bool> {
 pub(super) fn daemon_status() -> Result<Option<DaemonRecord>> {
     let _guard = acquire_daemon_lock()?;
     daemon_status_locked()
+}
+
+pub(crate) fn pixel_daemon_record() -> Option<(u32, u32)> {
+    let bytes = fs::read(daemon_path()).ok()?;
+    let record = serde_json::from_slice::<DaemonRecord>(&bytes).ok()?;
+    record.pixel_protocol.map(|protocol| (record.pid, protocol))
 }
 
 fn daemon_status_locked() -> Result<Option<DaemonRecord>> {
@@ -1026,6 +1036,7 @@ mod tests {
                 pid: u32::MAX - 1,
                 upstream_port: 41820,
             }),
+            pixel_protocol: Some(crate::web::TTYD_PIXEL_PROTOCOL),
         };
         write_daemon_at(&path, &daemon).expect("write daemon state");
         assert_eq!(read_json_optional(&path).expect("read state"), Some(daemon));
@@ -1069,6 +1080,16 @@ mod tests {
             auth_warnings(&spec).as_slice(),
             [WebWarning::HeaderAuthUnprotected(message)] if message.contains("trusted_proxies")
         ));
+    }
+
+    #[test]
+    fn pre_pixel_daemon_state_deserializes_without_protocol() {
+        let daemon = serde_json::from_str::<DaemonRecord>(r#"{"pid":42,"port":8200}"#)
+            .expect("legacy daemon state");
+
+        assert_eq!(daemon.pid, 42);
+        assert_eq!(daemon.port, 8200);
+        assert_eq!(daemon.pixel_protocol, None);
     }
 
     #[test]

--- a/crates/rimz/src/web/ttyd.rs
+++ b/crates/rimz/src/web/ttyd.rs
@@ -299,6 +299,9 @@ fn record_matches(record: &DaemonRecord, desired: &DaemonSpec) -> bool {
         && record.auth == desired.auth
         && record.trusted_proxies == desired.trusted_proxies
         && record.gate.is_some() == !desired.trusted_proxies.is_empty()
+        && record
+            .pixel_protocol
+            .is_none_or(|protocol| protocol == crate::web::TTYD_PIXEL_PROTOCOL)
 }
 
 fn auth_warnings(desired: &DaemonSpec) -> Vec<WebWarning> {
@@ -1090,6 +1093,19 @@ mod tests {
         assert_eq!(daemon.pid, 42);
         assert_eq!(daemon.port, 8200);
         assert_eq!(daemon.pixel_protocol, None);
+    }
+
+    #[test]
+    fn daemon_reuse_requires_the_current_pixel_protocol() {
+        let config = MachineConfig::default();
+        let desired = desired_spec(&config).expect("desired daemon");
+        let mut daemon = DaemonRecord::basic_loopback(42, config.web.port);
+
+        assert!(record_matches(&daemon, &desired));
+        daemon.pixel_protocol = Some(crate::web::TTYD_PIXEL_PROTOCOL);
+        assert!(record_matches(&daemon, &desired));
+        daemon.pixel_protocol = Some(crate::web::TTYD_PIXEL_PROTOCOL - 1);
+        assert!(!record_matches(&daemon, &desired));
     }
 
     #[test]

--- a/crates/rimz/src/web/ttyd/client.rs
+++ b/crates/rimz/src/web/ttyd/client.rs
@@ -18,6 +18,7 @@ use super::{
     DaemonRecord, START_TIMEOUT, choose_ephemeral_port, random_secret, spawn_detached,
     terminate_record, version_at, wait_for_port,
 };
+use crate::sidebar_pane::pixel::{PLACEHOLDER, ROW_COLUMN_DIACRITICS};
 use crate::web::WebWarning;
 
 const STOCK_INDEX_TIMEOUT: Duration = Duration::from_secs(5);
@@ -34,6 +35,7 @@ const MAX_FONT_BYTES: u64 = 16 * 1024 * 1024;
 pub(super) struct ClientProfile {
     pub(super) args: Vec<String>,
     pub(super) warnings: Vec<WebWarning>,
+    pub(super) pixel_protocol: Option<u32>,
 }
 
 pub(super) fn profile(config: &MachineConfig, ttyd_program: &Path) -> ClientProfile {
@@ -45,6 +47,7 @@ pub(super) fn profile(config: &MachineConfig, ttyd_program: &Path) -> ClientProf
             "cursorBlink=false".to_owned(),
         ],
         warnings: Vec::new(),
+        pixel_protocol: None,
     };
     if !config.web.enabled {
         return profile;
@@ -89,16 +92,23 @@ pub(super) fn profile(config: &MachineConfig, ttyd_program: &Path) -> ClientProf
     let index = version_at(ttyd_program)
         .map_err(|err| err.to_string())
         .and_then(|version| ensure_custom_index(ttyd_program, &version, font_family, &font_faces));
+    apply_custom_index(&mut profile, index);
+    profile
+}
+
+fn apply_custom_index(profile: &mut ClientProfile, index: Result<Option<PathBuf>, String>) {
     match index {
-        Ok(Some(path)) => profile
-            .args
-            .extend(["-I".to_owned(), path.display().to_string()]),
+        Ok(Some(path)) => {
+            profile
+                .args
+                .extend(["-I".to_owned(), path.display().to_string()]);
+            profile.pixel_protocol = Some(crate::web::TTYD_PIXEL_PROTOCOL);
+        }
         Ok(None) => profile.warnings.push(WebWarning::BrowserClientSkipped(
             "stock ttyd index has no </head> or </body> marker".to_owned(),
         )),
         Err(err) => profile.warnings.push(WebWarning::BrowserClientSkipped(err)),
     }
-    profile
 }
 
 fn ensure_custom_index(
@@ -177,8 +187,17 @@ fn get_stock_index(port: u16, secret: &str) -> Result<String, String> {
 }
 
 fn custom_index_key(ttyd_version: &str, family: Option<&str>, faces: &[FontFace]) -> String {
+    custom_index_key_with_schema(CUSTOM_INDEX_SCHEMA, ttyd_version, family, faces)
+}
+
+fn custom_index_key_with_schema(
+    schema: &str,
+    ttyd_version: &str,
+    family: Option<&str>,
+    faces: &[FontFace],
+) -> String {
     let mut hasher = Sha256::new();
-    hash_index_part(&mut hasher, CUSTOM_INDEX_SCHEMA.as_bytes());
+    hash_index_part(&mut hasher, schema.as_bytes());
     hash_index_part(&mut hasher, ttyd_version.as_bytes());
     hash_index_part(&mut hasher, family.unwrap_or_default().as_bytes());
     for face in faces {
@@ -233,10 +252,23 @@ fn inject_client_profile(stock: &str, family: Option<&str>, faces: &[FontFace]) 
 
 fn client_bootstrap(family: Option<&str>) -> String {
     let family = family.map_or_else(|| "null".to_owned(), js_string);
+    let diacritics = ROW_COLUMN_DIACRITICS
+        .iter()
+        .map(char::to_string)
+        .collect::<Vec<_>>();
+    let diacritics = serde_json::to_string(&diacritics)
+        .expect("serializing the static pixel diacritic table cannot fail");
+    let pixel_layer = include_str!("pixel_layer.js");
+    let pixel_protocol = crate::web::TTYD_PIXEL_PROTOCOL;
+    let placeholder = u32::from(PLACEHOLDER);
     format!(
         r#"<script id="rimz-web-client">(()=>{{
 "use strict";
 const fontFamily={family};
+const RIMZ_PIXEL_PROTOCOL={pixel_protocol};
+const RIMZ_PIXEL_PLACEHOLDER={placeholder};
+const RIMZ_PIXEL_DIACRITICS={diacritics};
+{pixel_layer}
 const waitForTerminal=()=>new Promise(resolve=>{{
   let attempts=0;
   const find=()=>{{
@@ -249,6 +281,7 @@ const loadFont=fontFamily&&document.fonts
   ?Promise.all([400,700].map(weight=>document.fonts.load(`${{weight}} 13px ${{JSON.stringify(fontFamily)}}`))).catch(()=>{{}})
   :Promise.resolve();
 waitForTerminal().then(term=>{{
+  installPixelLayer(term);
   const sendInput=data=>{{
     if(typeof term.input==="function"){{term.input(data,true);return true;}}
     const core=term._core&&term._core.coreService;
@@ -819,6 +852,7 @@ mod tests {
             ["-t", "macOptionIsMeta=true", "-t", "cursorBlink=false"]
         );
         assert!(profile.warnings.is_empty());
+        assert_eq!(profile.pixel_protocol, None);
     }
 
     #[test]
@@ -828,7 +862,41 @@ mod tests {
         assert!(rendered.contains("rimz-web-client"));
         assert!(rendered.contains("term.options.cursorBlink=false"));
         assert!(rendered.contains("registerCsiHandler({intermediates:\" \",final:\"q\"}"));
+        assert!(rendered.contains("const installPixelLayer=term=>"));
+        assert!(rendered.contains("installPixelLayer(term)"));
+        assert!(rendered.contains("const RIMZ_PIXEL_PLACEHOLDER=1109742"));
+        assert!(rendered.contains("const RIMZ_PIXEL_DIACRITICS=[\"̅\",\"̍\",\"̎\""));
         assert!(!rendered.contains("@font-face"));
+    }
+
+    #[test]
+    fn pixel_protocol_requires_a_generated_custom_index() {
+        let base = || ClientProfile {
+            args: Vec::new(),
+            warnings: Vec::new(),
+            pixel_protocol: None,
+        };
+
+        let mut capable = base();
+        apply_custom_index(&mut capable, Ok(Some(PathBuf::from("/cache/index.html"))));
+        assert_eq!(
+            capable.args,
+            ["-I".to_owned(), "/cache/index.html".to_owned()]
+        );
+        assert_eq!(
+            capable.pixel_protocol,
+            Some(crate::web::TTYD_PIXEL_PROTOCOL)
+        );
+
+        let mut markerless = base();
+        apply_custom_index(&mut markerless, Ok(None));
+        assert_eq!(markerless.pixel_protocol, None);
+        assert_eq!(markerless.warnings.len(), 1);
+
+        let mut failed = base();
+        apply_custom_index(&mut failed, Err("fetch failed".to_owned()));
+        assert_eq!(failed.pixel_protocol, None);
+        assert_eq!(failed.warnings.len(), 1);
     }
 
     #[test]
@@ -844,6 +912,10 @@ mod tests {
         assert_eq!(key, custom_index_key("ttyd 1.7.7", Some(family), &faces));
         assert_ne!(key, custom_index_key("ttyd 1.7.8", Some(family), &faces));
         assert_ne!(key, custom_index_key("ttyd 1.7.7", None, &faces));
+        assert_ne!(
+            key,
+            custom_index_key_with_schema("rimz.ttyd-index.v3", "ttyd 1.7.7", Some(family), &faces)
+        );
 
         let rendered = inject_client_profile(
             "<html><head><title>ttyd</title></head><body></body></html>",

--- a/crates/rimz/src/web/ttyd/client.rs
+++ b/crates/rimz/src/web/ttyd/client.rs
@@ -24,7 +24,7 @@ use crate::web::WebWarning;
 const STOCK_INDEX_TIMEOUT: Duration = Duration::from_secs(5);
 const STOCK_INDEX_MAX_BYTES: u64 = 16 * 1024 * 1024;
 const INDEX_CACHE_DIR: &str = "rimz/web-ttyd";
-const CUSTOM_INDEX_SCHEMA: &str = "rimz.ttyd-index.v4";
+const CUSTOM_INDEX_SCHEMA: &str = "rimz.ttyd-index.v5";
 
 const OFFLINE_ENV: &str = "RIMZ_WEB_FONTS_OFFLINE";
 const FONT_CACHE_DIR: &str = "rimz/web-fonts";
@@ -866,6 +866,9 @@ mod tests {
         assert!(rendered.contains("installPixelLayer(term)"));
         assert!(rendered.contains("const RIMZ_PIXEL_PLACEHOLDER=1109742"));
         assert!(rendered.contains("const RIMZ_PIXEL_DIACRITICS=[\"̅\",\"̍\",\"̎\""));
+        assert!(rendered.contains("const PLACEHOLDER_OVERHANG_COLS=3"));
+        assert!(rendered.contains("const fittedImageRect="));
+        assert!(rendered.contains("if(placement.rows>1)"));
         assert!(!rendered.contains("@font-face"));
     }
 
@@ -907,14 +910,14 @@ mod tests {
             weight: 400,
         }];
         let family = "RimZ \"Font\" </style></script>\n";
-        assert_eq!(CUSTOM_INDEX_SCHEMA, "rimz.ttyd-index.v4");
+        assert_eq!(CUSTOM_INDEX_SCHEMA, "rimz.ttyd-index.v5");
         let key = custom_index_key("ttyd 1.7.7", Some(family), &faces);
         assert_eq!(key, custom_index_key("ttyd 1.7.7", Some(family), &faces));
         assert_ne!(key, custom_index_key("ttyd 1.7.8", Some(family), &faces));
         assert_ne!(key, custom_index_key("ttyd 1.7.7", None, &faces));
         assert_ne!(
             key,
-            custom_index_key_with_schema("rimz.ttyd-index.v3", "ttyd 1.7.7", Some(family), &faces)
+            custom_index_key_with_schema("rimz.ttyd-index.v4", "ttyd 1.7.7", Some(family), &faces)
         );
 
         let rendered = inject_client_profile(

--- a/crates/rimz/src/web/ttyd/pixel_layer.js
+++ b/crates/rimz/src/web/ttyd/pixel_layer.js
@@ -1,0 +1,272 @@
+const installPixelLayer=term=>{
+  const screen=term.element.querySelector(".xterm-screen");
+  if(!screen||typeof createImageBitmap!=="function")return;
+  const ESC=0x1b;
+  const MAX_APC_BYTES=8*1024*1024;
+  const MAX_IMAGE_BYTES=4*1024*1024;
+  const MAX_IMAGES=128;
+  const encoder=new TextEncoder();
+  const decoder=new TextDecoder();
+  const diacriticIndexes=new Map(RIMZ_PIXEL_DIACRITICS.map((value,index)=>[value.codePointAt(0),index]));
+  const images=new Map();
+  const placements=new Map();
+  const pendingDecodes=new Map();
+  let transfer=null;
+  let decodeToken=0;
+  let carry=new Uint8Array();
+  let dropping=false;
+  let dropSawEscape=false;
+
+  const canvas=document.createElement("canvas");
+  canvas.className="rimz-pixel-layer";
+  canvas.dataset.rimzPixelProtocol=String(RIMZ_PIXEL_PROTOCOL);
+  canvas.style.cssText="position:absolute;inset:0;pointer-events:none;z-index:10";
+  if(getComputedStyle(screen).position==="static")screen.style.position="relative";
+  screen.append(canvas);
+  const context=canvas.getContext("2d");
+  if(!context){canvas.remove();return;}
+  context.imageSmoothingEnabled=false;
+
+  const closeBitmap=bitmap=>{try{bitmap.close();}catch(_){}};
+  const clearCanvas=()=>{
+    const dpr=window.devicePixelRatio||1;
+    context.setTransform(dpr,0,0,dpr,0,0);
+    context.clearRect(0,0,canvas.width/dpr,canvas.height/dpr);
+  };
+  const resizeCanvas=()=>{
+    const rect=screen.getBoundingClientRect();
+    const dpr=window.devicePixelRatio||1;
+    const width=Math.max(1,Math.round(rect.width*dpr));
+    const height=Math.max(1,Math.round(rect.height*dpr));
+    if(canvas.width!==width||canvas.height!==height){
+      canvas.width=width;
+      canvas.height=height;
+      canvas.style.width=`${rect.width}px`;
+      canvas.style.height=`${rect.height}px`;
+    }
+    context.setTransform(dpr,0,0,dpr,0,0);
+    context.imageSmoothingEnabled=false;
+    return rect;
+  };
+  const deleteImage=id=>{
+    pendingDecodes.delete(id);
+    const image=images.get(id);
+    if(image)closeBitmap(image);
+    images.delete(id);
+    placements.delete(id);
+  };
+  const clearImages=()=>{
+    pendingDecodes.clear();
+    for(const image of images.values())closeBitmap(image);
+    images.clear();
+    placements.clear();
+    transfer=null;
+    clearCanvas();
+  };
+  const evictOldest=(map,onEvict)=>{
+    while(map.size>=MAX_IMAGES){
+      const oldest=map.keys().next().value;
+      const value=map.get(oldest);
+      map.delete(oldest);
+      onEvict(oldest,value);
+    }
+  };
+  const retainImage=(id,bitmap)=>{
+    const previous=images.get(id);
+    if(previous){
+      images.delete(id);
+      closeBitmap(previous);
+    }else{
+      evictOldest(images,(_id,image)=>closeBitmap(image));
+    }
+    images.set(id,bitmap);
+    scheduleDraw();
+  };
+  const decodeImage=(id,payload)=>{
+    if(pendingDecodes.has(id)||pendingDecodes.size>=MAX_IMAGES)return;
+    let binary;
+    try{binary=atob(payload);}catch(_){return;}
+    const bytes=new Uint8Array(binary.length);
+    for(let index=0;index<binary.length;index++)bytes[index]=binary.charCodeAt(index);
+    const token=++decodeToken;
+    pendingDecodes.set(id,token);
+    createImageBitmap(new Blob([bytes],{type:"image/png"})).then(bitmap=>{
+      if(pendingDecodes.get(id)!==token){closeBitmap(bitmap);return;}
+      pendingDecodes.delete(id);
+      retainImage(id,bitmap);
+    }).catch(()=>{
+      if(pendingDecodes.get(id)===token)pendingDecodes.delete(id);
+    });
+  };
+  const integer=value=>typeof value==="string"&&/^\d+$/.test(value)?Number(value):null;
+  const parseControl=value=>{
+    const fields={};
+    for(const part of value.split(",")){
+      const split=part.indexOf("=");
+      if(split>0)fields[part.slice(0,split)]=part.slice(split+1);
+    }
+    return fields;
+  };
+  const rememberPlacement=(id,cols,rows)=>{
+    if(!placements.has(id))evictOldest(placements,()=>{});
+    else placements.delete(id);
+    placements.set(id,{cols,rows});
+    scheduleDraw();
+  };
+  const handleApc=bytes=>{
+    const separator=bytes.indexOf(0x3b);
+    if(separator<0)return;
+    const fields=parseControl(decoder.decode(bytes.subarray(0,separator)));
+    const payload=decoder.decode(bytes.subarray(separator+1));
+    if(fields.a==="t"){
+      transfer=null;
+      const id=integer(fields.i);
+      if(fields.f!=="100"||id===null||id<1||id>0xffffff||payload.length>MAX_IMAGE_BYTES)return;
+      transfer={id,chunks:[payload],size:payload.length};
+      if(fields.m!=="1"){
+        decodeImage(id,payload);
+        transfer=null;
+      }
+      return;
+    }
+    if(fields.a===undefined&&transfer){
+      if(transfer.size+payload.length>MAX_IMAGE_BYTES){transfer=null;return;}
+      transfer.chunks.push(payload);
+      transfer.size+=payload.length;
+      if(fields.m!=="1"){
+        decodeImage(transfer.id,transfer.chunks.join(""));
+        transfer=null;
+      }
+      return;
+    }
+    transfer=null;
+    if(fields.a==="p"&&fields.U==="1"){
+      const id=integer(fields.i);
+      const cols=integer(fields.c);
+      const rows=integer(fields.r);
+      if(id!==null&&id>0&&id<=0xffffff&&cols!==null&&cols>0&&cols<=RIMZ_PIXEL_DIACRITICS.length&&rows!==null&&rows>0&&rows<=RIMZ_PIXEL_DIACRITICS.length){
+        rememberPlacement(id,cols,rows);
+      }
+    }else if(fields.a==="d"&&fields.d==="i"){
+      const id=integer(fields.i);
+      if(id!==null)deleteImage(id);
+      scheduleDraw();
+    }
+  };
+  const joinBytes=parts=>{
+    const length=parts.reduce((sum,part)=>sum+part.length,0);
+    const joined=new Uint8Array(length);
+    let offset=0;
+    for(const part of parts){joined.set(part,offset);offset+=part.length;}
+    return joined;
+  };
+  const scan=chunk=>{
+    let input=carry.length?joinBytes([carry,chunk]):chunk;
+    carry=new Uint8Array();
+    let offset=0;
+    if(dropping){
+      if(dropSawEscape&&input[0]===0x5c){
+        dropping=false;
+        dropSawEscape=false;
+        offset=1;
+      }else{
+        let end=-1;
+        for(let index=0;index+1<input.length;index++)if(input[index]===ESC&&input[index+1]===0x5c){end=index;break;}
+        if(end<0){dropSawEscape=input[input.length-1]===ESC;return new Uint8Array();}
+        dropping=false;
+        dropSawEscape=false;
+        offset=end+2;
+      }
+    }
+    const output=[];
+    while(offset<input.length){
+      let start=-1;
+      for(let index=offset;index+2<input.length;index++){
+        if(input[index]===ESC&&input[index+1]===0x5f&&input[index+2]===0x47){start=index;break;}
+      }
+      if(start<0){
+        let keep=0;
+        if(input[input.length-1]===ESC)keep=1;
+        else if(input.length>=2&&input[input.length-2]===ESC&&input[input.length-1]===0x5f)keep=2;
+        if(input.length-keep>offset)output.push(input.subarray(offset,input.length-keep));
+        if(keep)carry=input.slice(input.length-keep);
+        break;
+      }
+      if(start>offset)output.push(input.subarray(offset,start));
+      let end=-1;
+      for(let index=start+3;index+1<input.length;index++)if(input[index]===ESC&&input[index+1]===0x5c){end=index;break;}
+      if(end<0){
+        carry=input.slice(start);
+        if(carry.length>MAX_APC_BYTES){carry=new Uint8Array();dropping=true;dropSawEscape=false;}
+        break;
+      }
+      handleApc(input.subarray(start+3,end));
+      offset=end+2;
+    }
+    return joinBytes(output);
+  };
+
+  const cellSize=rect=>{
+    const dimensions=term._core&&term._core._renderService&&term._core._renderService.dimensions;
+    const cell=dimensions&&dimensions.css&&dimensions.css.cell;
+    return {
+      width:cell&&cell.width||rect.width/Math.max(1,term.cols),
+      height:cell&&cell.height||rect.height/Math.max(1,term.rows),
+    };
+  };
+  const draw=()=>{
+    const rect=resizeCanvas();
+    context.clearRect(0,0,rect.width,rect.height);
+    const size=cellSize(rect);
+    const buffer=term.buffer.active;
+    const viewport=buffer.viewportY;
+    const theme=term.options.theme||{};
+    const viewportElement=term.element.querySelector(".xterm-viewport");
+    const background=theme.background||(viewportElement&&getComputedStyle(viewportElement).backgroundColor)||"#000";
+    for(let row=0;row<term.rows;row++){
+      const line=buffer.getLine(viewport+row);
+      if(!line)continue;
+      for(let col=0;col<Math.min(term.cols,line.length);col++){
+        const cell=line.getCell(col);
+        if(!cell)continue;
+        const chars=Array.from(cell.getChars());
+        if(chars.length<3||chars[0].codePointAt(0)!==RIMZ_PIXEL_PLACEHOLDER)continue;
+        const sourceRow=diacriticIndexes.get(chars[1].codePointAt(0));
+        const sourceCol=diacriticIndexes.get(chars[2].codePointAt(0));
+        const x=col*size.width;
+        const y=row*size.height;
+        context.fillStyle=background;
+        context.fillRect(x,y,size.width,size.height);
+        const id=cell.getFgColor()&0xffffff;
+        const placement=placements.get(id);
+        const image=images.get(id);
+        if(!placement||!image||sourceRow===undefined||sourceCol===undefined||sourceRow>=placement.rows||sourceCol>=placement.cols)continue;
+        const sourceWidth=image.width/placement.cols;
+        const sourceHeight=image.height/placement.rows;
+        context.drawImage(image,sourceCol*sourceWidth,sourceRow*sourceHeight,sourceWidth,sourceHeight,x,y,size.width,size.height);
+      }
+    }
+  };
+  let drawQueued=false;
+  function scheduleDraw(){
+    if(drawQueued)return;
+    drawQueued=true;
+    window.requestAnimationFrame(()=>{drawQueued=false;draw();});
+  }
+
+  const write=term.write.bind(term);
+  term.write=(data,callback)=>{
+    const bytes=typeof data==="string"?encoder.encode(data):data;
+    if(!(bytes instanceof Uint8Array))return write(data,callback);
+    const forwarded=scan(bytes);
+    if(forwarded.length)return write(forwarded,callback);
+    if(typeof callback==="function")queueMicrotask(callback);
+  };
+  term.onRender(scheduleDraw);
+  term.onScroll(scheduleDraw);
+  term.onResize(()=>{clearCanvas();scheduleDraw();});
+  new ResizeObserver(()=>{clearCanvas();scheduleDraw();}).observe(screen);
+  const reset=term.reset.bind(term);
+  term.reset=(...args)=>{clearImages();const result=reset(...args);scheduleDraw();return result;};
+  scheduleDraw();
+};

--- a/crates/rimz/src/web/ttyd/pixel_layer.js
+++ b/crates/rimz/src/web/ttyd/pixel_layer.js
@@ -5,6 +5,9 @@ const installPixelLayer=term=>{
   const MAX_APC_BYTES=8*1024*1024;
   const MAX_IMAGE_BYTES=4*1024*1024;
   const MAX_IMAGES=128;
+  // xterm advances the Kitty placeholder by one cell, while browser fallback
+  // fonts can rasterize its noncharacter plus two diacritics across three more.
+  const PLACEHOLDER_OVERHANG_COLS=3;
   const encoder=new TextEncoder();
   const decoder=new TextDecoder();
   const diacriticIndexes=new Map(RIMZ_PIXEL_DIACRITICS.map((value,index)=>[value.codePointAt(0),index]));
@@ -214,6 +217,19 @@ const installPixelLayer=term=>{
       height:cell&&cell.height||rect.height/Math.max(1,term.rows),
     };
   };
+  const fittedImageRect=(image,placement,size,x,y)=>{
+    const boxWidth=placement.cols*size.width;
+    const boxHeight=placement.rows*size.height;
+    const scale=Math.min(boxWidth/image.width,boxHeight/image.height);
+    const width=image.width*scale;
+    const height=image.height*scale;
+    return {
+      x:x+(boxWidth-width)/2,
+      y:y+boxHeight-height,
+      width,
+      height,
+    };
+  };
   const draw=()=>{
     const rect=resizeCanvas();
     context.clearRect(0,0,rect.width,rect.height);
@@ -223,6 +239,7 @@ const installPixelLayer=term=>{
     const theme=term.options.theme||{};
     const viewportElement=term.element.querySelector(".xterm-viewport");
     const background=theme.background||(viewportElement&&getComputedStyle(viewportElement).backgroundColor)||"#000";
+    const fittedImages=new Map();
     for(let row=0;row<term.rows;row++){
       const line=buffer.getLine(viewport+row);
       if(!line)continue;
@@ -240,11 +257,26 @@ const installPixelLayer=term=>{
         const id=cell.getFgColor()&0xffffff;
         const placement=placements.get(id);
         const image=images.get(id);
-        if(!placement||!image||sourceRow===undefined||sourceCol===undefined||sourceRow>=placement.rows||sourceCol>=placement.cols)continue;
+        if(!placement||sourceRow===undefined||sourceCol===undefined||sourceRow>=placement.rows||sourceCol>=placement.cols)continue;
+        if(placement.rows>1){
+          if(sourceCol===placement.cols-1){
+            context.fillRect(x+size.width,y,size.width*PLACEHOLDER_OVERHANG_COLS,size.height);
+          }
+          if(!image)continue;
+          const originX=x-sourceCol*size.width;
+          const originY=y-sourceRow*size.height;
+          fittedImages.set(`${id}:${originX}:${originY}`,{image,placement,x:originX,y:originY});
+          continue;
+        }
+        if(!image)continue;
         const sourceWidth=image.width/placement.cols;
         const sourceHeight=image.height/placement.rows;
         context.drawImage(image,sourceCol*sourceWidth,sourceRow*sourceHeight,sourceWidth,sourceHeight,x,y,size.width,size.height);
       }
+    }
+    for(const {image,placement,x,y} of fittedImages.values()){
+      const fitted=fittedImageRect(image,placement,size,x,y);
+      context.drawImage(image,fitted.x,fitted.y,fitted.width,fitted.height);
     }
   };
   let drawQueued=false;

--- a/crates/rimz/tests/fixtures/ttyd-trace/main.rs
+++ b/crates/rimz/tests/fixtures/ttyd-trace/main.rs
@@ -4,6 +4,7 @@ use std::env;
 use std::fs::OpenOptions;
 use std::io::{Read as _, Write as _};
 use std::net::TcpListener;
+use std::sync::Arc;
 use std::time::Duration;
 
 const INDEX: &str = "<html><head></head><body></body></html>";
@@ -15,6 +16,7 @@ fn main() {
         return;
     }
     let log = env::var_os("RIMZ_TEST_TTYD_LOG").expect("RIMZ_TEST_TTYD_LOG unset");
+    let index = Arc::new(env::var("RIMZ_TEST_TTYD_INDEX").unwrap_or_else(|_| INDEX.to_owned()));
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
@@ -29,6 +31,7 @@ fn main() {
     let listener = TcpListener::bind(("127.0.0.1", port)).expect("bind ttyd trace port");
     for stream in listener.incoming() {
         let Ok(mut stream) = stream else { break };
+        let index = Arc::clone(&index);
         std::thread::spawn(move || {
             stream
                 .set_read_timeout(Some(Duration::from_secs(1)))
@@ -41,10 +44,11 @@ fn main() {
                 return;
             }
             let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{INDEX}",
-                INDEX.len()
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                index.len()
             );
             let _ = stream.write_all(response.as_bytes());
+            let _ = stream.write_all(index.as_bytes());
         });
     }
 }

--- a/crates/rimz/tests/integration/web.rs
+++ b/crates/rimz/tests/integration/web.rs
@@ -382,6 +382,10 @@ fn two_rooms_reuse_one_shared_daemon_and_rotate_restarts_it() {
         .state_root()
         .join("rimz/web-ttyd-credential.json");
     let daemon_path = fixture.env.state_root().join("rimz/web-ttyd.json");
+    let daemon: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&daemon_path).expect("read capable daemon record"))
+            .expect("parse capable daemon record");
+    assert_eq!(daemon["pixel_protocol"], 1);
     let credential_before = std::fs::read(&credential_path).expect("credential before bad revoke");
     let daemon_before = std::fs::read(&daemon_path).expect("daemon before bad revoke");
     let bad_revoke = fixture
@@ -722,6 +726,45 @@ fn stale_gated_daemon_terminates_its_surviving_gate_and_can_restart() {
         .bounded_output()
         .expect("stop recovered gated daemon");
     assert_success(&stop, "stop recovered gated daemon");
+}
+
+#[cfg(unix)]
+#[test]
+fn markerless_stock_index_keeps_daemon_pixel_incapable() {
+    let _guard = daemon_test_guard();
+    let fixture = WebFixture::new("ttyd-markerless.log");
+    let open = fixture
+        .command()
+        .env(
+            "RIMZ_TEST_TTYD_INDEX",
+            "<html><body>markerless</body></html>",
+        )
+        .args(["--mux", "tmux", "web", "open", "--session"])
+        .arg(&fixture.workspace.session_name)
+        .args(["--print", "--json"])
+        .bounded_output()
+        .expect("open web with markerless stock page");
+    success_json(&open, "markerless web open");
+
+    let daemon: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(fixture.env.state_root().join("rimz/web-ttyd.json"))
+            .expect("read markerless daemon record"),
+    )
+    .expect("parse markerless daemon record");
+    assert!(daemon.get("pixel_protocol").is_none(), "{daemon}");
+    let log = std::fs::read_to_string(&fixture.ttyd_log).expect("read markerless ttyd log");
+    let daemon_argv = log
+        .lines()
+        .find(|line| line.contains("\tweb\texec"))
+        .expect("markerless daemon argv");
+    assert!(!daemon_argv.contains("\t-I\t"), "{daemon_argv}");
+
+    let stop = fixture
+        .command()
+        .args(["web", "stop"])
+        .bounded_output()
+        .expect("stop markerless daemon");
+    assert_success(&stop, "stop markerless daemon");
 }
 
 #[cfg(unix)]

--- a/crates/rimz/tests/integration/web.rs
+++ b/crates/rimz/tests/integration/web.rs
@@ -385,7 +385,7 @@ fn two_rooms_reuse_one_shared_daemon_and_rotate_restarts_it() {
     let daemon: serde_json::Value =
         serde_json::from_slice(&std::fs::read(&daemon_path).expect("read capable daemon record"))
             .expect("parse capable daemon record");
-    assert_eq!(daemon["pixel_protocol"], 1);
+    assert_eq!(daemon["pixel_protocol"], 2);
     let credential_before = std::fs::read(&credential_path).expect("credential before bad revoke");
     let daemon_before = std::fs::read(&daemon_path).expect("daemon before bad revoke");
     let bad_revoke = fixture

--- a/docs/guide/pets.md
+++ b/docs/guide/pets.md
@@ -61,7 +61,7 @@ Every source uses the petdex sheet geometry — a `1536x1872` image holding an `
 
 ## Crisp pixels and cell art
 
-Two tiers render the same sheet. **Pixel** draws the sprite through the kitty graphics protocol, crisp at native resolution: it needs a Ghostty or kitty terminal ([installation](./installation.md#truecolor-terminal-and-a-nerd-font-optional) sets one up), and inside tmux also tmux 3.6+ with `allow-passthrough on` (or `all`). **Sextant** draws the sprite as cell art, each terminal cell split into a 2x3 pixel grid, and works everywhere: Zellij, SSH, and any terminal that shows color.
+Two tiers render the same sheet. **Pixel** draws the sprite through the kitty graphics protocol, crisp at native resolution: it works in Ghostty and kitty ([installation](./installation.md#truecolor-terminal-and-a-nerd-font-optional) sets one up), and in the RimZ browser page for tmux rooms; tmux 3.6+ with `allow-passthrough on` (or `all`) remains required. **Sextant** draws the sprite as cell art, each terminal cell split into a 2x3 pixel grid, and works everywhere: Zellij, SSH, stock ttyd pages, and any terminal that shows color.
 
 <p align="center">
   <img src="../rimz-pets-sexant.png" alt="rimz list-pets in Alacritty: the same built-in pets rendered as sextant cell art" width="100%">
@@ -75,6 +75,8 @@ Two tiers render the same sheet. **Pixel** draws the sprite through the kitty gr
 | `auto` (default) | pixels when the terminal and mux qualify, otherwise sextant cell art |
 | `pixel` | opts past the terminal-name allowlist for newer kitty-compatible terminals, while hard gates such as tmux passthrough still apply |
 | `sextant` | the most portable cell art, on every backend |
+
+`auto` requires every rendering client attached to the tmux room to support RimZ's Kitty subset. Attaching a plain terminal drops the room to sextant within ten seconds; detaching it restores pixels. `glyphs = "sextant"` remains authoritative in the browser, and Zellij remains on sextant.
 
 Sextant pets fit their source proportions inside the fixed dashboard footprint. RimZ probes the terminal's cell pixel dimensions when the pty exposes them; Zellij reports no pixel dimensions, so set the ratio manually when its font makes pets look tall or wide: `rimz config set theme.pets.cell_aspect 2.5`. Explicit config wins over the probe, and a neutral `13/6` fallback preserves the previous rendering when neither fact is available.
 

--- a/docs/guide/web.md
+++ b/docs/guide/web.md
@@ -39,7 +39,9 @@ RimZ gives ttyd the active theme and configured browser font when the daemon sta
 
 Set `font_source` to a local `.ttf`, `.otf`, `.woff`, or `.woff2` file, or to an HTTPS URL. A family with no preset and no source asks the browser to resolve an installed font. `style_client = false` keeps ttyd's browser colors while retaining keyboard, cursor, clipboard, and reconnect fixes.
 
-The compatibility layer keeps the cursor steady when terminal apps request blinking while preserving their requested cursor shapes, preserves Shift+Enter and macOS Option-as-Meta input, sends tmux copy-mode yanks and Shift-drag selections to the clipboard, and refreshes xterm after a downloaded font loads. Missing font bytes warn and fall back to monospace.
+The compatibility layer keeps the cursor steady when terminal apps request blinking while preserving their requested cursor shapes, preserves Shift+Enter and macOS Option-as-Meta input, sends tmux copy-mode yanks and Shift-drag selections to the clipboard, refreshes xterm after a downloaded font loads, and renders pixel pets plus the pixel context meter in qualifying tmux rooms. Missing font bytes warn and fall back to monospace. Zellij rooms, tmux below 3.6, disabled passthrough, a stock-page fallback, or any attached plain terminal use sextant cell art instead.
+
+A browser tab kept open while RimZ upgrades can retain the previous compatibility page until it reloads. Reload that tab after an upgrade to converge it with the new shared daemon.
 
 Appearance is fixed when the shared daemon starts. After changing `[theme]` or web styling, run:
 

--- a/docs/internals/sidebar/pets.md
+++ b/docs/internals/sidebar/pets.md
@@ -125,16 +125,16 @@ The two tiers keep different things in memory. Cell tier renders all 72 grids on
 | --- | --- | --- |
 | `sextant` | nothing | `Cell` |
 | `pixel` | pixel transport | `Pixel`, else `Cell` |
-| `auto` (default) | pixel transport **and** a kitty-capable terminal | `Pixel`, else `Cell` |
+| `auto` (default) | pixel transport **and** kitty-capable rendering clients | `Pixel`, else `Cell` |
 
 `effective_render_tier` then folds in this frame's reality: `[theme.display] pixel = "off"` forces `Cell` outright, and a resolved pixel tier downgrades to `Cell` when there is no provider block to ride beside or the body is suppressed. A cell tier always passes through unchanged, so `sextant` stays sextant.
 
 Capabilities come from [`pixel/probe.rs`](../../../crates/rimz/src/sidebar_pane/pixel/probe.rs) as two independent facts:
 
 - **Pixel transport.** Inside tmux: version 3.6 or newer *and* `allow-passthrough` set to `on` or `all` on the pane (falling back to the session). Standalone: always available. Zellij: never.
-- **Kitty terminal.** Inside tmux: every rendering client's terminfo is `xterm-ghostty`, `ghostty`, `xterm-kitty`, or `kitty`, with control-mode clients excluded. Standalone: `$TERM` matches the same list.
+- **Kitty clients.** Inside tmux: every rendering client either advertises `xterm-ghostty`, `ghostty`, `xterm-kitty`, or `kitty`, or descends from the live ttyd daemon serving RimZ's current pixel compatibility protocol; control-mode clients are excluded. Standalone: `$TERM` matches the native-terminal list.
 
-Live re-probes fold failures onto the previous reading — a command that fails keeps the last known fact rather than flapping the tier — and every runtime probe only reads. One startup command writes: it raises the sidebar's own pane from `allow-passthrough on` to `all`, so graphics transmitted while the window is hidden still reach the terminal. A pane already at `all`, and a user's explicit `off`, stay as they are.
+Live re-probes fold failures onto the previous reading — a command that fails keeps the last known fact rather than flapping the tier — and every runtime probe only reads. Resize re-probes immediately; a ten-second tmux backstop covers equal-size browser attaches and detaches. One startup command writes: it raises the sidebar's own pane from `allow-passthrough on` to `all`, so graphics transmitted while the window is hidden still reach the terminal. A pane already at `all`, and a user's explicit `off`, stay as they are.
 
 Sextant is the downgrade target because it is the portable baseline. Capability misses, Zellij, `NO_COLOR`, a suppressed body, and a dashboard with no provider column all converge on it.
 

--- a/docs/internals/web.md
+++ b/docs/internals/web.md
@@ -32,7 +32,7 @@ The shim accepts only a session with a durable RimZ workspace record and a match
 
 The ttyd binary resolves from `RIMZ_TTYD_BIN`, then `PATH`. A missing binary reports the Homebrew and apt install fix. `interface` must parse as an IP address, each trusted proxy must parse as an IP or CIDR, and an occupied configured listener returns a typed error that points to `[web] port`.
 
-RimZ spawns ttyd and the optional gate with null stdio and their own process groups, then writes `$XDG_STATE_HOME/rimz/web-ttyd.json` with `pid`, `port`, `interface`, `auth`, `trusted_proxies`, and optional `gate: {pid, upstream_port}`. Old `{pid, port}` records deserialize as Basic Auth on loopback without a gate. The record is live only while ttyd is the recorded process, the optional gate is a recorded `rimz web gate` process, and the configured listener accepts a connection; readers remove stale records.
+RimZ spawns ttyd and the optional gate with null stdio and their own process groups, then writes `$XDG_STATE_HOME/rimz/web-ttyd.json` with `pid`, `port`, `interface`, `auth`, `trusted_proxies`, optional `gate: {pid, upstream_port}`, and optional `pixel_protocol`. `pixel_protocol` is present only when the live daemon serves a generated page with RimZ's current pixel compatibility layer. Old `{pid, port}` records deserialize as Basic Auth on loopback without a gate or pixel capability. The record is live only while ttyd is the recorded process, the optional gate is a recorded `rimz web gate` process, and the configured listener accepts a connection; readers remove stale records.
 
 The desired listener, auth mode, and proxy list participate in daemon reuse. Any drift stops the old processes and starts the desired shape; Basic mode also requires the credential file before reuse.
 
@@ -56,7 +56,11 @@ The built-in Nerd Font families use SHA-256-pinned regular and bold faces. HTTPS
 
 ttyd serves no additional static route, so RimZ caches a generated index under `$XDG_CACHE_HOME/rimz/web-ttyd`. A cache miss starts a throwaway loopback ttyd on an ephemeral port, fetches its stock `/` page with temporary Basic Auth, stops it, and injects the font faces plus the compatibility bootstrap.
 
-The bootstrap refreshes xterm after fonts load, keeps the cursor steady across reconnects and app-emitted blink sequences while preserving requested cursor shapes, preserves Shift+Enter and macOS Meta chords, bridges OSC 52 and browser selections to the clipboard, and restyles disconnect and resize overlays. It guards blinking DECSCUSR styles and DEC mode 12 at the xterm parser. A font or index failure warns and falls back without blocking the daemon.
+The bootstrap refreshes xterm after fonts load, keeps the cursor steady across reconnects and app-emitted blink sequences while preserving requested cursor shapes, preserves Shift+Enter and macOS Meta chords, bridges OSC 52 and browser selections to the clipboard, restyles disconnect and resize overlays, and installs a bounded Kitty graphics compatibility layer. It guards blinking DECSCUSR styles and DEC mode 12 at the xterm parser. A font or index failure warns and falls back without blocking the daemon.
+
+The pixel layer consumes RimZ's transmit, virtual-placement, and delete subset before xterm parses it, retains at most 128 decoded PNGs by image id, and paints slices onto a DPR-scaled overlay canvas. Each redraw scans xterm's visible buffer for U+10EEEE placeholder cells, reads their row and column combining marks plus the RGB image id, and therefore follows scroll, resize, reconnect, and tmux client switches without a second state channel.
+
+The tmux capability probe accepts an `xterm-256color` rendering client when its pid ancestry reaches the live ttyd pid recorded with the current `pixel_protocol`. Stock-page fallback omits the field and stays sextant-capable only. A browser tab kept open across a RimZ upgrade can retain the previous page generation against the replacement daemon; reload the page to converge it.
 
 ## Commands and room start
 


### PR DESCRIPTION
## Context

Pixel pets and the pixel context meter render as sextant cell art in browsers because ttyd's xterm.js client identifies as `xterm-256color`, which the `auto` capability gate correctly rejects — xterm.js cannot decode the Kitty graphics subset RimZ emits. This adds a RimZ-owned Kitty compatibility layer to the custom ttyd page so qualifying tmux rooms show true pixel pets in the browser, with sextant remaining the fallback everywhere else (Zellij, tmux below 3.6, disabled passthrough, a stock-page fallback, or any attached plain terminal).

RimZ already emits a narrow Kitty subset (chunked base64 PNG transmit, virtual placement, delete) and generates a cached custom ttyd index that injects a bootstrap script. tmux `allow-passthrough` forwards the wrapped sequences verbatim to every client regardless of TERM, so the browser receives the raw APC bytes.

## Design choices

- **Kitty compat layer in the custom ttyd page.** Rejected SIXEL (a second renderer, no image IDs, per-frame retransmit), waiting on upstream xterm.js Kitty support (no schedule), and a separate web state channel (duplicates sidebar state, grows the security surface).
- **Capability negotiation via pid ancestry, not termname.** A custom terminal-type would break `tmux attach` on missing terminfo. Instead the daemon record gains a versioned `pixel_protocol` field, set only when the enhanced page was generated and passed via `-I`; the probe classifies a rendering client as capable when its termname is allowlisted (native Ghostty/kitty) *or* its pid ancestry reaches the live recorded ttyd daemon carrying the current protocol version. Stock-page fallback is non-capable by construction.
- **Buffer readback for image placement.** The browser renderer locates images by scanning the xterm viewport buffer for placeholder cells — robust across scroll, redraw, and tmux client switches — rather than tracking stream positions. A pre-implementation spike confirmed xterm's buffer preserves the U+10EEEE cluster's combining marks and the 24-bit RGB foreground (`getChars() → [1109742,773,781]`, `getFgColor() → 0x123456`).
- **Periodic re-probe backstop.** Attach/detach usually fires a tmux resize (which re-probes), but equal-dimension clients don't. A bounded 10 s tmux-only re-probe in the serve loop flips the room to sextant when an unsupported client attaches and restores pixels when it detaches.
- **Generated JS constants.** The diacritics table, placeholder codepoint, and protocol constants are formatted into the injected script from the Rust consts at page-generation time, so there is no duplicated table and no drift.
- **No new config, no JS toolchain.** `theme.pets.glyphs` semantics are unchanged (`sextant` authoritative, `auto` picks pixels when transport and all clients qualify). The repo has no JS toolchain, so Rust tests cover negotiation, injection, record state, and cache invalidation; browser rendering is verified with a scripted manual recipe. A headless-browser harness is a possible follow-up.

## Implementation

- **Browser pixel layer** (`web/ttyd/pixel_layer.js`, new; `web/ttyd/client.rs`). A bounded Kitty-subset parser and DPR-scaled overlay-canvas renderer, injected into the generated ttyd page. It intercepts `term.write`, splits out `ESC _ G … ESC \` APC sequences (carrying sequences split across write chunks), decodes and retains bounded PNG/image-id state (≤128 images, oldest-first eviction), and on render/scroll/resize scans the visible buffer for placeholder cells to paint image slices over the tofu glyph. `CUSTOM_INDEX_SCHEMA` bumped to `v4` to invalidate cached pages; `ClientProfile.pixel_protocol` is set to the current protocol only on the successful custom-index branch.
- **Daemon record** (`web/ttyd.rs`, `web/mod.rs`). `DaemonRecord` gains `#[serde(default)] pixel_protocol: Option<u32>` (old records deserialize as `None`). The record is written on daemon start and credential-rotation restart; the reuse path keeps the existing record. A lock-free `pixel_daemon_record()` accessor (plain `fs::read` + serde) serves the probe, exposed through a crate-private `web` wrapper so the store-write path stays out of the sidebar's import graph.
- **Capability probe** (`sidebar_pane/pixel/probe.rs`). `PixelRenderCaps.kitty_term` renamed to `kitty_clients` across call sites. The list-clients format carries `client_pid`; a client qualifies when its termname is allowlisted or it descends (bounded ≤4 hops) from the recorded ttyd daemon pid whose protocol matches. `kitty_clients` is true only when every rendering client qualifies.
- **Serve-loop backstop** (`sidebar_pane/app/paint.rs`, `app/loop_state.rs`). A 10 s tmux-only staleness guard on the `Wakeup::Tick` path; `on_resize` keeps its unconditional refresh.
- **Docs + changelog** updated across the web/pets guides and internals.

Deviations from the plan, all justified: the probe unit suite moved to `pixel/probe/tests.rs` to stay under the 500-line inline invariant; the daemon-record reader is exposed through a crate-private `web` wrapper because `web::ttyd` is private to its parent; a `program_label == "ttyd"` check was added to the ancestor liveness test so a recycled daemon pid cannot be accepted; `docs/internals/theme.md` was left unedited because it carries no termname-allowlist claim.

Verification: `cargo xtask gate` passes (fmt, invariants, docs-links, lint, test); focused `probe`/`web`/`pets` suites and `-P live` are green. Manual Chromium 145 + ttyd + sandbox tmux checks confirmed the generated page advertises protocol 1, real `list-pets` painted decoded pet slices over the buffer, an APC split across five `term.write` calls reassembled correctly, a foreign `xterm-256color` attach dropped the room to sextant and detach restored pixels, a DPR-2 resize kept painted content, and a daemon restart re-parented a new client under the new recorded pid.

## Advisories

Non-blocking, from review:

- **Per-write copy on the browser hot path** (`pixel_layer.js`). `installPixelLayer` wraps `term.write` on every custom-index page, so all browser output runs the scanner; with no graphics present it still copies the chunk. Inherent to the plan-approved interception approach and negligible against network + xterm parsing cost. A single-segment fast path returning the subarray directly would remove the copy if it ever surfaces in profiling.
- **Non-`ttyd`-named `RIMZ_TTYD_BIN` disables browser pixels** (`probe.rs`). The daemon-liveness guard requires the recorded pid's program to be `ttyd`, matching the existing pid-reuse guard, so pointing `RIMZ_TTYD_BIN` at a differently-named wrapper negotiates to sextant even on a capable page. Deliberate and degrades gracefully; noted as a behavioral edge.

Known limitation: a browser tab kept open across a RimZ upgrade may serve the previous page generation against a new capable daemon until reloaded; a page reload converges it.