### PR TITLE
feat(web): read-only no-auth broadcast sharing per room

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-RimZ is a single Rust binary that turns a Zellij or tmux session into a control room for coding agents. It owns no database or always-on state service: it builds on the multiplexer you already run, a directory of flat files for durable state, and one CLI that every event flows through. Optional browser access adds one machine-wide ttyd process as terminal transport.
+RimZ is a single Rust binary that turns a Zellij or tmux session into a control room for coding agents. It owns no database or always-on state service: it builds on the multiplexer you already run, a directory of flat files for durable state, and one CLI that every event flows through. Optional browser access adds a machine-wide authenticated ttyd process for writable transport and a separate unauthenticated, input-blocked process for explicitly shared rooms.
 
 One invariant ties the runtime together:
 
@@ -43,7 +43,7 @@ rimz CLI and hook subprocesses
 workspace store (a directory of flat files)
 ```
 
-When browser access is enabled, one authenticated ttyd daemon binds the configured loopback port for every Zellij and tmux room. Each connection supplies a session argument to the hidden `rimz web exec` shim; the shim validates durable workspace ownership and live mux state before it attaches, so ttyd owns transport but no session authority ([web.md](./docs/internals/web.md)).
+When browser access is enabled, one authenticated ttyd daemon binds the configured loopback port for every Zellij and tmux room. A second no-auth daemon binds its own port only after `rimz web share` allowlists a live room and omits ttyd's write flag. Each connection supplies a session argument to a hidden `rimz web exec` shim; the writable shim validates durable workspace ownership and live mux state, while the broadcast shim also validates the durable per-room allowlist, so ttyd owns transport but no session authority ([web.md](./docs/internals/web.md)).
 
 The spending service is a private thread inside whichever host-eligible long-lived RimZ process wins its persistent/discovery-namespace lifetime lock; one-shot inspection commands connect or fall back directly without becoming the warm owner. Its schema- and namespace-versioned Unix socket accepts clients concurrently while one try-locked walker owns stale work, so a slow request cannot queue another workspace's refresh tick. `spending.json`, provider/workspace publications, and their atomic-write and downgrade guards remain truth. Process exit discards the service and the next eligible client re-elects an owner, so this warm-cache optimization introduces no RimZ daemon.
 
@@ -57,7 +57,7 @@ The CLI and hook subprocesses are the only writers of product truth. The sidebar
 | RimZ store | events, agent state, messages, runs, snapshots | terminal rendering, pane mechanics |
 | CLI / hook subprocesses | durable writes, supervised-run waiters, mux command calls | UI presentation |
 | Sidebar | rendering, focus affordances, human actions through the CLI | durable state files |
-| ttyd browser daemon | authenticated loopback terminal transport | workspace identity, session validation, durable state |
+| ttyd browser daemons | authenticated writable transport; no-auth input-blocked transport | workspace identity, session validation, broadcast allowlist, durable state |
 | Agents | native UI, prompts, sandboxing, bypass behaviour | RimZ store state |
 | Host | process resurrection, OS sandboxing | workspace state |
 
@@ -82,7 +82,7 @@ shared runtime          $XDG_RUNTIME_DIR/rimz/shared/
 
 user-global persistent  ~/.local/state/rimz/
   builds/<build_id>/rimz immutable executable generations, the loop registry,
-  and the shared browser daemon pid/port record and credential
+  the browser daemon pid/port records and credential, and the broadcast room allowlist
 ```
 
 One rule sorts a new file into a tier: **persistent tiers hold what must survive a reboot, runtime tiers hold what is meaningless without the process that wrote it.** A lock, a socket, or a cache that only speeds the next read is runtime and dies with the session; a durable record, or a cache the dashboard needs to open warm, is persistent. The store tier's durability contract — temp-file-plus-rename, the framed log, and the write classes — is [store.md](./docs/internals/store.md), the provider files are [providers.md](./docs/internals/agents/providers.md), the loop registry is [loops.md](./docs/internals/harness/loops.md), and executable staging is [sidebar.md → Build promotion](./docs/internals/sidebar/sidebar.md#build-promotion).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ RimZ is alpha software on the 0.x line. Commands, flags, config keys, and output
 
 ### Added
 
