### PR TITLE
test(integration): synchronize flaky process lifecycles

### DIFF
--- a/crates/rimz/src/sidebar_pane/supervise.rs
+++ b/crates/rimz/src/sidebar_pane/supervise.rs
@@ -42,6 +42,8 @@ const TEST_PANE_PROBE_INTERVAL_MS_ENV: &str = "RIMZ_TEST_SIDEBAR_PANE_PROBE_INTE
 #[cfg(feature = "testkit")]
 const TEST_PANE_PROBE_ENV: &str = "RIMZ_TEST_SIDEBAR_PANE_PROBE";
 #[cfg(feature = "testkit")]
+const TEST_PANE_PROBE_ABSENT_FILE_ENV: &str = "RIMZ_TEST_SIDEBAR_PANE_PROBE_ABSENT_FILE";
+#[cfg(feature = "testkit")]
 const TEST_RECORD_POLL_MS_ENV: &str = "RIMZ_TEST_SIDEBAR_RECORD_POLL_MS";
 #[cfg(feature = "testkit")]
 const TEST_STABLE_RUN_MS_ENV: &str = "RIMZ_TEST_SIDEBAR_STABLE_RUN_MS";
@@ -1237,6 +1239,14 @@ fn pane_probe_interval() -> Duration {
 
 #[cfg(feature = "testkit")]
 fn forced_pane_probe() -> Option<PaneProbe> {
+    if let Some(path) = env::var_os(TEST_PANE_PROBE_ABSENT_FILE_ENV).filter(|path| !path.is_empty())
+    {
+        return Some(if Path::new(&path).exists() {
+            PaneProbe::Absent(0)
+        } else {
+            PaneProbe::Present(0)
+        });
+    }
     match env::var(TEST_PANE_PROBE_ENV).ok().as_deref() {
         Some("present") => Some(PaneProbe::Present(0)),
         Some("absent") => Some(PaneProbe::Absent(0)),

--- a/crates/rimz/tests/integration/sidebar_supervisor.rs
+++ b/crates/rimz/tests/integration/sidebar_supervisor.rs
@@ -326,6 +326,8 @@ fn sidebar_supervisor_keeps_pane_watchdog_across_worker_respawns() {
     let env = Env::new();
     let instance =
         rimz::SidebarInstanceId::parse("sb_019e8c565bbd708097fce9514f79da05").expect("instance id");
+    let starts = env.home_root.join("watchdog-worker-starts.log");
+    let pane_absent = env.home_root.join("watchdog-pane-absent");
     let mut cmd = env.rimz();
     cmd.args([
         "sidebar",
@@ -342,13 +344,16 @@ fn sidebar_supervisor_keeps_pane_watchdog_across_worker_respawns() {
     .env("RIMZ_TEST_SIDEBAR_WORKER_FAULT", "abort_after_delay")
     .env("RIMZ_TEST_SIDEBAR_SUPERVISOR_REAP_POLL_MS", "5")
     .env("RIMZ_TEST_SIDEBAR_SUPERVISOR_RESPAWN_BACKOFF_MS", "10")
-    .env("RIMZ_TEST_SIDEBAR_PANE_PROBE_INTERVAL_MS", "100")
-    .env("RIMZ_TEST_SIDEBAR_PANE_PROBE", "absent")
+    .env("RIMZ_TEST_SIDEBAR_WORKER_STARTED_FILE", &starts)
+    .env("RIMZ_TEST_SIDEBAR_PANE_PROBE_INTERVAL_MS", "10")
+    .env("RIMZ_TEST_SIDEBAR_PANE_PROBE_ABSENT_FILE", &pane_absent)
     .stdin(Stdio::null())
     .stdout(Stdio::null())
     .stderr(Stdio::null());
 
     let mut child = cmd.spawn().expect("spawn sidebar supervisor");
+    wait_for_start_after(&starts, &env.rimz_bin(), 1, Duration::from_secs(2));
+    std::fs::write(&pane_absent, b"absent").expect("release pane watchdog");
     let status = wait_child(&mut child, Duration::from_secs(3));
 
     assert!(status.success(), "supervisor exited with {status}");

--- a/crates/rimz/tests/integration/web.rs
+++ b/crates/rimz/tests/integration/web.rs
@@ -1,17 +1,23 @@
 use std::io::{Read as _, Write as _};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
+#[cfg(unix)]
+use std::time::Duration;
 
 use crate::common::{CommandTimeoutExt, Env};
 
 #[cfg(unix)]
-static DAEMON_TEST: std::sync::Mutex<()> = std::sync::Mutex::new(());
+const DAEMON_TEST_LOCK_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[cfg(unix)]
-fn daemon_test_guard() -> std::sync::MutexGuard<'static, ()> {
-    DAEMON_TEST
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
+fn daemon_test_guard() -> rimz::store::lock::WorkspaceLock {
+    // Nextest gives every test its own process, so an in-process mutex leaves
+    // the machine-wide listener and ttyd's ephemeral stock-index listener
+    // contended. `cargo xtask test` gives the whole run one shared TMPDIR,
+    // making this lock run-wide and isolated across runs.
+    let path = std::env::temp_dir().join("rimz-web-daemon-tests.lock");
+    rimz::store::lock::WorkspaceLock::acquire_with_timeout(&path, DAEMON_TEST_LOCK_TIMEOUT)
+        .unwrap_or_else(|err| panic!("acquire web daemon test lock {}: {err}", path.display()))
 }
 
 fn assert_success(output: &Output, action: &str) {


### PR DESCRIPTION
## Summary

- Hold the sidebar pane probe present until the supervisor has observably respawned its worker, then release the watchdog through a test marker.
- Replace the process-local web daemon test mutex with a run-wide advisory lock that works across nextest test processes.

## Why

The sidebar test relied on a delayed worker abort winning a wall-clock race against the pane watchdog. Under CI scheduler load, the watchdog could reap the first worker before it ran and emitted its crash diagnostic. The web test's mutex could not serialize nextest's process-per-test execution, leaving loopback and ttyd stock-index ports contended.

## Validation

- `cargo nextest run --workspace --all-features --locked -E 'test(sidebar_supervisor_keeps_pane_watchdog_across_worker_respawns)' --stress-count 100` (100/100 passed)
- `cargo xtask test web::` (54 passed)
- `cargo xtask gate`