+- `rimz web share` serves an explicitly allowlisted live room through a second no-auth, input-blocked ttyd daemon; `unshare` revokes live viewers, tmux attaches ignore viewer size, and status reports both browser surfaces. → [web](./docs/guide/web.md#share-a-read-only-broadcast)
 - Layout cells accept any executable on PATH as a raw command pane, while configured commands and profiles keep precedence over same-named binaries. → [fleet](./docs/guide/fleet.md#compose-a-layout)
 - `rimz events follow` streams versioned agent lifecycle transitions as JSON Lines, with current-generation replay and gap-free handoff across event-log rotation. → [events](./docs/reference/cli/events.md)
 

--- a/crates/rimz/src/cli/reload.rs
+++ b/crates/rimz/src/cli/reload.rs
@@ -30,11 +30,15 @@ pub struct ReloadArgs {
 pub fn run(args: ReloadArgs, globals: &GlobalFlags) -> Result<()> {
     let outcome = reload_user_sidebars()?;
     let web_restarted = match rimz::web::restart_if_online(&super::machine_config()) {
-        Ok(Some(web)) => {
-            render::web_warnings(&web.warnings);
-            true
+        Ok(web) => {
+            if let Some(writable) = &web.writable {
+                render::web_warnings(&writable.warnings);
+            }
+            if let Some(share) = &web.share {
+                render::web_warnings(&share.warnings);
+            }
+            web.writable.is_some() || web.share.is_some()
         }
-        Ok(None) => false,
         Err(err) => {
             let _ = writeln!(std::io::stderr().lock(), "rimz: warning: {err}");
             false

--- a/crates/rimz/src/cli/render/mod.rs
+++ b/crates/rimz/src/cli/render/mod.rs
@@ -87,6 +87,10 @@ pub(crate) fn web_warnings(warnings: &[rimz::web::WebWarning]) {
                 let _ = writeln!(stderr, "rimz: warning: {detail}");
                 None
             }
+            rimz::web::WebWarning::BroadcastUnauthenticated(detail) => {
+                let _ = writeln!(stderr, "rimz: warning: {detail}");
+                None
+            }
         };
         if let Some((surface, detail)) = skipped {
             let _ = writeln!(stderr, "rimz: skipping {surface}: {detail}");

--- a/crates/rimz/src/cli/snapshots/rimz__cli__surface_tests__cli_surface.snap
+++ b/crates/rimz/src/cli/snapshots/rimz__cli__surface_tests__cli_surface.snap
@@ -913,6 +913,8 @@ rimz help web open
 
 rimz help web restart
 
+rimz help web share
+
 rimz help web start
 
 rimz help web status
@@ -928,6 +930,8 @@ rimz help web token list
 rimz help web token revoke
 
 rimz help web token revoke-all
+
+rimz help web unshare
 
 rimz help web url
 
@@ -2007,6 +2011,7 @@ rimz web exec [hidden]
     -h, --help  [action=help takes=0..=0]
     --mux <MUX>  [action=set takes=1..=1 global]
     --root <ROOT>  [action=set takes=1..=1 global]
+    --share  [action=set-true takes=0..=0]
     --tmux  [action=set-true takes=0..=0 global]
     --zellij  [action=set-true takes=0..=0 global]
 
@@ -2034,6 +2039,8 @@ rimz web help open
 
 rimz web help restart
 
+rimz web help share
+
 rimz web help start
 
 rimz web help status
@@ -2049,6 +2056,8 @@ rimz web help token list
 rimz web help token revoke
 
 rimz web help token revoke-all
+
+rimz web help unshare
 
 rimz web help url
 
@@ -2072,6 +2081,18 @@ rimz web restart
     -h, --help  [action=help takes=0..=0]
     --mux <MUX>  [action=set takes=1..=1 global]
     --root <ROOT>  [action=set takes=1..=1 global]
+    --tmux  [action=set-true takes=0..=0 global]
+    --zellij  [action=set-true takes=0..=0 global]
+
+rimz web share
+    <path>  [action=set takes=1..=1]
+    --color <COLOR>  [action=set takes=1..=1 global default=auto values=auto|always|never]
+    -h, --help  [action=help takes=0..=0]
+    --json  [action=set-true takes=0..=0]
+    --mux <MUX>  [action=set takes=1..=1 global]
+    --print  [action=set-true takes=0..=0]
+    --root <ROOT>  [action=set takes=1..=1 global]
+    --session <SESSION>  [action=set takes=1..=1]
     --tmux  [action=set-true takes=0..=0 global]
     --zellij  [action=set-true takes=0..=0 global]
 
@@ -2151,6 +2172,17 @@ rimz web token revoke-all
     -h, --help  [action=help takes=0..=0]
     --mux <MUX>  [action=set takes=1..=1 global]
     --root <ROOT>  [action=set takes=1..=1 global]
+    --tmux  [action=set-true takes=0..=0 global]
+    --zellij  [action=set-true takes=0..=0 global]
+
+rimz web unshare
+    <path>  [action=set takes=1..=1]
+    --all  [action=set-true takes=0..=0]
+    --color <COLOR>  [action=set takes=1..=1 global default=auto values=auto|always|never]
+    -h, --help  [action=help takes=0..=0]
+    --mux <MUX>  [action=set takes=1..=1 global]
+    --root <ROOT>  [action=set takes=1..=1 global]
+    --session <SESSION>  [action=set takes=1..=1]
     --tmux  [action=set-true takes=0..=0 global]
     --zellij  [action=set-true takes=0..=0 global]
 

--- a/crates/rimz/src/cli/web.rs
+++ b/crates/rimz/src/cli/web.rs
@@ -1,4 +1,4 @@
-//! `rimz web` — browser access through the shared ttyd daemon.
+//! `rimz web` — writable browser access and read-only room broadcasts.
 
 use std::io::Write as _;
 use std::net::SocketAddr;
@@ -23,6 +23,10 @@ enum WebSubcmd {
     Open(WebOpenArgs),
     /// Print the current workspace's web URL without starting the daemon.
     Url(WebUrlArgs),
+    /// Share one live room as an unauthenticated read-only broadcast.
+    Share(WebShareArgs),
+    /// Stop sharing one room or every room.
+    Unshare(WebUnshareArgs),
     /// Report the shared ttyd daemon's status.
     Status(WebStatusArgs),
     /// Start the shared ttyd daemon.
@@ -41,6 +45,8 @@ enum WebSubcmd {
     Exec {
         #[arg(value_name = "SESSION")]
         session: Option<String>,
+        #[arg(long)]
+        share: bool,
     },
     /// Restrict and forward connections to the shared ttyd daemon.
     #[command(hide = true)]
@@ -95,6 +101,35 @@ struct WebUrlArgs {
 }
 
 #[derive(Debug, Args)]
+struct WebShareArgs {
+    /// Workspace path. Defaults to the current directory.
+    #[arg(value_name = "PATH")]
+    path: Option<PathBuf>,
+    /// Existing live RimZ session to share instead of resolving a path.
+    #[arg(long, conflicts_with = "path")]
+    session: Option<String>,
+    /// Print the URL without launching a browser.
+    #[arg(long)]
+    print: bool,
+    /// Emit the versioned `rimz.web.share.v1` payload.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
+struct WebUnshareArgs {
+    /// Workspace path. Defaults to the current directory.
+    #[arg(value_name = "PATH", conflicts_with = "session")]
+    path: Option<PathBuf>,
+    /// RimZ session name to stop sharing.
+    #[arg(long)]
+    session: Option<String>,
+    /// Stop sharing every room.
+    #[arg(long, conflicts_with_all = ["path", "session"])]
+    all: bool,
+}
+
+#[derive(Debug, Args)]
 struct WebStatusArgs {
     /// Emit JSON.
     #[arg(long)]
@@ -129,12 +164,14 @@ pub fn run(args: WebArgs, globals: &GlobalFlags) -> Result<()> {
     })) {
         WebSubcmd::Open(args) => open(args, globals),
         WebSubcmd::Url(args) => url(args, globals),
+        WebSubcmd::Share(args) => share(args, globals),
+        WebSubcmd::Unshare(args) => unshare(args, globals),
         WebSubcmd::Status(args) => status(args),
         WebSubcmd::Start => start(),
         WebSubcmd::Restart => restart(),
         WebSubcmd::Stop => stop(),
         WebSubcmd::Token { command } => token(command),
-        WebSubcmd::Exec { session } => exec(session.as_deref()),
+        WebSubcmd::Exec { session, share } => exec(session.as_deref(), share),
         WebSubcmd::Gate {
             listen,
             upstream,
@@ -209,6 +246,66 @@ fn url(args: WebUrlArgs, globals: &GlobalFlags) -> Result<()> {
     }
 }
 
+fn share(args: WebShareArgs, globals: &GlobalFlags) -> Result<()> {
+    let config = machine_config();
+    ensure_web_enabled(&config)?;
+    let context = if let Some(session) = args.session {
+        room::web_room_for_session(&session, globals)?
+    } else {
+        let path = args.path.unwrap_or_else(|| PathBuf::from("."));
+        room::existing_web_room_for_path(&path, globals)?
+    };
+    let outcome = rimz::web::share_session(context.session_name(), &config)?;
+    crate::cli::render::web_warnings(&outcome.warnings);
+    if args.json {
+        return crate::cli::render::json(&outcome.payload);
+    }
+    print_url(&outcome.payload.url)?;
+    if !args.print {
+        open_browser_best_effort(&outcome.payload.url);
+    }
+    Ok(())
+}
+
+fn unshare(args: WebUnshareArgs, globals: &GlobalFlags) -> Result<()> {
+    let config = machine_config();
+    if args.all {
+        let outcome = rimz::web::unshare_all(&config)?;
+        writeln!(
+            std::io::stdout().lock(),
+            "{}",
+            if outcome.changed {
+                "stopped sharing all rooms"
+            } else {
+                "no rooms were shared"
+            }
+        )?;
+        return Ok(());
+    }
+    let session = if let Some(session) = args.session {
+        session
+    } else {
+        let path = args.path.unwrap_or_else(|| PathBuf::from("."));
+        rimz::WorkspaceResolver::resolve(&path, globals.root.clone())
+            .with_context(|| format!("resolving workspace at {}", path.display()))?
+            .session_name
+    };
+    let outcome = rimz::web::unshare_session(&session, &config)?;
+    if let Some(daemon) = &outcome.daemon {
+        crate::cli::render::web_warnings(&daemon.warnings);
+    }
+    writeln!(
+        std::io::stdout().lock(),
+        "{}",
+        if outcome.changed {
+            format!("stopped sharing `{session}`")
+        } else {
+            format!("`{session}` was not shared")
+        }
+    )?;
+    Ok(())
+}
+
 fn status(args: WebStatusArgs) -> Result<()> {
     let status = rimz::web::status(&machine_config())?;
     if args.json {
@@ -226,6 +323,29 @@ fn status(args: WebStatusArgs) -> Result<()> {
             stdout,
             "ttyd: offline (configured listener {})",
             listener_display(&status.interface, status.port)
+        )?;
+    }
+    if let Some(pid) = status.share.pid {
+        let sessions = if status.share.sessions.is_empty() {
+            "(none)".to_owned()
+        } else {
+            status.share.sessions.join(", ")
+        };
+        writeln!(
+            stdout,
+            "share: online on {} (pid {pid}), sharing: {sessions}",
+            listener_display(&status.share.interface, status.share.port)
+        )?;
+    } else {
+        writeln!(
+            stdout,
+            "share: offline (configured listener {}), sharing: {}",
+            listener_display(&status.share.interface, status.share.port),
+            if status.share.sessions.is_empty() {
+                "(none)".to_owned()
+            } else {
+                status.share.sessions.join(", ")
+            }
         )?;
     }
     Ok(())
@@ -258,11 +378,20 @@ fn restart() -> Result<()> {
             "ttyd: was offline; started a fresh daemon"
         )?;
     }
+    if let Some(share) = outcome.share {
+        crate::cli::render::web_warnings(&share.warnings);
+        writeln!(
+            std::io::stdout().lock(),
+            "share: online on {} (pid {})",
+            listener_display(&share.interface, share.port),
+            share.pid
+        )?;
+    }
     Ok(())
 }
 
 fn stop() -> Result<()> {
-    let stopped = usize::from(rimz::web::stop_daemon()?);
+    let stopped = rimz::web::stop_daemons()?;
     writeln!(
         std::io::stdout().lock(),
         "stopped {} ttyd daemon{}",
@@ -309,9 +438,22 @@ fn render_revoked(stopped: bool) -> Result<()> {
     Ok(())
 }
 
-fn exec(session: Option<&str>) -> Result<()> {
-    let spec = rimz::web::existing_session_attach_command(session)?;
+fn exec(session: Option<&str>, share: bool) -> Result<()> {
+    let spec = if share {
+        rimz::web::share_attach_command(session)?
+    } else {
+        rimz::web::existing_session_attach_command(session)?
+    };
     room::exec_attach_command(&spec)
+}
+
+fn ensure_web_enabled(config: &rimz::config::MachineConfig) -> Result<()> {
+    if !config.web.enabled {
+        bail!(
+            "Browser access is disabled: set `[web] enabled = true` in the RimZ config on the machine serving this room (`rimz config path`) to allow browser sharing."
+        );
+    }
+    Ok(())
 }
 
 fn write_web_credential(credential: &WebCredential) {

--- a/crates/rimz/src/config/template_tests.rs
+++ b/crates/rimz/src/config/template_tests.rs
@@ -73,6 +73,7 @@ fn template_covers_serialized_default_leaves() {
         "web.auth_header".to_owned(),
         "web.base_url".to_owned(),
         "web.font_source".to_owned(),
+        "web.share_base_url".to_owned(),
         "web.trusted_proxies".to_owned(),
     ]);
     for path in template.difference(&expected) {

--- a/crates/rimz/src/config/templates/config.template.toml
+++ b/crates/rimz/src/config/templates/config.template.toml
@@ -80,8 +80,10 @@
 # The daemon listens on loopback by default; `rimz remote connect --web` forwards Basic Auth over SSH.
 # enabled = true                      # best-effort start the daemon with each room and allow rimz web / remote --web
 # port = 8200                         # exact port for the shared daemon
+# share_port = 8201                   # exact port for the unauthenticated read-only broadcast daemon
 # interface = "127.0.0.1"             # listener IP; use a non-loopback address only with a firewall or trusted_proxies
 ## base_url = "https://devbox.example/rimz" # public URL when a reverse proxy fronts ttyd
+## share_base_url = "https://watch.example/rimz" # public URL when a reverse proxy fronts read-only broadcasts
 ## auth_header = "X-Authentik-Username" # delegate auth to a proxy that injects this trusted header; disables Basic Auth
 ## trusted_proxies = ["172.18.0.0/16"] # source CIDRs allowed to reach ttyd; loopback is always allowed
 # font = "JetBrainsMono Nerd Font Mono" # browser terminal font; built-in JetBrainsMono and CaskaydiaCove Nerd Font Mono presets download automatically

--- a/crates/rimz/src/config/tests.rs
+++ b/crates/rimz/src/config/tests.rs
@@ -104,7 +104,12 @@ fn assert_web_config(config: &MachineConfig) {
         Some("https://devbox.example/rimz")
     );
     assert_eq!(config.web.port, 9123);
+    assert_eq!(config.web.share_port, 9124);
     assert_eq!(config.web.interface, "0.0.0.0");
+    assert_eq!(
+        config.web.share_base_url.as_deref(),
+        Some("https://watch.example/rimz")
+    );
     assert_eq!(config.web.auth_header.as_deref(), Some("X-Forwarded-User"));
     assert_eq!(config.web.trusted_proxies, ["10.0.0.0/8", "fd00::/8"]);
     assert_eq!(config.web.font, "FiraCode Nerd Font Mono");
@@ -1616,6 +1621,7 @@ fn notifications_parse_per_machine_preferences() {
 fn web_enabled_defaults_on_and_parses_off() {
     assert!(WebPrefs::default().enabled);
     assert_eq!(WebPrefs::default().port, 8200);
+    assert_eq!(WebPrefs::default().share_port, 8201);
     assert_eq!(WebPrefs::default().interface, "127.0.0.1");
     assert!(WebPrefs::default().auth_header.is_none());
     assert!(WebPrefs::default().trusted_proxies.is_empty());
@@ -1638,8 +1644,10 @@ fn scalar_sections_parse_non_default_values() {
             "[web]\n\
              enabled = false\n\
              port = 9123\n\
+             share_port = 9124\n\
              interface = \"0.0.0.0\"\n\
              base_url = \"https://devbox.example/rimz\"\n\
+             share_base_url = \"https://watch.example/rimz\"\n\
              auth_header = \"X-Forwarded-User\"\n\
              trusted_proxies = [\"10.0.0.0/8\", \"fd00::/8\"]\n\
              font = \"FiraCode Nerd Font Mono\"\n\

--- a/crates/rimz/src/config/web.rs
+++ b/crates/rimz/src/config/web.rs
@@ -3,18 +3,22 @@ use serde::{Deserialize, Serialize};
 /// Browser-access preferences for the machine-wide ttyd daemon.
 ///
 /// These are per-machine preferences: the interface and port select the
-/// listener, trusted-header authentication and proxy CIDRs constrain access,
-/// base URLs can name private hostnames or reverse-proxy paths, font sources
-/// name read-only paths or HTTPS URLs, and no field executes a command. The
-/// section therefore stays outside the project trust hash.
+/// writable and broadcast listeners, trusted-header authentication and proxy
+/// CIDRs constrain writable access, base URLs can name private hostnames or
+/// reverse-proxy paths, font sources name read-only paths or HTTPS URLs, and no
+/// field executes a command. The section therefore stays outside the project
+/// trust hash.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct WebPrefs {
     pub enabled: bool,
     pub port: u16,
+    pub share_port: u16,
     pub interface: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub share_base_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_header: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -30,8 +34,10 @@ impl Default for WebPrefs {
         Self {
             enabled: true,
             port: 8200,
+            share_port: 8201,
             interface: "127.0.0.1".to_owned(),
             base_url: None,
+            share_base_url: None,
             auth_header: None,
             trusted_proxies: Vec::new(),
             font: "JetBrainsMono Nerd Font Mono".to_owned(),

--- a/crates/rimz/src/mux/mod.rs
+++ b/crates/rimz/src/mux/mod.rs
@@ -787,6 +787,9 @@ pub trait MuxBackend: Send + Sync {
     fn attach_command(&self, name: &str, config: &crate::config::MultiplexerConfig) -> CommandSpec;
     /// Attach to a live session without creating a missing session.
     fn attach_existing_command(&self, name: &str) -> CommandSpec;
+    /// Attach a browser broadcast client without granting mux input where the
+    /// backend supports that distinction.
+    fn attach_readonly_command(&self, name: &str) -> CommandSpec;
     fn detach(&self, name: &str) -> Result<()>;
     /// Force-remove a session by name. A missing session is success — the goal
     /// state is "no session by that name", so callers can retire a stale or

--- a/crates/rimz/src/mux/tmux/backend.rs
+++ b/crates/rimz/src/mux/tmux/backend.rs
@@ -187,6 +187,19 @@ impl MuxBackend for TmuxBackend {
         self.cmd().args(["attach", "-t", name])
     }
 
+    fn attach_readonly_command(&self, name: &str) -> CommandSpec {
+        let mut spec = self.cmd().args(["attach", "-t", name, "-r"]);
+        if self
+            .version()
+            .ok()
+            .and_then(|raw| super::parse_version(&raw))
+            .is_some_and(|version| version >= (3, 2, 0))
+        {
+            spec = spec.args(["-f", "ignore-size"]);
+        }
+        spec
+    }
+
     fn detach(&self, name: &str) -> Result<()> {
         self.cmd()
             .args(["detach-client", "-s", name])

--- a/crates/rimz/src/mux/tmux/tests.rs
+++ b/crates/rimz/src/mux/tmux/tests.rs
@@ -41,6 +41,21 @@ fn existing_session_attach_targets_the_managed_server() {
 }
 
 #[test]
+fn readonly_attach_blocks_input_and_ignores_viewer_size() {
+    let backend = TmuxBackend::with_socket("/run/user/1000/rimz/tmux/server");
+    backend
+        .version
+        .set("tmux 3.5".to_owned())
+        .expect("fresh version cache");
+    let spec = backend.attach_readonly_command("rimz-test");
+
+    assert_eq!(
+        verb_args(&spec),
+        ["attach", "-t", "rimz-test", "-r", "-f", "ignore-size"]
+    );
+}
+
+#[test]
 fn the_managed_endpoint_needs_no_workspace_to_reconstruct() {
     // Any caller rebuilds the same endpoint from the runtime domain alone —
     // this is what keeps `backend_for(MuxName)` free of a workspace argument.

--- a/crates/rimz/src/mux/zellij/backend.rs
+++ b/crates/rimz/src/mux/zellij/backend.rs
@@ -456,6 +456,11 @@ impl MuxBackend for ZellijBackend {
         self.cmd().args(["attach", name])
     }
 
+    fn attach_readonly_command(&self, name: &str) -> CommandSpec {
+        // Zellij has no read-only attach; broadcast ttyd drops all client input.
+        self.attach_existing_command(name)
+    }
+
     fn detach(&self, _name: &str) -> Result<()> {
         self.cmd().args(["action", "detach"]).run().map(|_| ())
     }

--- a/crates/rimz/src/mux/zellij/tests.rs
+++ b/crates/rimz/src/mux/zellij/tests.rs
@@ -107,6 +107,13 @@ fn existing_session_attach_has_no_creation_or_options_tail() {
     assert!(!spec.args.iter().any(|arg| arg == "options"));
 }
 
+#[test]
+fn readonly_attach_relies_on_the_broadcast_ttyd_input_boundary() {
+    let spec = ZellijBackend::new().attach_readonly_command("rimz-test");
+
+    assert_eq!(spec.args, ["attach", "rimz-test"]);
+}
+
 #[cfg(unix)]
 fn terminal_pane(
     id: u64,

--- a/crates/rimz/src/sidebar_pane/pixel/probe.rs
+++ b/crates/rimz/src/sidebar_pane/pixel/probe.rs
@@ -35,7 +35,7 @@ trait Probe {
     fn tmux_rendering_clients(&self, session_name: &str) -> io::Result<Vec<RenderingClient>>;
     fn tmux_session_name(&self) -> io::Result<String>;
     fn processes(&self) -> Vec<crate::proc::ProcInfo>;
-    fn pixel_daemon_record(&self) -> Option<(u32, u32)>;
+    fn pixel_daemon_records(&self) -> Vec<(u32, u32)>;
     fn env_var(&self, key: &str) -> Option<String>;
 }
 
@@ -168,8 +168,8 @@ impl Probe for LiveProbe {
         crate::proc::list_processes()
     }
 
-    fn pixel_daemon_record(&self) -> Option<(u32, u32)> {
-        crate::web::pixel_daemon_record()
+    fn pixel_daemon_records(&self) -> Vec<(u32, u32)> {
+        crate::web::pixel_daemon_records()
     }
 
     fn env_var(&self, key: &str) -> Option<String> {
@@ -192,19 +192,25 @@ fn rendering_clients_allowed(clients: &[RenderingClient], probe: &impl Probe) ->
     {
         return true;
     }
-    let Some((daemon_pid, protocol)) = probe.pixel_daemon_record() else {
-        return false;
-    };
-    if protocol != crate::web::TTYD_PIXEL_PROTOCOL {
-        return false;
-    }
     let processes = probe.processes();
-    let daemon_live = processes.iter().any(|process| {
-        process.pid == daemon_pid && crate::proc::command::program_label(&process.cmdline) == "ttyd"
-    });
-    daemon_live
+    let daemons = probe
+        .pixel_daemon_records()
+        .into_iter()
+        .filter(|(_, protocol)| *protocol == crate::web::TTYD_PIXEL_PROTOCOL)
+        .map(|(pid, _)| pid)
+        .filter(|pid| {
+            processes.iter().any(|process| {
+                process.pid == *pid
+                    && crate::proc::command::program_label(&process.cmdline) == "ttyd"
+            })
+        })
+        .collect::<Vec<_>>();
+    !daemons.is_empty()
         && clients.iter().all(|client| {
-            termname_allowed(&client.termname) || descends_from(client.pid, daemon_pid, &processes)
+            termname_allowed(&client.termname)
+                || daemons
+                    .iter()
+                    .any(|daemon| descends_from(client.pid, *daemon, &processes))
         })
 }
 

--- a/crates/rimz/src/sidebar_pane/pixel/probe/tests.rs
+++ b/crates/rimz/src/sidebar_pane/pixel/probe/tests.rs
@@ -20,7 +20,7 @@ struct FakeProbe {
     termnames: Option<Vec<String>>,
     session_name: Option<String>,
     processes: Vec<crate::proc::ProcInfo>,
-    daemon_record: Option<(u32, u32)>,
+    daemon_records: Vec<(u32, u32)>,
     env: BTreeMap<String, String>,
     passthrough_targets: RefCell<Vec<String>>,
     passthrough_all_panes: RefCell<Vec<String>>,
@@ -35,7 +35,7 @@ impl FakeProbe {
             termnames: Some(vec!["xterm-ghostty".to_owned()]),
             session_name: Some(TEST_SESSION.to_owned()),
             processes: Vec::new(),
-            daemon_record: None,
+            daemon_records: Vec::new(),
             env: BTreeMap::new(),
             passthrough_targets: RefCell::new(Vec::new()),
             passthrough_all_panes: RefCell::new(Vec::new()),
@@ -98,8 +98,8 @@ impl Probe for FakeProbe {
         self.processes.clone()
     }
 
-    fn pixel_daemon_record(&self) -> Option<(u32, u32)> {
-        self.daemon_record
+    fn pixel_daemon_records(&self) -> Vec<(u32, u32)> {
+        self.daemon_records.clone()
     }
 
     fn env_var(&self, key: &str) -> Option<String> {
@@ -454,7 +454,7 @@ fn ttyd_descendant_client_requires_live_matching_protocol_daemon() {
             process(10, 1, "/usr/bin/ttyd -p 8200"),
             process(100, 10, "tmux attach -t rimz-test"),
         ],
-        daemon_record: Some((10, crate::web::TTYD_PIXEL_PROTOCOL)),
+        daemon_records: vec![(10, crate::web::TTYD_PIXEL_PROTOCOL)],
         ..FakeProbe::ok()
     };
     assert!(
@@ -471,19 +471,19 @@ fn ttyd_descendant_client_requires_live_matching_protocol_daemon() {
         FakeProbe {
             termnames: Some(vec!["xterm-256color".to_owned()]),
             processes: capable.processes.clone(),
-            daemon_record: None,
+            daemon_records: Vec::new(),
             ..FakeProbe::ok()
         },
         FakeProbe {
             termnames: Some(vec!["xterm-256color".to_owned()]),
             processes: capable.processes.clone(),
-            daemon_record: Some((10, crate::web::TTYD_PIXEL_PROTOCOL + 1)),
+            daemon_records: vec![(10, crate::web::TTYD_PIXEL_PROTOCOL + 1)],
             ..FakeProbe::ok()
         },
         FakeProbe {
             termnames: Some(vec!["xterm-256color".to_owned()]),
             processes: vec![process(100, 10, "tmux attach -t rimz-test")],
-            daemon_record: Some((10, crate::web::TTYD_PIXEL_PROTOCOL)),
+            daemon_records: vec![(10, crate::web::TTYD_PIXEL_PROTOCOL)],
             ..FakeProbe::ok()
         },
         FakeProbe {
@@ -492,7 +492,7 @@ fn ttyd_descendant_client_requires_live_matching_protocol_daemon() {
                 process(10, 1, "sleep 60"),
                 process(100, 10, "tmux attach -t rimz-test"),
             ],
-            daemon_record: Some((10, crate::web::TTYD_PIXEL_PROTOCOL)),
+            daemon_records: vec![(10, crate::web::TTYD_PIXEL_PROTOCOL)],
             ..FakeProbe::ok()
         },
     ] {
@@ -520,7 +520,7 @@ fn ttyd_ancestry_walk_is_bounded_to_four_hops() {
             process(22, 23, "sh"),
             process(23, 10, "sh"),
         ],
-        daemon_record: Some((10, crate::web::TTYD_PIXEL_PROTOCOL)),
+        daemon_records: vec![(10, crate::web::TTYD_PIXEL_PROTOCOL)],
         ..FakeProbe::ok()
     };
 
@@ -543,7 +543,7 @@ fn native_and_ttyd_clients_share_the_all_clients_gate() {
             process(10, 1, "ttyd -p 8200"),
             process(101, 10, "tmux attach"),
         ],
-        daemon_record: Some((10, crate::web::TTYD_PIXEL_PROTOCOL)),
+        daemon_records: vec![(10, crate::web::TTYD_PIXEL_PROTOCOL)],
         ..FakeProbe::ok()
     };
     assert!(
@@ -563,7 +563,7 @@ fn native_and_ttyd_clients_share_the_all_clients_gate() {
             "screen-256color".to_owned(),
         ]),
         processes: capable.processes.clone(),
-        daemon_record: capable.daemon_record,
+        daemon_records: capable.daemon_records.clone(),
         ..FakeProbe::ok()
     };
     assert!(
@@ -572,6 +572,37 @@ fn native_and_ttyd_clients_share_the_all_clients_gate() {
             TEST_SESSION,
             PixelRenderCaps::default(),
             &foreign,
+        )
+        .kitty_clients
+    );
+}
+
+#[test]
+fn clients_from_writable_and_broadcast_ttyd_daemons_are_pixel_capable() {
+    let probe = FakeProbe {
+        termnames: Some(vec![
+            "xterm-256color".to_owned(),
+            "xterm-256color".to_owned(),
+        ]),
+        processes: vec![
+            process(10, 1, "ttyd -p 8200"),
+            process(20, 1, "ttyd -p 8201"),
+            process(100, 10, "tmux attach -t rimz-test"),
+            process(101, 20, "tmux attach -r -t rimz-test"),
+        ],
+        daemon_records: vec![
+            (10, crate::web::TTYD_PIXEL_PROTOCOL),
+            (20, crate::web::TTYD_PIXEL_PROTOCOL),
+        ],
+        ..FakeProbe::ok()
+    };
+
+    assert!(
+        detect_with(
+            MuxName::Tmux,
+            TEST_SESSION,
+            PixelRenderCaps::default(),
+            &probe,
         )
         .kitty_clients
     );

--- a/crates/rimz/src/web/mod.rs
+++ b/crates/rimz/src/web/mod.rs
@@ -15,6 +15,7 @@ use crate::room::session::{LiveSessions, workspace_record_for_session};
 use crate::store::atomic;
 
 mod gate;
+mod share;
 mod ttyd;
 
 pub use gate::GateAuth;
@@ -22,8 +23,11 @@ pub use gate::GateAuth;
 pub const WEB_SCHEMA_VERSION: &str = "rimz.web.v2";
 pub(crate) const TTYD_PIXEL_PROTOCOL: u32 = 2;
 
-pub(crate) fn pixel_daemon_record() -> Option<(u32, u32)> {
-    ttyd::pixel_daemon_record()
+pub(crate) fn pixel_daemon_records() -> Vec<(u32, u32)> {
+    [ttyd::pixel_daemon_record(), share::pixel_daemon_record()]
+        .into_iter()
+        .flatten()
+        .collect()
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -61,7 +65,15 @@ pub enum WebErr {
     )]
     ConfiguredPortInUse { port: u16 },
     #[error(
-        "ttyd read-only access is per process, not per credential; read-only credentials are not supported"
+        "[web] share_port {port} is already in use by another process; choose a free port in `rimz config path`"
+    )]
+    ConfiguredSharePortInUse { port: u16 },
+    #[error(
+        "the read-only broadcast ttyd daemon did not accept connections on {address} within 5 seconds"
+    )]
+    ShareStartTimeout { address: SocketAddr },
+    #[error(
+        "ttyd read-only access is per process, not per credential; use `rimz web share` for a read-only broadcast"
     )]
     TtydReadOnlyCredential,
     #[error(
@@ -168,6 +180,26 @@ pub struct WebStatusPayload {
     pub pid: Option<u32>,
     pub interface: String,
     pub port: u16,
+    #[serde(default)]
+    pub share: WebShareStatus,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WebShareStatus {
+    pub online: bool,
+    pub pid: Option<u32>,
+    pub interface: String,
+    pub port: u16,
+    #[serde(default)]
+    pub sessions: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WebSharePayload {
+    pub version: String,
+    pub url: String,
+    pub session: String,
+    pub port: u16,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -176,6 +208,7 @@ pub enum WebWarning {
     BrowserFontSkipped(String),
     BrowserThemeSkipped(String),
     HeaderAuthUnprotected(String),
+    BroadcastUnauthenticated(String),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -193,12 +226,33 @@ pub struct WebDaemonOutcome {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WebShareOutcome {
+    pub payload: WebSharePayload,
+    pub changed: bool,
+    pub warnings: Vec<WebWarning>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WebUnshareOutcome {
+    pub changed: bool,
+    pub sessions: Vec<String>,
+    pub daemon: Option<WebDaemonOutcome>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WebRestartOutcome {
     pub pid: u32,
     pub interface: String,
     pub port: u16,
     pub was_online: bool,
     pub warnings: Vec<WebWarning>,
+    pub share: Option<WebDaemonOutcome>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WebReloadOutcome {
+    pub writable: Option<WebDaemonOutcome>,
+    pub share: Option<WebDaemonOutcome>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -269,24 +323,26 @@ pub fn ensure_daemon(config: &MachineConfig) -> Result<WebDaemonOutcome> {
 
 pub fn restart_daemon(config: &MachineConfig) -> Result<WebRestartOutcome> {
     let (daemon, was_online) = ttyd::restart_daemon(config)?;
+    let share = share::restart_if_shared(config)?.map(share_daemon_outcome);
     Ok(WebRestartOutcome {
         pid: daemon.pid,
         interface: daemon.interface,
         port: daemon.port,
         was_online,
         warnings: daemon.warnings,
+        share,
     })
 }
 
-pub fn restart_if_online(config: &MachineConfig) -> Result<Option<WebDaemonOutcome>> {
-    ttyd::restart_if_online(config).map(|daemon| {
-        daemon.map(|daemon| WebDaemonOutcome {
-            pid: daemon.pid,
-            interface: daemon.interface,
-            port: daemon.port,
-            warnings: daemon.warnings,
-        })
-    })
+pub fn restart_if_online(config: &MachineConfig) -> Result<WebReloadOutcome> {
+    let writable = ttyd::restart_if_online(config)?.map(|daemon| WebDaemonOutcome {
+        pid: daemon.pid,
+        interface: daemon.interface,
+        port: daemon.port,
+        warnings: daemon.warnings,
+    });
+    let share = share::restart_if_online(config)?.map(share_daemon_outcome);
+    Ok(WebReloadOutcome { writable, share })
 }
 
 pub fn credential_summary() -> Result<Option<CredentialSummary>> {
@@ -335,6 +391,8 @@ pub fn revoke_credential(name: Option<&str>) -> Result<bool> {
 
 pub fn status(config: &MachineConfig) -> Result<WebStatusPayload> {
     let daemon = ttyd::daemon_status()?;
+    let share_daemon = share::daemon_status()?;
+    let shared_sessions = share::sessions()?;
     Ok(WebStatusPayload {
         version: WEB_SCHEMA_VERSION.to_owned(),
         online: daemon.is_some(),
@@ -344,11 +402,83 @@ pub fn status(config: &MachineConfig) -> Result<WebStatusPayload> {
             |record| record.interface.clone(),
         ),
         port: daemon.map_or(config.web.port, |record| record.port),
+        share: WebShareStatus {
+            online: share_daemon.is_some(),
+            pid: share_daemon.as_ref().map(|record| record.pid),
+            interface: share_daemon.as_ref().map_or_else(
+                || config.web.interface.clone(),
+                |record| record.interface.clone(),
+            ),
+            port: share_daemon.map_or(config.web.share_port, |record| record.port),
+            sessions: shared_sessions,
+        },
     })
 }
 
-pub fn stop_daemon() -> Result<bool> {
-    ttyd::stop_daemon()
+pub fn stop_daemons() -> Result<usize> {
+    Ok(usize::from(ttyd::stop_daemon()?) + usize::from(share::stop_daemon()?))
+}
+
+pub fn share_session(session: &str, config: &MachineConfig) -> Result<WebShareOutcome> {
+    if live_session_target(Some(session)).is_none() {
+        return Err(WebErr::InvalidSession("this room is not shared".to_owned()));
+    }
+    let (daemon, changed) = share::add_session(session, config)?;
+    let base_url = normalized_base_url(config.web.share_base_url.as_deref(), daemon.record.port);
+    Ok(WebShareOutcome {
+        payload: WebSharePayload {
+            version: "rimz.web.share.v1".to_owned(),
+            url: join_session_url(&base_url, session),
+            session: session.to_owned(),
+            port: daemon.record.port,
+        },
+        changed,
+        warnings: daemon.warnings,
+    })
+}
+
+pub fn unshare_session(session: &str, config: &MachineConfig) -> Result<WebUnshareOutcome> {
+    let mutation = share::remove_session(session, config)?;
+    Ok(WebUnshareOutcome {
+        changed: mutation.changed,
+        sessions: mutation.sessions,
+        daemon: mutation.daemon.map(share_daemon_outcome),
+    })
+}
+
+pub fn unshare_all(config: &MachineConfig) -> Result<WebUnshareOutcome> {
+    let mutation = share::remove_all(config)?;
+    Ok(WebUnshareOutcome {
+        changed: mutation.changed,
+        sessions: mutation.sessions,
+        daemon: mutation.daemon.map(share_daemon_outcome),
+    })
+}
+
+pub fn shared_sessions() -> Result<Vec<String>> {
+    share::sessions()
+}
+
+pub fn share_attach_command(session: Option<&str>) -> Result<CommandSpec> {
+    let Some(session) = session.filter(|session| !session.is_empty()) else {
+        return Err(WebErr::InvalidSession("this room is not shared".to_owned()));
+    };
+    if !share::contains(session)? {
+        return Err(WebErr::InvalidSession("this room is not shared".to_owned()));
+    }
+    let Some((session, mux)) = live_session_target(Some(session)) else {
+        return Err(WebErr::InvalidSession("this room is not shared".to_owned()));
+    };
+    Ok(crate::mux::backend_for(mux).attach_readonly_command(session))
+}
+
+fn share_daemon_outcome(daemon: share::RunningDaemon) -> WebDaemonOutcome {
+    WebDaemonOutcome {
+        pid: daemon.record.pid,
+        interface: daemon.record.interface,
+        port: daemon.record.port,
+        warnings: daemon.warnings,
+    }
 }
 
 const WEB_ADDRESSABLE_TIMEOUT: Duration = Duration::from_secs(5);
@@ -379,20 +509,32 @@ pub fn ensure_session_addressable(mux: MuxName, session: &str) -> Result<()> {
 
 pub fn existing_session_attach_command(session: Option<&str>) -> Result<CommandSpec> {
     let live = LiveSessions::probe();
-    let target = session
-        .filter(|session| !session.is_empty())
-        .and_then(|session| {
-            workspace_record_for_session(session)
-                .ok()
-                .flatten()
-                .and_then(|_| live.mux_of(session).map(|mux| (session, mux)))
-        });
+    let target = live_session_target_with_probe(session, &live);
     let Some((session, mux)) = target else {
         return Err(WebErr::InvalidSession(invalid_session_message(
             session, &live,
         )?));
     };
     Ok(crate::mux::backend_for(mux).attach_existing_command(session))
+}
+
+fn live_session_target(session: Option<&str>) -> Option<(&str, MuxName)> {
+    let live = LiveSessions::probe();
+    live_session_target_with_probe(session, &live)
+}
+
+fn live_session_target_with_probe<'a>(
+    session: Option<&'a str>,
+    live: &LiveSessions,
+) -> Option<(&'a str, MuxName)> {
+    session
+        .filter(|session| !session.is_empty())
+        .and_then(|session| {
+            workspace_record_for_session(session)
+                .ok()
+                .flatten()
+                .and_then(|_| live.mux_of(session).map(|mux| (session, mux)))
+        })
 }
 
 fn invalid_session_message(session: Option<&str>, live: &LiveSessions) -> Result<String> {
@@ -513,5 +655,34 @@ mod tests {
         .expect("old v2 payload");
         assert_eq!(basic.auth, WebAuth::Basic);
         assert_eq!(basic.tunnel_port, None);
+    }
+
+    #[test]
+    fn status_share_block_is_additive_to_v2() {
+        let old: WebStatusPayload = serde_json::from_str(
+            r#"{"version":"rimz.web.v2","online":false,"pid":null,"interface":"127.0.0.1","port":8200}"#,
+        )
+        .expect("old status payload");
+        assert_eq!(old.share, WebShareStatus::default());
+
+        let status = WebStatusPayload {
+            version: WEB_SCHEMA_VERSION.to_owned(),
+            online: true,
+            pid: Some(10),
+            interface: "127.0.0.1".to_owned(),
+            port: 8200,
+            share: WebShareStatus {
+                online: true,
+                pid: Some(20),
+                interface: "127.0.0.1".to_owned(),
+                port: 8201,
+                sessions: vec!["rimz-test".to_owned()],
+            },
+        };
+        let roundtrip = serde_json::from_slice::<WebStatusPayload>(
+            &serde_json::to_vec(&status).expect("serialize status"),
+        )
+        .expect("parse status");
+        assert_eq!(roundtrip, status);
     }
 }

--- a/crates/rimz/src/web/share.rs
+++ b/crates/rimz/src/web/share.rs
@@ -1,0 +1,452 @@
+//! Durable room allowlist and unauthenticated read-only ttyd daemon.
+
+use std::net::{IpAddr, SocketAddr, TcpStream};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::MachineConfig;
+use crate::mux::CommandSpec;
+use crate::store::{atomic, paths};
+
+use super::{Result, TTYD_PIXEL_PROTOCOL, WebErr, WebWarning, ttyd};
+
+const ALLOWLIST_FILE: &str = "web-share.json";
+const DAEMON_FILE: &str = "web-ttyd-share.json";
+const DAEMON_LOCK_FILE: &str = "web-ttyd-share.lock";
+const START_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct Allowlist {
+    #[serde(default)]
+    sessions: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct DaemonRecord {
+    pub(super) pid: u32,
+    pub(super) port: u16,
+    #[serde(default = "default_interface")]
+    pub(super) interface: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) pixel_protocol: Option<u32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct DaemonSpec {
+    port: u16,
+    interface: String,
+}
+
+pub(super) struct RunningDaemon {
+    pub(super) record: DaemonRecord,
+    pub(super) warnings: Vec<WebWarning>,
+}
+
+pub(super) struct ShareMutation {
+    pub(super) changed: bool,
+    pub(super) sessions: Vec<String>,
+    pub(super) daemon: Option<RunningDaemon>,
+}
+
+pub(super) fn add_session(session: &str, config: &MachineConfig) -> Result<(RunningDaemon, bool)> {
+    let desired = desired_spec(config)?;
+    let _guard = acquire_lock()?;
+    let mut allowlist = read_allowlist()?;
+    let previous = allowlist.clone();
+    let changed = !allowlist.sessions.iter().any(|shared| shared == session);
+    if changed {
+        allowlist.sessions.push(session.to_owned());
+        normalize(&mut allowlist.sessions);
+        write_allowlist(&allowlist)?;
+    }
+    match ensure_daemon_locked(config, &desired) {
+        Ok(daemon) => Ok((daemon, changed)),
+        Err(err) => {
+            if changed && let Err(rollback) = write_allowlist(&previous) {
+                tracing::error!(
+                    error = &rollback as &dyn std::error::Error,
+                    "could not roll back broadcast allowlist after daemon start failed"
+                );
+            }
+            Err(err)
+        }
+    }
+}
+
+pub(super) fn remove_session(session: &str, config: &MachineConfig) -> Result<ShareMutation> {
+    let _guard = acquire_lock()?;
+    let mut allowlist = read_allowlist()?;
+    let before = allowlist.sessions.len();
+    allowlist.sessions.retain(|shared| shared != session);
+    if allowlist.sessions.len() == before {
+        return Ok(ShareMutation {
+            changed: false,
+            sessions: allowlist.sessions,
+            daemon: None,
+        });
+    }
+    write_allowlist(&allowlist)?;
+    let daemon = restart_or_stop_locked(config, &allowlist)?;
+    Ok(ShareMutation {
+        changed: true,
+        sessions: allowlist.sessions,
+        daemon,
+    })
+}
+
+pub(super) fn remove_all(_config: &MachineConfig) -> Result<ShareMutation> {
+    let _guard = acquire_lock()?;
+    let allowlist = read_allowlist()?;
+    let changed = !allowlist.sessions.is_empty();
+    if changed {
+        write_allowlist(&Allowlist::default())?;
+    }
+    stop_daemon_locked()?;
+    Ok(ShareMutation {
+        changed,
+        sessions: Vec::new(),
+        daemon: None,
+    })
+}
+
+pub(super) fn sessions() -> Result<Vec<String>> {
+    let _guard = acquire_lock()?;
+    Ok(read_allowlist()?.sessions)
+}
+
+pub(super) fn contains(session: &str) -> Result<bool> {
+    let _guard = acquire_lock()?;
+    Ok(read_allowlist()?
+        .sessions
+        .iter()
+        .any(|shared| shared == session))
+}
+
+pub(super) fn daemon_status() -> Result<Option<DaemonRecord>> {
+    let _guard = acquire_lock()?;
+    daemon_status_locked()
+}
+
+pub(crate) fn pixel_daemon_record() -> Option<(u32, u32)> {
+    let bytes = std::fs::read(daemon_path()).ok()?;
+    let record = serde_json::from_slice::<DaemonRecord>(&bytes).ok()?;
+    record.pixel_protocol.map(|protocol| (record.pid, protocol))
+}
+
+pub(super) fn restart_if_shared(config: &MachineConfig) -> Result<Option<RunningDaemon>> {
+    let _guard = acquire_lock()?;
+    let allowlist = read_allowlist()?;
+    if allowlist.sessions.is_empty() {
+        stop_daemon_locked()?;
+        return Ok(None);
+    }
+    let desired = desired_spec(config)?;
+    restart_daemon_locked(config, &desired).map(Some)
+}
+
+pub(super) fn restart_if_online(config: &MachineConfig) -> Result<Option<RunningDaemon>> {
+    let _guard = acquire_lock()?;
+    if daemon_status_locked()?.is_none() {
+        return Ok(None);
+    }
+    if read_allowlist()?.sessions.is_empty() {
+        stop_daemon_locked()?;
+        return Ok(None);
+    }
+    let desired = desired_spec(config)?;
+    restart_daemon_locked(config, &desired).map(Some)
+}
+
+pub(super) fn stop_daemon() -> Result<bool> {
+    let _guard = acquire_lock()?;
+    stop_daemon_locked()
+}
+
+fn restart_or_stop_locked(
+    config: &MachineConfig,
+    allowlist: &Allowlist,
+) -> Result<Option<RunningDaemon>> {
+    if allowlist.sessions.is_empty() {
+        stop_daemon_locked()?;
+        Ok(None)
+    } else {
+        // Revocation wins over config or restart failures: disconnect the old
+        // process before validating and starting the replacement.
+        stop_daemon_locked()?;
+        let desired = desired_spec(config)?;
+        start_fresh_locked(config, &desired, None).map(Some)
+    }
+}
+
+fn desired_spec(config: &MachineConfig) -> Result<DaemonSpec> {
+    let interface = config
+        .web
+        .interface
+        .parse::<IpAddr>()
+        .map_err(|_| WebErr::InvalidInterface {
+            value: config.web.interface.clone(),
+        })?
+        .to_string();
+    Ok(DaemonSpec {
+        port: config.web.share_port,
+        interface,
+    })
+}
+
+fn ensure_daemon_locked(config: &MachineConfig, desired: &DaemonSpec) -> Result<RunningDaemon> {
+    let daemon = daemon_status_locked()?;
+    if let Some(record) = daemon.as_ref()
+        && record_matches(record, desired)
+    {
+        return Ok(running_daemon(record.clone(), desired, Vec::new()));
+    }
+    start_fresh_locked(config, desired, daemon)
+}
+
+fn restart_daemon_locked(config: &MachineConfig, desired: &DaemonSpec) -> Result<RunningDaemon> {
+    let daemon = daemon_status_locked()?;
+    start_fresh_locked(config, desired, daemon)
+}
+
+fn start_fresh_locked(
+    config: &MachineConfig,
+    desired: &DaemonSpec,
+    daemon: Option<DaemonRecord>,
+) -> Result<RunningDaemon> {
+    let program = ttyd::program()?;
+    let address = ttyd::socket_address(&desired.interface, desired.port)?;
+    if daemon.as_ref().is_none_or(|record| {
+        ttyd::socket_address(&record.interface, record.port).ok() != Some(address)
+    }) {
+        ensure_share_port_available(address)?;
+    }
+    let profile = ttyd::client::profile(config, &program);
+    if let Some(record) = daemon {
+        stop_record(&record)?;
+    }
+    ensure_share_port_available(address)?;
+    let interface = desired
+        .interface
+        .parse::<IpAddr>()
+        .map_err(|_| WebErr::InvalidInterface {
+            value: desired.interface.clone(),
+        })?;
+    let spec = spawn_spec(&program, interface, desired.port, &profile.args)?;
+    let pid = ttyd::spawn_detached(spec)?;
+    let probe = ttyd::probe_address(address);
+    if !ttyd::wait_for_address(probe, START_TIMEOUT) {
+        ttyd::terminate_pids(&[pid]);
+        return Err(WebErr::ShareStartTimeout { address: probe });
+    }
+    let record = DaemonRecord {
+        pid,
+        port: desired.port,
+        interface: desired.interface.clone(),
+        pixel_protocol: profile.pixel_protocol,
+    };
+    if let Err(err) = write_daemon(&record) {
+        let _ = stop_record(&record);
+        return Err(err);
+    }
+    Ok(running_daemon(record, desired, profile.warnings))
+}
+
+fn running_daemon(
+    record: DaemonRecord,
+    desired: &DaemonSpec,
+    mut warnings: Vec<WebWarning>,
+) -> RunningDaemon {
+    if desired
+        .interface
+        .parse::<IpAddr>()
+        .is_ok_and(|interface| !interface.is_loopback())
+    {
+        warnings.push(WebWarning::BroadcastUnauthenticated(format!(
+            "broadcast is unauthenticated; anyone reaching {}:{} can watch",
+            desired.interface, desired.port
+        )));
+    }
+    RunningDaemon { record, warnings }
+}
+
+fn record_matches(record: &DaemonRecord, desired: &DaemonSpec) -> bool {
+    record.port == desired.port
+        && record.interface == desired.interface
+        && record
+            .pixel_protocol
+            .is_none_or(|protocol| protocol == TTYD_PIXEL_PROTOCOL)
+}
+
+fn daemon_status_locked() -> Result<Option<DaemonRecord>> {
+    let path = daemon_path();
+    let Some(record) = ttyd::read_json_optional::<DaemonRecord>(&path)? else {
+        return Ok(None);
+    };
+    let processes = crate::proc::list_processes();
+    let ttyd_live = processes
+        .iter()
+        .any(|process| process.pid == record.pid && ttyd::is_ttyd_process(process));
+    let listening = ttyd::socket_address(&record.interface, record.port)
+        .ok()
+        .map(ttyd::probe_address)
+        .is_some_and(|address| TcpStream::connect(address).is_ok());
+    if ttyd_live && listening {
+        return Ok(Some(record));
+    }
+    if ttyd_live {
+        ttyd::terminate_pids(&[record.pid]);
+    }
+    ttyd::remove_optional(&path)?;
+    Ok(None)
+}
+
+fn stop_daemon_locked() -> Result<bool> {
+    let Some(record) = daemon_status_locked()? else {
+        return Ok(false);
+    };
+    stop_record(&record)?;
+    Ok(true)
+}
+
+fn stop_record(record: &DaemonRecord) -> Result<()> {
+    ttyd::terminate_pids(&[record.pid]);
+    #[cfg(unix)]
+    if let Ok(address) = ttyd::socket_address(&record.interface, record.port) {
+        ttyd::wait_for_address_close(ttyd::probe_address(address), Duration::from_secs(1));
+    }
+    ttyd::remove_optional(&daemon_path())?;
+    Ok(())
+}
+
+fn spawn_spec(
+    program: &Path,
+    interface: IpAddr,
+    port: u16,
+    extra_args: &[String],
+) -> Result<CommandSpec> {
+    let rimz_exe = std::env::current_exe().map_err(|source| WebErr::Io {
+        path: PathBuf::from("/proc/self/exe"),
+        source,
+    })?;
+    Ok(spawn_spec_for(
+        program, &rimz_exe, interface, port, extra_args,
+    ))
+}
+
+fn spawn_spec_for(
+    program: &Path,
+    rimz_exe: &Path,
+    interface: IpAddr,
+    port: u16,
+    extra_args: &[String],
+) -> CommandSpec {
+    CommandSpec::new(program.display().to_string())
+        .args(["-O", "-a", "-i", &interface.to_string(), "-p"])
+        .arg(port.to_string())
+        .args(extra_args.iter().cloned())
+        .arg(rimz_exe.display().to_string())
+        .args(["web", "exec", "--share"])
+}
+
+fn ensure_share_port_available(address: SocketAddr) -> Result<()> {
+    ttyd::ensure_port_available(address).map_err(|err| match err {
+        WebErr::ConfiguredPortInUse { port } => WebErr::ConfiguredSharePortInUse { port },
+        other => other,
+    })
+}
+
+fn normalize(sessions: &mut Vec<String>) {
+    sessions.sort();
+    sessions.dedup();
+}
+
+fn read_allowlist() -> Result<Allowlist> {
+    Ok(ttyd::read_json_optional(&allowlist_path())?.unwrap_or_default())
+}
+
+fn write_allowlist(allowlist: &Allowlist) -> Result<()> {
+    write_allowlist_at(&allowlist_path(), allowlist)
+}
+
+fn write_allowlist_at(path: &Path, allowlist: &Allowlist) -> Result<()> {
+    atomic::write_temp_then_rename_cache(path, allowlist)?;
+    Ok(())
+}
+
+fn write_daemon(record: &DaemonRecord) -> Result<()> {
+    atomic::write_temp_then_rename_cache(&daemon_path(), record)?;
+    Ok(())
+}
+
+fn allowlist_path() -> PathBuf {
+    paths::state_home().join("rimz").join(ALLOWLIST_FILE)
+}
+
+fn daemon_path() -> PathBuf {
+    paths::state_home().join("rimz").join(DAEMON_FILE)
+}
+
+fn acquire_lock() -> Result<crate::store::lock::WorkspaceLock> {
+    let path = paths::state_home().join("rimz").join(DAEMON_LOCK_FILE);
+    Ok(crate::store::lock::WorkspaceLock::acquire(&path)?)
+}
+
+fn default_interface() -> String {
+    "127.0.0.1".to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn broadcast_argv_has_no_write_or_auth_and_uses_share_shim() {
+        let spec = spawn_spec_for(
+            Path::new("/tmp/ttyd"),
+            Path::new("/opt/rimz/bin/rimz"),
+            "127.0.0.1".parse().expect("IP"),
+            8201,
+            &["-t".to_owned(), "cursorBlink=false".to_owned()],
+        );
+
+        assert_eq!(
+            spec.args,
+            [
+                "-O",
+                "-a",
+                "-i",
+                "127.0.0.1",
+                "-p",
+                "8201",
+                "-t",
+                "cursorBlink=false",
+                "/opt/rimz/bin/rimz",
+                "web",
+                "exec",
+                "--share"
+            ]
+        );
+        assert!(!spec.args.iter().any(|arg| arg == "-W"));
+        assert!(!spec.args.iter().any(|arg| arg == "-c"));
+    }
+
+    #[test]
+    fn allowlist_roundtrips_sorted_sessions() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("web-share.json");
+        let mut allowlist = Allowlist {
+            sessions: vec!["rimz-b".to_owned(), "rimz-a".to_owned()],
+        };
+        normalize(&mut allowlist.sessions);
+        write_allowlist_at(&path, &allowlist).expect("write allowlist");
+
+        assert_eq!(
+            ttyd::read_json_optional(&path).expect("read allowlist"),
+            Some(Allowlist {
+                sessions: vec!["rimz-a".to_owned(), "rimz-b".to_owned()]
+            })
+        );
+    }
+}

--- a/crates/rimz/src/web/ttyd.rs
+++ b/crates/rimz/src/web/ttyd.rs
@@ -17,7 +17,7 @@ use crate::store::{atomic, paths};
 
 use super::{CredentialSummary, Result, WebAuth, WebCredential, WebErr, WebWarning, gate::Cidr};
 
-mod client;
+pub(super) mod client;
 
 use client::ClientProfile;
 
@@ -381,7 +381,7 @@ fn reap_legacy_instances() {
     remove_legacy_instance_dir(&dir);
 }
 
-fn is_ttyd_process(process: &crate::proc::ProcInfo) -> bool {
+pub(super) fn is_ttyd_process(process: &crate::proc::ProcInfo) -> bool {
     crate::proc::command::program_label(&process.cmdline) == "ttyd"
 }
 
@@ -718,7 +718,7 @@ fn terminate_live_record(record: &DaemonRecord, ttyd_live: bool, gate_live: bool
 }
 
 #[cfg(unix)]
-fn terminate_pids(pids: &[u32]) {
+pub(super) fn terminate_pids(pids: &[u32]) {
     use nix::sys::signal::{Signal, kill};
     use nix::unistd::Pid;
 
@@ -745,7 +745,7 @@ fn terminate_pids(pids: &[u32]) {
 }
 
 #[cfg(not(unix))]
-fn terminate_pids(_pids: &[u32]) {}
+pub(super) fn terminate_pids(_pids: &[u32]) {}
 
 fn spawn_spec(
     program: &Path,
@@ -785,7 +785,7 @@ fn spawn_spec_for(
         .args(["web", "exec"]))
 }
 
-fn spawn_detached(spec: CommandSpec) -> Result<u32> {
+pub(super) fn spawn_detached(spec: CommandSpec) -> Result<u32> {
     let mut command = spec.to_command();
     command
         .stdin(Stdio::null())
@@ -804,7 +804,7 @@ fn spawn_detached(spec: CommandSpec) -> Result<u32> {
     })
 }
 
-fn ensure_port_available(address: SocketAddr) -> Result<()> {
+pub(super) fn ensure_port_available(address: SocketAddr) -> Result<()> {
     TcpListener::bind(address)
         .map(|_| ())
         .map_err(|_| WebErr::ConfiguredPortInUse {
@@ -824,7 +824,7 @@ fn wait_for_port(port: u16, timeout: Duration) -> bool {
     )
 }
 
-fn wait_for_address(address: SocketAddr, timeout: Duration) -> bool {
+pub(super) fn wait_for_address(address: SocketAddr, timeout: Duration) -> bool {
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
         if TcpStream::connect(address).is_ok() {
@@ -836,14 +836,14 @@ fn wait_for_address(address: SocketAddr, timeout: Duration) -> bool {
 }
 
 #[cfg(unix)]
-fn wait_for_address_close(address: SocketAddr, timeout: Duration) {
+pub(super) fn wait_for_address_close(address: SocketAddr, timeout: Duration) {
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline && TcpStream::connect(address).is_ok() {
         std::thread::sleep(Duration::from_millis(25));
     }
 }
 
-fn socket_address(interface: &str, port: u16) -> Result<SocketAddr> {
+pub(super) fn socket_address(interface: &str, port: u16) -> Result<SocketAddr> {
     let interface = interface
         .parse::<IpAddr>()
         .map_err(|_| WebErr::InvalidInterface {
@@ -859,7 +859,7 @@ fn record_public_address(record: &DaemonRecord) -> Result<SocketAddr> {
     )?))
 }
 
-fn probe_address(mut address: SocketAddr) -> SocketAddr {
+pub(super) fn probe_address(mut address: SocketAddr) -> SocketAddr {
     if address.ip().is_unspecified() {
         address.set_ip(match address.ip() {
             IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::LOCALHOST),
@@ -913,7 +913,7 @@ fn write_daemon_at(path: &Path, record: &DaemonRecord) -> Result<()> {
     Ok(())
 }
 
-fn read_json_optional<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<Option<T>> {
+pub(super) fn read_json_optional<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<Option<T>> {
     let bytes = match fs::read(path) {
         Ok(bytes) => bytes,
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
@@ -932,7 +932,7 @@ fn read_json_optional<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<Optio
         })
 }
 
-fn remove_optional(path: &Path) -> Result<bool> {
+pub(super) fn remove_optional(path: &Path) -> Result<bool> {
     match fs::remove_file(path) {
         Ok(()) => Ok(true),
         Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(false),

--- a/crates/rimz/src/web/ttyd/client.rs
+++ b/crates/rimz/src/web/ttyd/client.rs
@@ -32,13 +32,13 @@ const FONT_FETCH_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_FONT_BYTES: u64 = 16 * 1024 * 1024;
 
 #[derive(Clone, Debug, Default)]
-pub(super) struct ClientProfile {
-    pub(super) args: Vec<String>,
-    pub(super) warnings: Vec<WebWarning>,
-    pub(super) pixel_protocol: Option<u32>,
+pub(in crate::web) struct ClientProfile {
+    pub(in crate::web) args: Vec<String>,
+    pub(in crate::web) warnings: Vec<WebWarning>,
+    pub(in crate::web) pixel_protocol: Option<u32>,
 }
 
-pub(super) fn profile(config: &MachineConfig, ttyd_program: &Path) -> ClientProfile {
+pub(in crate::web) fn profile(config: &MachineConfig, ttyd_program: &Path) -> ClientProfile {
     let mut profile = ClientProfile {
         args: vec![
             "-t".to_owned(),

--- a/crates/rimz/tests/integration/sidebar_launch.rs
+++ b/crates/rimz/tests/integration/sidebar_launch.rs
@@ -196,6 +196,10 @@ impl MuxBackend for FakeBackend {
         CommandSpec::new("fake").arg(name)
     }
 
+    fn attach_readonly_command(&self, name: &str) -> CommandSpec {
+        CommandSpec::new("fake").arg(name)
+    }
+
     fn detach(&self, _name: &str) -> rimz::mux::Result<()> {
         Ok(())
     }

--- a/crates/rimz/tests/integration/web.rs
+++ b/crates/rimz/tests/integration/web.rs
@@ -104,6 +104,7 @@ struct WebFixture {
     bin_dir: PathBuf,
     ttyd_bin: PathBuf,
     web_port: u16,
+    share_port: u16,
     tmux_log: PathBuf,
     ttyd_log: PathBuf,
 }
@@ -120,13 +121,18 @@ impl WebFixture {
         std::os::unix::fs::symlink(ttyd_shim(), &ttyd_bin).expect("link named ttyd fixture");
         let ttyd_log = env.project_root.join(log_name);
         let web_port = free_loopback_port();
-        write_machine_config(&env, &format!("[web]\nport = {web_port}\n"));
+        let share_port = free_loopback_port();
+        write_machine_config(
+            &env,
+            &format!("[web]\nport = {web_port}\nshare_port = {share_port}\n"),
+        );
         Self {
             env,
             workspace,
             bin_dir,
             ttyd_bin,
             web_port,
+            share_port,
             tmux_log,
             ttyd_log,
         }
@@ -549,6 +555,225 @@ fn two_rooms_reuse_one_shared_daemon_and_rotate_restarts_it() {
     assert_eq!(
         String::from_utf8_lossy(&stop.stdout),
         "revoked ttyd credential and stopped 1 daemon(s)\n"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn read_only_broadcast_allowlist_reuses_restarts_and_stops_its_daemon() {
+    let _guard = daemon_test_guard();
+    let fixture = WebFixture::new("ttyd-broadcast.log");
+    write_machine_config(
+        &fixture.env,
+        &format!(
+            "[web]\nport = {}\nshare_port = {}\ninterface = \"0.0.0.0\"\nshare_base_url = \"https://watch.example/rimz\"\nstyle_client = false\n",
+            fixture.web_port, fixture.share_port
+        ),
+    );
+    let second_root = fixture.env.project_root.join("broadcast-second");
+    std::fs::create_dir_all(&second_root).expect("mkdir second room");
+    fixture.env.record(&second_root);
+    let second = rimz::WorkspaceResolver::resolve(&second_root, None).expect("resolve second room");
+    let sessions = format!(
+        "{}\\n{}",
+        fixture.workspace.session_name, second.session_name
+    );
+
+    let first = fixture
+        .command_with_sessions(&sessions)
+        .args(["--mux", "tmux", "web", "share", "--session"])
+        .arg(&fixture.workspace.session_name)
+        .args(["--print", "--json"])
+        .bounded_output()
+        .expect("share first room");
+    let first_payload = success_json(&first, "share first room");
+    assert_eq!(first_payload["version"], "rimz.web.share.v1");
+    assert_eq!(first_payload["port"], fixture.share_port);
+    assert_eq!(
+        first_payload["url"],
+        format!(
+            "https://watch.example/rimz/?arg={}",
+            fixture.workspace.session_name
+        )
+    );
+    assert!(
+        String::from_utf8_lossy(&first.stderr).contains("broadcast is unauthenticated"),
+        "{}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let daemon_path = fixture.env.state_root().join("rimz/web-ttyd-share.json");
+    let allowlist_path = fixture.env.state_root().join("rimz/web-share.json");
+    let first_daemon: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&daemon_path).expect("first share record"))
+            .expect("first share JSON");
+
+    let second_share = fixture
+        .command_with_sessions(&sessions)
+        .args(["--mux", "tmux", "web", "share", "--session"])
+        .arg(&second.session_name)
+        .args(["--print", "--json"])
+        .bounded_output()
+        .expect("share second room");
+    assert_success(&second_share, "share second room");
+    let reused_daemon: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&daemon_path).expect("reused share record"))
+            .expect("reused share JSON");
+    assert_eq!(first_daemon["pid"], reused_daemon["pid"]);
+    let allowlist: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&allowlist_path).expect("broadcast allowlist"))
+            .expect("allowlist JSON");
+    let mut expected_sessions = vec![
+        fixture.workspace.session_name.clone(),
+        second.session_name.clone(),
+    ];
+    expected_sessions.sort();
+    assert_eq!(
+        allowlist["sessions"],
+        serde_json::to_value(expected_sessions).expect("expected sessions JSON")
+    );
+    let log = std::fs::read_to_string(&fixture.ttyd_log).expect("broadcast ttyd log");
+    let share_argv = log
+        .lines()
+        .find(|line| line.contains("\tweb\texec\t--share"))
+        .expect("broadcast daemon argv");
+    assert!(
+        !share_argv.split('\t').any(|arg| arg == "-W"),
+        "{share_argv}"
+    );
+    assert!(
+        !share_argv.split('\t').any(|arg| arg == "-c"),
+        "{share_argv}"
+    );
+
+    let status = fixture
+        .command_with_sessions(&sessions)
+        .args(["web", "status", "--json"])
+        .bounded_output()
+        .expect("broadcast status");
+    let status = success_json(&status, "broadcast status");
+    assert_eq!(status["share"]["online"], true);
+    assert_eq!(status["share"]["port"], fixture.share_port);
+    assert_eq!(status["share"]["sessions"], allowlist["sessions"]);
+
+    let attach = fixture
+        .command_with_sessions(&sessions)
+        .args(["--mux", "tmux", "web", "exec", "--share"])
+        .arg(&fixture.workspace.session_name)
+        .bounded_output()
+        .expect("run read-only attach shim");
+    assert_success(&attach, "read-only attach shim");
+    let tmux_log = std::fs::read_to_string(&fixture.tmux_log).expect("tmux attach log");
+    assert!(
+        tmux_log.contains(&format!(
+            "attach -t {} -r -f ignore-size",
+            fixture.workspace.session_name
+        )),
+        "{tmux_log}"
+    );
+
+    let unshare_first = fixture
+        .command_with_sessions(&sessions)
+        .args(["web", "unshare", "--session"])
+        .arg(&fixture.workspace.session_name)
+        .bounded_output()
+        .expect("unshare first room");
+    assert_success(&unshare_first, "unshare first room");
+    let restarted_daemon: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&daemon_path).expect("restarted share record"))
+            .expect("restarted share JSON");
+    assert_ne!(reused_daemon["pid"], restarted_daemon["pid"]);
+
+    let refused = fixture
+        .command_with_sessions(&sessions)
+        .args(["--mux", "tmux", "web", "exec", "--share"])
+        .arg(&fixture.workspace.session_name)
+        .bounded_output()
+        .expect("refuse unshared room");
+    assert!(!refused.status.success());
+    let refused = String::from_utf8_lossy(&refused.stderr);
+    assert!(refused.contains("this room is not shared"), "{refused}");
+    assert!(!refused.contains("Live RimZ sessions"), "{refused}");
+    assert!(!refused.contains(&second.session_name), "{refused}");
+
+    let unshare_second = fixture
+        .command_with_sessions(&sessions)
+        .args(["web", "unshare", "--session"])
+        .arg(&second.session_name)
+        .bounded_output()
+        .expect("unshare second room");
+    assert_success(&unshare_second, "unshare second room");
+    assert!(!daemon_path.exists(), "last unshare stops broadcast daemon");
+    let empty: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&allowlist_path).expect("empty allowlist"))
+            .expect("empty allowlist JSON");
+    assert_eq!(empty["sessions"], serde_json::json!([]));
+}
+
+#[cfg(unix)]
+#[test]
+fn web_stop_stops_writable_and_broadcast_daemons() {
+    let _guard = daemon_test_guard();
+    let fixture = WebFixture::new("ttyd-stop-both.log");
+    write_machine_config(
+        &fixture.env,
+        &format!(
+            "[web]\nport = {}\nshare_port = {}\nstyle_client = false\n",
+            fixture.web_port, fixture.share_port
+        ),
+    );
+    assert_success(
+        &fixture
+            .command()
+            .args(["web", "start"])
+            .bounded_output()
+            .expect("start writable daemon"),
+        "start writable daemon",
+    );
+    assert_success(
+        &fixture
+            .command()
+            .args(["--mux", "tmux", "web", "share", "--session"])
+            .arg(&fixture.workspace.session_name)
+            .args(["--print"])
+            .bounded_output()
+            .expect("start broadcast daemon"),
+        "start broadcast daemon",
+    );
+
+    let stop = fixture
+        .command()
+        .args(["web", "stop"])
+        .bounded_output()
+        .expect("stop both daemons");
+    assert_success(&stop, "stop both daemons");
+    assert_eq!(
+        String::from_utf8_lossy(&stop.stdout),
+        "stopped 2 ttyd daemons\n"
+    );
+    assert!(!fixture.env.state_root().join("rimz/web-ttyd.json").exists());
+    assert!(
+        !fixture
+            .env
+            .state_root()
+            .join("rimz/web-ttyd-share.json")
+            .exists()
+    );
+}
+
+#[test]
+fn read_only_token_error_points_to_broadcast_sharing() {
+    let fixture = WebFixture::new("ttyd-read-only-token.log");
+    let output = fixture
+        .command()
+        .args(["web", "token", "create", "--read-only"])
+        .bounded_output()
+        .expect("reject read-only token");
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("use `rimz web share`"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
     );
 }
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -202,8 +202,10 @@ Remote control is the bridge the providers' official mobile apps drive: with a h
 [web]
 enabled = true
 port = 8200
+share_port = 8201
 interface = "127.0.0.1"
 base_url = "https://devbox.example/rimz"
+share_base_url = "https://watch.example/rimz"
 # auth_header = "X-Authentik-Username"
 # trusted_proxies = ["172.18.0.0/16"]
 font = "JetBrainsMono Nerd Font Mono"
@@ -213,7 +215,7 @@ style_client = true
 
 `[web] enabled` defaults to true and gates `rimz web open` plus `rimz remote connect --web`. A normal `rimz start` best-effort starts one ttyd daemon for every Zellij and tmux room on the machine; a missing ttyd or occupied port warns without blocking the room. When disabled, web commands fail before any room change and tell you to change the config on the machine serving the room.
 
-`interface` and `port` select the public listener and default to `127.0.0.1:8200`; `interface` accepts an IPv4 or IPv6 address. `base_url` is the URL prefix RimZ prints for `rimz web open` and `rimz web url`, useful when a reverse proxy serves the daemon under a public host or path. A non-empty `auth_header` delegates the public decision to a proxy-injected header at RimZ's gate while ttyd retains its machine-wide Basic Auth. A non-empty `trusted_proxies` list accepts bare IPs or IPv4 and IPv6 CIDRs at that gate; loopback peers remain allowed by the source check. `style_client` passes the active theme and `font` family to the browser terminal. The built-in `JetBrainsMono Nerd Font Mono` and `CaskaydiaCove Nerd Font Mono` families download and cache verified regular and bold faces automatically; `font_source` instead names one local font file or HTTPS font URL, while an unrecognized `font` with no source passes through for browser-local resolution. Install ttyd with `brew install ttyd` or `apt install ttyd`. These fields execute nothing, so the section stays outside the trust hash. Command detail is in [web.md](../reference/cli/web.md), and remote browser tunnels in [remote.md](../internals/remote.md#web-tunnels).
+`interface` selects the bind address for both browser daemons; `port` defaults the writable listener to 8200 and `share_port` defaults the unauthenticated read-only broadcast listener to 8201. `base_url` is the URL prefix RimZ prints for `rimz web open` and `rimz web url`; `share_base_url` is the prefix printed by `rimz web share`. A non-empty `auth_header` delegates the writable listener's public decision to a proxy-injected header at RimZ's gate while ttyd retains its machine-wide Basic Auth. A non-empty `trusted_proxies` list accepts bare IPs or IPv4 and IPv6 CIDRs at that gate; neither field applies to the broadcast listener. `style_client` passes the active theme and `font` family to both browser terminals. The built-in `JetBrainsMono Nerd Font Mono` and `CaskaydiaCove Nerd Font Mono` families download and cache verified regular and bold faces automatically; `font_source` instead names one local font file or HTTPS font URL, while an unrecognized `font` with no source passes through for browser-local resolution. Install ttyd with `brew install ttyd` or `apt install ttyd`. These fields execute nothing, so the section stays outside the trust hash. Command detail is in [web.md](../reference/cli/web.md), and remote browser tunnels in [remote.md](../internals/remote.md#web-tunnels).
 
 ### Daemon view
 

--- a/docs/guide/web.md
+++ b/docs/guide/web.md
@@ -18,10 +18,12 @@ apt install ttyd         # Debian or Ubuntu
 ```sh
 rimz web            # ensure the room and shared daemon, print URL + credential, open browser
 rimz web url        # print an existing room's URL without requiring the daemon
+rimz web share      # share one live room as a read-only broadcast
+rimz web unshare    # revoke one room's broadcast
 rimz web start      # start the machine-wide daemon without targeting a room
-rimz web restart    # restart it with the current binary and config
-rimz web status     # report the daemon's pid and configured port
-rimz web stop       # stop the daemon
+rimz web restart    # restart active browser daemons with current config
+rimz web status     # report writable and broadcast listeners
+rimz web stop       # stop both browser daemons
 ```
 
 `rimz web` is `rimz web open`.
@@ -33,6 +35,24 @@ The printed route is `http://127.0.0.1:8200/?arg=<session>`. ttyd passes the sel
 The browser shows a Basic-Auth prompt. Use the printed user `rimz` and password. Add `--no-start` when a supervisor owns ttyd and the command should fail rather than start it.
 
 With `[web] enabled = true`, every normal `rimz start` also asks for the shared daemon after the room is ready. A missing binary, occupied port, or daemon error warns on stderr and leaves the room usable in the terminal.
+
+## Share a read-only broadcast
+
+```sh
+rimz web share [PATH] --print
+rimz web share --session rimz-project-a1b2c3 --json
+rimz web unshare [PATH]
+rimz web unshare --session rimz-project-a1b2c3
+rimz web unshare --all
+```
+
+`share` requires an already-live RimZ room, adds only that room to a durable allowlist, starts a second ttyd daemon on `127.0.0.1:8201` by default, and prints its viewer URL. The viewer daemon has no Basic-Auth prompt and drops all browser input; it cannot reach another live room by changing `?arg=` because its shim accepts only allowlisted sessions and gives the same generic refusal for unknown, stopped, and unshared names.
+
+The viewer link is deliberately unauthenticated. Keep the listener on loopback for local viewing, or put HTTPS and any desired viewer authentication in a reverse proxy before exposing it. Set `share_base_url` to the proxy's public prefix; `auth_header` and `trusted_proxies` govern only the writable listener. A shared room on a non-loopback `interface` prints a warning that anyone who can reach `share_port` can watch.
+
+`unshare` restarts the broadcast daemon while other rooms remain shared, which disconnects every existing viewer and lets still-shared tabs reconnect. Removing the last room or using `--all` stops the daemon. The allowlist survives `rimz web stop`; `rimz web status` shows both its retained sessions and whether the broadcast daemon is online.
+
+tmux viewers attach read-only and with `ignore-size`, so they cannot type or resize the presenter's layout. Zellij has no read-only or size-isolated attach mode: ttyd still blocks viewer input, but a viewer window resize can influence the shared Zellij session geometry.
 
 ## Browser appearance and input
 
@@ -106,7 +126,7 @@ rimz web token revoke-all
 
 One credential named `rimz` serves the whole machine in every auth mode. `create` rotates it and restarts the live daemon and gate. Either revoke command stops the daemon and clears the credential.
 
-ttyd read-only mode belongs to the whole process, so `rimz web token create --read-only` is rejected rather than presenting a misleading per-user permission.
+ttyd read-only mode belongs to the whole process, so `rimz web token create --read-only` points to the separate `rimz web share` broadcast instead of presenting a misleading per-user permission.
 
 Treat the password like an SSH private key. It stays out of the URL, logs, events, and workspace records.
 
@@ -116,8 +136,10 @@ Treat the password like an SSH private key. It stays out of the URL, logs, event
 [web]
 enabled = true
 port = 8200
+share_port = 8201
 interface = "127.0.0.1"
 # base_url = "https://devbox.example/rimz"
+# share_base_url = "https://watch.example/rimz"
 # auth_header = "X-Authentik-Username"
 # trusted_proxies = ["172.18.0.0/16"]
 font = "JetBrainsMono Nerd Font Mono"
@@ -125,13 +147,15 @@ font = "JetBrainsMono Nerd Font Mono"
 style_client = true
 ```
 
-`interface` and `port` select the exact public listener. `base_url` changes the prefix RimZ prints when a reverse proxy fronts RimZ; the `/?arg=<session>` query remains. `auth_header` puts a proxy-validated identity header at the authorization gate while ttyd retains Basic Auth, and non-empty `trusted_proxies` admits those source addresses to the gate.
+`interface` selects the bind address for both daemons; `port` selects the writable listener and `share_port` selects the read-only broadcast listener. `base_url` and `share_base_url` change the respective prefixes RimZ prints when a reverse proxy fronts RimZ; the `/?arg=<session>` query remains. `auth_header` puts a proxy-validated identity header at the writable authorization gate while ttyd retains Basic Auth, and non-empty `trusted_proxies` admits those source addresses to that gate.
 
 ## Security boundary
 
 By default, RimZ invokes ttyd with write access, origin checks, mandatory Basic Auth, and an explicit loopback bind.
 
 The one machine credential authenticates the shared listener, so it grants access to every live RimZ room on that machine rather than only the room named in the first URL. An authenticated client can submit another session argument, and a missing or rejected argument lists the live RimZ rooms. A remote `--web` tunnel forwards this same machine-wide surface through its local port.
+
+The broadcast listener is a separate process without `-W` or `-c`: ttyd drops input and admits connections without authentication, while RimZ's per-connection shim limits attachment to the durable room allowlist and never lists other rooms. Its output can still contain secrets. Bind it to loopback or place it behind a reverse proxy and firewall before public exposure.
 
 The browser session is shell access as the serving user, and terminal output can contain secrets. Treat either the credential or trusted-header boundary as machine-wide shell access. Put HTTPS and rate limiting in front before exposing the listener beyond loopback:
 

--- a/docs/internals/web.md
+++ b/docs/internals/web.md
@@ -2,7 +2,7 @@
 
 > See [DESIGN.md](../../DESIGN.md) and [multiplexers.md](./multiplexers.md) for the commitments this doc extends.
 
-RimZ serves every local Zellij and tmux room through one Basic-authenticated ttyd daemon, with a loopback listener by default and an authorization gate for trusted-header reverse proxies.
+RimZ serves every local Zellij and tmux room through one Basic-authenticated writable ttyd daemon and serves explicitly shared rooms through a separate unauthenticated, input-blocked broadcast daemon; both bind loopback by default.
 
 ## Contract
 
@@ -10,7 +10,7 @@ The daemon owns browser transport and rendering; RimZ owns room birth, session v
 
 The store, hooks, sidebar, and wake paths are unchanged for a browser client, and RimZ proxies no pane I/O.
 
-`[web] interface` and `port` select one exact listener, default `127.0.0.1:8200`. A live daemon serves every room on both backends, so mux choice affects only the attach command selected after a browser connects.
+`[web] interface` selects both bind addresses, `port` selects the writable listener at 8200 by default, and `share_port` selects the broadcast listener at 8201 by default. The writable daemon can reach every room after machine-wide authentication; the broadcast daemon reaches only its durable allowlist.
 
 ## Daemon
 
@@ -42,11 +42,29 @@ The first shared-daemon start after an upgrade consumes the old `$XDG_STATE_HOME
 
 `rimz web restart` performs the same stop under the daemon lock when a daemon is online and always starts a fresh process with the current binary and browser profile. `rimz web stop` sends SIGTERM to the gate and ttyd, waits one second while refreshing the process table, uses SIGKILL for a survivor, waits for the public listener to close, and removes the record.
 
+## Broadcast daemon
+
+The read-only surface uses a second ttyd process with structurally separate argv:
+
+```text
+ttyd -O -a -i <interface> -p <share_port> [-t <client-option>...] [-I <custom-index>] <current-rimz-exe> web exec --share
+```
+
+The missing `-W` makes ttyd 1.7 and later drop client input, and the missing `-c` makes the viewer URL unauthenticated. `auth_header`, `trusted_proxies`, the authorization gate, credentials, and remote `--web` forwarding apply only to the writable daemon. The broadcast process receives the same theme, font, reconnect fixes, and pixel-compatible custom index.
+
+`$XDG_STATE_HOME/rimz/web-share.json` stores `{ "sessions": [...] }` through temp-file plus rename. `share` validates a durable workspace record and live mux session before adding one sorted session and ensuring the daemon. The hidden share shim re-reads the file for every connection, repeats the record and liveness checks, and returns the single `this room is not shared` error for missing, unknown, unshared, and dead targets without listing other rooms.
+
+A valid tmux broadcast execs `tmux -S <managed-socket> attach -t <session> -r -f ignore-size` when the probed tmux supports client flags; `-r` blocks mux input as defense in depth and `ignore-size` excludes the viewer from window sizing. A valid Zellij broadcast execs the ordinary `zellij attach <session>` because Zellij has no read-only attach; ttyd remains the input boundary, and viewer geometry can influence the session.
+
+The daemon record at `$XDG_STATE_HOME/rimz/web-ttyd-share.json` carries `pid`, `port`, `interface`, and optional `pixel_protocol`; `$XDG_STATE_HOME/rimz/web-ttyd-share.lock` serializes allowlist and process transitions. A record is live only while its pid names ttyd and the listener accepts a connection. Listener or pixel-protocol drift replaces the process before reuse. Both writable and broadcast records participate in the tmux pixel-client ancestry check.
+
+Removing one session rewrites the allowlist and restarts the daemon so every existing viewer disconnects; still-shared browser tabs can reconnect through ttyd. Removing the final session or using `unshare --all` stops the process. `web stop` stops both daemons but retains the allowlist, `web restart` restarts the broadcast daemon when that list is non-empty, and `rimz reload` replaces each browser daemon only when it is online.
+
 ## Credential and browser client
 
 The one credential named `rimz` lives at `$XDG_STATE_HOME/rimz/web-ttyd-credential.json`, mode 0600, with `name`, `created_at`, and `secret`. ttyd requires it in every auth mode, and a trusted-header gate reads the file at startup to precompute the injected Basic authorization value; the secret stays off gate argv.
 
-Rotation stops and restarts the one live daemon so the old secret stops working immediately. Revocation stops the daemon and removes the credential. ttyd read-only mode is process-wide, so RimZ rejects read-only credential creation.
+Rotation stops and restarts the live writable daemon so the old secret stops working immediately. Revocation stops that daemon and removes the credential. ttyd read-only mode is process-wide, so RimZ rejects read-only credential creation and directs users to the separate broadcast process.
 
 Credential creation, rotation, listing, and revocation have the same behavior in Basic and trusted-header modes. Rotation restarts both ttyd and its gate, so the gate's startup read receives the new secret.
 
@@ -66,15 +84,15 @@ The tmux capability probe accepts an `xterm-256color` rendering client when its 
 
 `rimz web open` resolves or births the room, confirms the session is addressable, ensures the shared daemon, and returns its URL, auth mode, credential, and tunnel target. `--no-start` requires an already-live daemon.
 
-`rimz web url` reads the room identity, existing credential, and live daemon state without changing the daemon or credential. It uses the live port when the daemon runs and the configured port otherwise; its v2 JSON omits `credential` when none exists. `start`, `restart`, `status`, and `stop` act on the one machine daemon and need no room target. `rimz reload` restarts the daemon when it is online so a newly installed build supplies its current browser client; an offline daemon stays offline, and a restart failure warns without failing reload.
+`rimz web url` reads the room identity, existing credential, and live daemon state without changing the daemon or credential. It uses the live port when the daemon runs and the configured port otherwise; its v2 JSON omits `credential` when none exists. `share` and `unshare` own the broadcast allowlist; `restart`, `status`, and `stop` cover both daemon records. `rimz reload` restarts each daemon when it is online so a newly installed build supplies its current browser client; an offline daemon stays offline, and a restart failure warns without failing reload.
 
 After a normal `rimz start` makes the room ready, `[web] enabled = true` asks RimZ to ensure the daemon. This path is deliberately best-effort: missing ttyd, a port collision, or a start failure prints a warning and never refuses the room.
 
 ## Configuration
 
-`[web]` carries `enabled`, `interface`, `port`, `base_url`, `auth_header`, `trusted_proxies`, `font`, `font_source`, and `style_client`.
+`[web]` carries `enabled`, `interface`, `port`, `share_port`, `base_url`, `share_base_url`, `auth_header`, `trusted_proxies`, `font`, `font_source`, and `style_client`.
 
-`enabled` defaults to true, `interface` defaults to `127.0.0.1`, `port` defaults to 8200, and an absent `base_url` resolves to `http://127.0.0.1:<port>`. A reverse proxy can set `base_url` to its public prefix; RimZ appends `/?arg=<session>`.
+`enabled` defaults to true, `interface` defaults to `127.0.0.1`, `port` defaults to 8200, and `share_port` defaults to 8201. Absent base URLs resolve to `http://127.0.0.1:<respective-port>`; a reverse proxy can set either public prefix, and RimZ appends `/?arg=<session>`.
 
 A non-empty trimmed `auth_header` selects trusted-header auth and always enables the gate, while an empty or absent value selects direct Basic Auth unless `trusted_proxies` enables the gate. `trusted_proxies` is empty by default. Trusted-header auth on a non-loopback interface with an empty allowlist warns that only loopback proxies can connect and names the CIDR fix for a proxy on another host.
 
@@ -97,5 +115,7 @@ The gate treats a configured auth header as proof of the public proxy's authenti
 The source gate always admits loopback, but trusted-header authorization still requires the configured header there; loopback carries no header-auth bypass. The private ttyd upstream remains protected by Basic Auth. Use host-level user isolation when another local user can read the serving user's credential file or execute as that user.
 
 Credentials stay out of URLs, logs, store events, and workspace records. The v2 credential appears only in explicit JSON output that reports a saved credential and the human stderr relay.
+
+The broadcast listener intentionally has no RimZ authentication and prints a visible warning whenever an active share binds a non-loopback interface. Its allowlist limits rooms rather than viewers; anyone who can reach the listener can read the terminal output of every allowlisted room. Public deployments put HTTPS, optional viewer authentication, and network filtering in front of `share_port`.
 
 The browser session is shell access as the serving user. A reverse proxy that exposes the listener provides HTTPS and rate limiting.

--- a/docs/reference/cli/web.md
+++ b/docs/reference/cli/web.md
@@ -5,6 +5,8 @@
 ```sh
 rimz web open [PATH] [--session <name>] [--print] [--no-start] [--no-resume] [--json]
 rimz web url [PATH] [--session <name>] [--json]
+rimz web share [PATH] [--session <name>] [--print] [--json]
+rimz web unshare [PATH] [--session <name>] [--all]
 rimz web status [--json]
 rimz web start
 rimz web restart
@@ -29,7 +31,11 @@ rimz web token revoke-all
 
 `url` requires an existing workspace record and inspects its route without birthing a room, starting the daemon, or creating a credential. A live daemon's port wins over a changed configured port; offline inspection uses `[web] port`. JSON output includes the saved credential when one exists and omits `credential` otherwise.
 
-`start`, `restart`, `status`, and `stop` act on the one machine daemon and do not need a room. `restart` stops an online daemon when present, then always starts a fresh daemon with the current config and executable. Human status prints the configured `[web] interface` and `port`; command-line listener and TLS overrides are not supported.
+`share` requires an existing live room, adds it to the broadcast allowlist, ensures the no-auth read-only daemon, and opens the viewer URL unless `--print` is present. Its JSON payload is `{"version":"rimz.web.share.v1","url":"http://127.0.0.1:8201/?arg=rimz-project-a1b2c3","session":"rimz-project-a1b2c3","port":8201}`.
+
+`unshare` resolves a path to its session without requiring the room to remain live, or accepts an exact `--session`; `--all` conflicts with both target forms. Revoking one of several rooms restarts the broadcast daemon to disconnect existing viewers, while revoking the last room stops it.
+
+`start` starts the writable machine daemon. `restart` always replaces the writable daemon and also replaces the broadcast daemon when its allowlist is non-empty. `stop` stops both processes without clearing the broadcast allowlist. Human status prints both listeners and the shared sessions; command-line listener and TLS overrides are not supported.
 
 The JSON `open` payload is:
 
@@ -39,10 +45,12 @@ The JSON `open` payload is:
 
 The `url --json` payload has the same fields, with optional `credential` and `tunnel_port` while the daemon is offline. Trusted-header payloads use `"auth":{"mode":"trusted_header","header":"X-Authentik-Username"}` and still carry the Basic credential for the private ttyd upstream. A gated daemon reports that upstream as `tunnel_port`; a direct daemon reports the public `port` in both fields.
 
-`status --json` emits `version`, `online`, `pid`, and `port`.
+`status --json` keeps the writable daemon's `version`, `online`, `pid`, `interface`, and `port` fields and adds `share: {online, pid, interface, port, sessions}`.
 
 The one credential is named `rimz`. `create` rotates it and restarts the live daemon and gate in every auth mode, `list` prints its creation time, and either revoke verb stops the daemon before clearing it.
 
-`--read-only` is rejected because ttyd's read-only setting belongs to the whole process.
+`--read-only` is rejected because ttyd's read-only setting belongs to the whole process; the error points to `rimz web share`.
+
+The hidden `rimz web exec --share <session>` shim re-reads the durable allowlist for every viewer connection, requires a workspace record and live mux session, and returns only `this room is not shared` for every rejected target.
 
 Configure the daemon under `[web]`; see the [web guide](../../guide/web.md) and [configuration guide](../../guide/configuration.md#web-access).


### PR DESCRIPTION
## Context

The shared ttyd daemon serves every RimZ room writable behind one Basic credential. This adds a live broadcast mode: the owner keeps the authenticated writable surface, and a viewer gets a read-only view without authenticating — but only for rooms explicitly shared.

ttyd makes both write permission (`-W`) and Basic auth (`-c`) process-wide, which is why a read-only credential is impossible on the writable daemon. One daemon cannot serve both audiences, so the feature is a **second, separate ttyd daemon**: started without `-W` (ttyd ≥1.7 drops all client input without it) and without `-c` (no auth), running the same `rimz web exec` shim in a share mode that only admits explicitly shared sessions.

Locked at the gate: per-room opt-in (`rimz web share`; everything else stays invisible to viewers) and no viewer auth (frictionless view link, loopback by default, reverse proxy adds HTTPS/auth for public exposure — same posture as the writable daemon).

## Design choices

- **Second daemon, same shim binary.** Broadcast argv `ttyd -O -a -i <interface> -p <share_port> [-t …] [-I index] <rimz> web exec --share`, no `-W`/`-c`. Read-only enforcement lives in the ttyd process, so it holds identically for Zellij and tmux with no reliance on a backend feature.
- **Durable allowlist, checked per connection.** Shared sessions live in `$XDG_STATE_HOME/rimz/web-share.json` (atomic temp+rename); the share shim re-reads it per connection, so `share` never needs a daemon restart to admit a new room.
- **Unshare revokes for real.** Removing a session from the allowlist only blocks *new* connections, so `unshare` rewrites the allowlist and then restarts the broadcast daemon (or stops it when the list is empty), disconnecting live viewers; still-shared tabs reconnect via ttyd. Revocation is intentionally prioritized over config/restart failures: the old process is stopped before the replacement is validated, so a bad new config can leave still-shared rooms briefly offline but can never leave a revoked viewer attached.
- **Defense in depth on tmux.** The share shim attaches `attach -t <name> -r`, plus `-f ignore-size` when the probed tmux supports client flags (≥3.2), so a viewer cannot type or resize the presenter's layout. Zellij has no read-only attach; there ttyd's input-off is the sufficient enforcement layer and viewer window size can still influence session geometry — documented as a known caveat.
- **No info leak on the unauthenticated surface.** The writable shim's invalid-session message lists every live room; the share shim never does — an unknown, unshared, stopped, or dead session gets a single generic `this room is not shared` and exits non-zero.
- **No gate, no credential on broadcast.** `auth_header`/`trusted_proxies` and the authorization gate apply only to the writable listener. A non-loopback `interface` with an active share prints a visible warning that anyone reaching `<addr>:<share_port>` can watch.
- **Config stays minimal.** `[web]` gains `share_port` (default 8201) and optional `share_base_url`. No field executes a command, so `[web]` stays outside the trust hash.

## Implementation

- `rimz web share` / `unshare` with path/session targeting, `--all`, `--print`/`--json` (`rimz.web.share.v1` payload), browser open, and a `[web] enabled` precondition. `web exec` gains `--share`. `status`, `restart`, and `stop` cover both daemons; `stop` retains the allowlist and reports how many processes stopped.
- New `web/share.rs`: the durable allowlist plus a separately locked (`web-ttyd-share.lock`) broadcast daemon with drift-aware reuse (port/interface/pixel participate), stale-record teardown, restart-on-revocation, stop-on-empty, and the non-loopback warning. Process helpers stay in `web/ttyd.rs` at sibling scope and are reused directly rather than moved to a new module — reuse without a second consumer to justify an abstraction.
- Backend-neutral `attach_readonly_command` on `MuxBackend`: tmux `-r` + version-gated `-f ignore-size`; Zellij falls back to the ordinary attach and relies on ttyd's input boundary.
- Config defaults (`share_port = 8201`, optional `share_base_url`), CLI-surface snapshot, unit + integration coverage, and doc/reference/changelog updates.

**Deviations from the plan (verified, justified):**
- **Pixel-client ancestry now recognizes both daemon records** (`web/mod.rs`, `sidebar_pane/pixel/probe.rs`). The single-record probe would have *disabled* pixel rendering the moment a broadcast viewer connected (its client descends from the share daemon, not the writable one). Extending the probe to accept either live matching-protocol daemon is required to deliver the plan's "same browser client, including the pixel layer" for viewers; covered by a mixed-daemon test.
- `unshare_session`/`unshare_all` take `&MachineConfig` (plan pseudocode omitted it) so the remaining daemon restarts with the live listener/profile without loading config inside the domain module. `unshare_all` never restarts, so it does not use the argument.
- `ARCHITECTURE.md` updated beyond the plan's doc list, per the repo contract for runtime-shape changes.

## Advisories

- **Owner-facing error on a stopped room.** `rimz web share` on a room that has a workspace record but no live mux session returns the same generic `this room is not shared` string the shim shows viewers — reachable and mildly confusing for the sharer (a distinct "room is not running; start it first" would read better). Message quality only; the refusal itself is correct and recoverable. Left as a follow-up decision, not a blocker.
- **Input-block coverage.** Browser input blocking is ttyd's process-level `-W` contract; tests assert the flag's absence and inspect the real spawned argv, but an automated browser-keystroke attempt is not part of the suite (impractical to automate). A real tmux/Zellij sandbox run confirmed the viewer attaches read-only and unshared targets are refused.
- **Zellij resize caveat.** Zellij exposes no read-only or size-isolated attach, so a viewer resize can still influence a shared Zellij room; documented in the guide.

Reviewed at `8cadbc7c9`: `cargo xtask invariants` green (trust hash and sidebar/store boundaries intact; `[web]` stays outside the trust hash), and the web, mux read-only-attach, pixel-probe, share/broadcast, config, CLI-surface, and template tests all pass under nextest.