### PR TITLE
feat(web): interactive session manager in the browser terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ RimZ is alpha software on the 0.x line. Commands, flags, config keys, and output
 ### Added
 
 - `rimz web share` serves an explicitly allowlisted live room through a second no-auth, input-blocked ttyd daemon; `unshare` revokes live viewers, tmux attaches ignore viewer size, and status reports both browser surfaces. → [web](./docs/guide/web.md#share-a-read-only-broadcast)
+- The web daemon's base URL opens a themed live-session manager with filtering, mouse and keyboard selection, per-provider agent counts, and attention markers; detaching from one room returns to the list to switch rooms in the same browser tab. → [web](./docs/guide/web.md#session-manager)
 - Layout cells accept any executable on PATH as a raw command pane, while configured commands and profiles keep precedence over same-named binaries. → [fleet](./docs/guide/fleet.md#compose-a-layout)
 - `rimz events follow` streams versioned agent lifecycle transitions as JSON Lines, with current-generation replay and gap-free handoff across event-log rotation. → [events](./docs/reference/cli/events.md)
 

--- a/crates/rimz/src/cli/web/mod.rs
+++ b/crates/rimz/src/cli/web/mod.rs
@@ -1,5 +1,7 @@
 //! `rimz web` — writable browser access and read-only room broadcasts.
 
+mod picker;
+
 use std::io::Write as _;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -439,12 +441,21 @@ fn render_revoked(stopped: bool) -> Result<()> {
 }
 
 fn exec(session: Option<&str>, share: bool) -> Result<()> {
-    let spec = if share {
-        rimz::web::share_attach_command(session)?
-    } else {
-        rimz::web::existing_session_attach_command(session)?
-    };
-    room::exec_attach_command(&spec)
+    if share {
+        let spec = rimz::web::share_attach_command(session)?;
+        return room::exec_attach_command(&spec);
+    }
+    match rimz::web::existing_session_attach_command(session) {
+        Ok(spec) => room::exec_attach_command(&spec),
+        Err(rimz::web::WebErr::InvalidSession(message)) if picker::available() => {
+            if picker::run(session)? {
+                Ok(())
+            } else {
+                Err(anyhow::anyhow!(message))
+            }
+        }
+        Err(err) => Err(err.into()),
+    }
 }
 
 fn ensure_web_enabled(config: &rimz::config::MachineConfig) -> Result<()> {

--- a/crates/rimz/src/cli/web/picker.rs
+++ b/crates/rimz/src/cli/web/picker.rs
@@ -1,0 +1,636 @@
+//! Interactive live-room picker for ttyd browser sessions.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::{self, IsTerminal};
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use ratatui::backend::CrosstermBackend;
+use ratatui::crossterm::event::{
+    self, Event, KeyCode, KeyEventKind, KeyModifiers, MouseButton, MouseEventKind,
+};
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, Paragraph};
+use ratatui::{Frame, Terminal};
+use rimz::config::{MachineConfig, ThemeConfig, ThemeProviderStyle};
+use rimz::ids::{AgentKind, MuxName};
+use rimz::sidebar::consumer::PublishedSnapshotReader;
+use rimz::theme::{Palette, Tone, resolve_provider_brand};
+use rimz::tui::{MouseCapture, Screen, TerminalModeGuard};
+use rimz::{RuntimePaths, StatePaths};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+const EVENT_POLL: Duration = Duration::from_millis(250);
+const PROBE_INTERVAL: Duration = Duration::from_secs(2);
+
+pub(super) fn available() -> bool {
+    io::stdin().is_terminal() && io::stdout().is_terminal()
+}
+
+/// `false` means terminal setup failed before the picker painted, so the caller
+/// can preserve the plain invalid-session error as a useful fallback.
+pub(super) fn run(rejected_session: Option<&str>) -> Result<bool> {
+    let guard = match TerminalModeGuard::enable(MouseCapture::Stdout, Screen::Alternate) {
+        Ok(guard) => guard,
+        Err(err) => {
+            tracing::debug!(error = %err, "web session picker terminal mode unavailable");
+            return Ok(false);
+        }
+    };
+    let backend = CrosstermBackend::new(io::stdout());
+    let mut terminal = match Terminal::new(backend) {
+        Ok(terminal) => terminal,
+        Err(err) => {
+            tracing::debug!(error = %err, "web session picker terminal unavailable");
+            drop(guard);
+            return Ok(false);
+        }
+    };
+    if let Err(err) = terminal.clear() {
+        tracing::debug!(error = %err, "web session picker screen unavailable");
+        drop(guard);
+        return Ok(false);
+    }
+
+    let theme = PickerTheme::load();
+    let mut guard = Some(guard);
+    let mut picker = Picker::new(rejected_session);
+    let mut readers = BTreeMap::new();
+    let mut next_probe = Instant::now();
+
+    loop {
+        if Instant::now() >= next_probe {
+            match probe_rows(&mut readers) {
+                Ok(rows) => picker.apply_probe(rows),
+                Err(err) => picker.notice = Some(format!("could not read live rooms: {err}")),
+            }
+            next_probe = Instant::now() + PROBE_INTERVAL;
+        }
+
+        terminal.draw(|frame| render(frame, &mut picker, &theme))?;
+        if !event::poll(EVENT_POLL)? {
+            continue;
+        }
+        let Some(action) = picker.handle_event(event::read()?) else {
+            continue;
+        };
+        match action {
+            Action::Quit => return Ok(true),
+            Action::Attach(session, mux) => {
+                guard
+                    .take()
+                    .context("web session picker lost its terminal guard")?
+                    .release_keep_screen()
+                    .context("releasing the web session picker")?;
+                let spec = rimz::mux::backend_for(mux).attach_existing_command(&session);
+                let outcome = spec
+                    .to_command()
+                    .stdin(Stdio::inherit())
+                    .stdout(Stdio::inherit())
+                    .stderr(Stdio::inherit())
+                    .spawn()
+                    .and_then(|mut child| child.wait());
+                guard = Some(
+                    TerminalModeGuard::enable(MouseCapture::Stdout, Screen::Alternate)
+                        .context("restoring the web session picker")?,
+                );
+                terminal.clear()?;
+                match outcome {
+                    Ok(status) if status.success() => picker.notice = None,
+                    Ok(status) => {
+                        picker.notice = Some(format!(
+                            "session `{session}` attach exited with {}",
+                            exit_status_label(status)
+                        ));
+                    }
+                    Err(err) => {
+                        picker.notice =
+                            Some(format!("could not attach session `{session}`: {err}"));
+                    }
+                }
+                next_probe = Instant::now();
+            }
+        }
+    }
+}
+
+fn exit_status_label(status: std::process::ExitStatus) -> String {
+    status
+        .code()
+        .map_or_else(|| status.to_string(), |code| format!("status {code}"))
+}
+
+fn probe_rows(
+    readers: &mut BTreeMap<String, PublishedSnapshotReader>,
+) -> rimz::web::Result<Vec<RoomRow>> {
+    let rooms = rimz::web::live_rooms()?;
+    let live_names = rooms
+        .iter()
+        .map(|room| room.session_name.clone())
+        .collect::<BTreeSet<_>>();
+    readers.retain(|session, _| live_names.contains(session));
+    Ok(rooms
+        .into_iter()
+        .map(|room| {
+            let agents = agents_for_room(&room, readers);
+            RoomRow { room, agents }
+        })
+        .collect())
+}
+
+fn agents_for_room(
+    room: &rimz::web::LiveRoom,
+    readers: &mut BTreeMap<String, PublishedSnapshotReader>,
+) -> Option<RoomAgents> {
+    if !readers.contains_key(&room.session_name) {
+        let runtime = RuntimePaths::for_workspace(room.workspace_id.clone()).ok()?;
+        readers.insert(
+            room.session_name.clone(),
+            PublishedSnapshotReader::new(runtime, room.session_name.clone(), None),
+        );
+    }
+    let state = StatePaths::for_workspace(room.workspace_id.clone()).ok()?;
+    let snapshot = readers.get_mut(&room.session_name)?.read(&state).ok()?;
+    Some(RoomAgents::from_snapshot(&snapshot))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RoomAgents {
+    by_kind: Vec<(AgentKind, usize)>,
+    attention: usize,
+}
+
+impl RoomAgents {
+    fn from_snapshot(snapshot: &rimz::SidebarSnapshot) -> Self {
+        let mut by_kind = BTreeMap::new();
+        let mut attention = 0;
+        for agent in snapshot.root_agents() {
+            *by_kind.entry(agent.kind.clone()).or_insert(0) += 1;
+            attention += usize::from(agent.effective_status().is_attention());
+        }
+        Self {
+            by_kind: by_kind.into_iter().collect(),
+            attention,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.by_kind.is_empty() && self.attention == 0
+    }
+
+    fn width(&self) -> usize {
+        if self.is_empty() {
+            return 1;
+        }
+        let kinds = self
+            .by_kind
+            .iter()
+            .map(|(kind, count)| UnicodeWidthStr::width(kind.as_str()) + 2 + digits(*count))
+            .sum::<usize>();
+        let gaps = self.by_kind.len().saturating_sub(1);
+        let attention = if self.attention == 0 {
+            0
+        } else {
+            3 + digits(self.attention)
+        };
+        kinds + gaps + attention
+    }
+}
+
+fn digits(value: usize) -> usize {
+    value.checked_ilog10().map_or(1, |power| power as usize + 1)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RoomRow {
+    room: rimz::web::LiveRoom,
+    agents: Option<RoomAgents>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Action {
+    Attach(String, MuxName),
+    Quit,
+}
+
+#[derive(Debug)]
+struct Picker {
+    rows: Vec<RoomRow>,
+    selected: Option<String>,
+    filter: String,
+    notice: Option<String>,
+    hit_rows: BTreeMap<u16, String>,
+}
+
+impl Picker {
+    fn new(rejected_session: Option<&str>) -> Self {
+        Self {
+            rows: Vec::new(),
+            selected: None,
+            filter: String::new(),
+            notice: rejected_session
+                .filter(|session| !session.is_empty())
+                .map(|session| format!("session `{session}` is not a live RimZ room")),
+            hit_rows: BTreeMap::new(),
+        }
+    }
+
+    fn apply_probe(&mut self, rows: Vec<RoomRow>) {
+        self.rows = rows;
+        self.normalize_selection();
+    }
+
+    fn visible(&self) -> Vec<&RoomRow> {
+        let filter = self.filter.to_lowercase();
+        self.rows
+            .iter()
+            .filter(|row| {
+                filter.is_empty() || row.room.session_name.to_lowercase().contains(&filter)
+            })
+            .collect()
+    }
+
+    fn normalize_selection(&mut self) {
+        let current_is_visible = self.selected.as_deref().is_some_and(|selected| {
+            self.visible()
+                .iter()
+                .any(|row| row.room.session_name == selected)
+        });
+        if !current_is_visible {
+            self.selected = self
+                .visible()
+                .first()
+                .map(|row| row.room.session_name.clone());
+        }
+    }
+
+    fn move_selection(&mut self, offset: isize) {
+        let visible = self.visible();
+        if visible.is_empty() {
+            self.selected = None;
+            return;
+        }
+        let current = self
+            .selected
+            .as_deref()
+            .and_then(|selected| {
+                visible
+                    .iter()
+                    .position(|row| row.room.session_name == selected)
+            })
+            .unwrap_or(0);
+        let next = current
+            .saturating_add_signed(offset)
+            .min(visible.len().saturating_sub(1));
+        self.selected = Some(visible[next].room.session_name.clone());
+    }
+
+    fn selected_action(&self) -> Option<Action> {
+        let selected = self.selected.as_deref()?;
+        let row = self
+            .visible()
+            .into_iter()
+            .find(|row| row.room.session_name == selected)?;
+        Some(Action::Attach(row.room.session_name.clone(), row.room.mux))
+    }
+
+    fn handle_event(&mut self, event: Event) -> Option<Action> {
+        match event {
+            Event::Key(key) if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) => {
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && matches!(key.code, KeyCode::Char('c' | 'C'))
+                {
+                    return Some(Action::Quit);
+                }
+                match key.code {
+                    KeyCode::Up | KeyCode::Char('k') => self.move_selection(-1),
+                    KeyCode::Down | KeyCode::Char('j') => self.move_selection(1),
+                    KeyCode::Enter => return self.selected_action(),
+                    KeyCode::Backspace => {
+                        self.filter.pop();
+                        self.normalize_selection();
+                    }
+                    KeyCode::Esc if self.filter.is_empty() => return Some(Action::Quit),
+                    KeyCode::Esc => {
+                        self.filter.clear();
+                        self.normalize_selection();
+                    }
+                    KeyCode::Char(character)
+                        if !key
+                            .modifiers
+                            .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+                    {
+                        self.filter.push(character);
+                        self.normalize_selection();
+                    }
+                    _ => {}
+                }
+            }
+            Event::Mouse(mouse) => match mouse.kind {
+                MouseEventKind::ScrollUp => self.move_selection(-1),
+                MouseEventKind::ScrollDown => self.move_selection(1),
+                MouseEventKind::Down(MouseButton::Left) => {
+                    let session = self.hit_rows.get(&mouse.row)?.clone();
+                    if self.selected.as_deref() == Some(session.as_str()) {
+                        return self.selected_action();
+                    }
+                    self.selected = Some(session);
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+        None
+    }
+}
+
+struct PickerTheme {
+    palette: Palette,
+    providers: BTreeMap<String, ThemeProviderStyle>,
+    no_color: bool,
+}
+
+impl PickerTheme {
+    fn load() -> Self {
+        let config = MachineConfig::load_lenient();
+        Self::resolve(&config.theme, rimz::tui::truecolor(), rimz::tui::no_color())
+    }
+
+    fn resolve(theme: &ThemeConfig, truecolor: bool, no_color: bool) -> Self {
+        let depth = theme.effective_theme_mode().depth(truecolor);
+        Self {
+            palette: Palette::resolve(theme, depth),
+            providers: theme.providers.clone(),
+            no_color,
+        }
+    }
+
+    fn style(&self, tone: Tone) -> Style {
+        if self.no_color {
+            Style::default()
+        } else {
+            Style::default().fg(tone_color(tone))
+        }
+    }
+
+    fn body(&self) -> Style {
+        self.style(self.palette.body())
+    }
+
+    fn muted(&self) -> Style {
+        self.style(self.palette.muted())
+    }
+
+    fn faint(&self) -> Style {
+        self.style(self.palette.faint())
+    }
+
+    fn meta(&self) -> Style {
+        self.style(self.palette.meta())
+    }
+
+    fn accent(&self) -> Style {
+        self.style(self.palette.accent())
+    }
+
+    fn alarm(&self) -> Style {
+        self.style(self.palette.alarm())
+    }
+
+    fn rule(&self) -> Style {
+        self.style(self.palette.rule())
+    }
+
+    fn selected(&self) -> Style {
+        let style = Style::default().add_modifier(Modifier::BOLD);
+        if self.no_color {
+            style
+        } else {
+            style
+                .fg(tone_color(self.palette.selection()))
+                .bg(tone_color(self.palette.selection_bg()))
+        }
+    }
+
+    fn provider(&self, kind: &str) -> Style {
+        self.style(resolve_provider_brand(kind, &self.providers).tone(&self.palette))
+    }
+}
+
+fn tone_color(tone: Tone) -> Color {
+    match tone {
+        Tone::Indexed(index) => Color::Indexed(index),
+        Tone::Rgb(red, green, blue) => Color::Rgb(red, green, blue),
+    }
+}
+
+fn render(frame: &mut Frame<'_>, picker: &mut Picker, theme: &PickerTheme) {
+    let area = frame.area();
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(theme.rule())
+        .title(Line::from(vec![
+            Span::styled(" RimZ ", theme.accent().add_modifier(Modifier::BOLD)),
+            Span::styled("── sessions ", theme.muted()),
+        ]));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    picker.hit_rows.clear();
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+
+    let notice_height = u16::from(picker.notice.is_some());
+    if let Some(notice) = picker.notice.as_deref() {
+        frame.render_widget(
+            Paragraph::new(truncate_width(notice, usize::from(inner.width))).style(theme.alarm()),
+            Rect::new(inner.x, inner.y, inner.width, 1),
+        );
+    }
+
+    let controls_height = inner.height.saturating_sub(notice_height).min(2);
+    let list_height = inner
+        .height
+        .saturating_sub(notice_height)
+        .saturating_sub(controls_height);
+    let list_area = Rect::new(
+        inner.x,
+        inner.y.saturating_add(notice_height),
+        inner.width,
+        list_height,
+    );
+    render_rooms(frame, picker, theme, list_area);
+
+    if controls_height >= 1 {
+        let filter_y = inner.y.saturating_add(inner.height - controls_height);
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("filter: ", theme.meta()),
+                Span::styled(picker.filter.clone(), theme.body()),
+                Span::styled("_", theme.accent()),
+            ])),
+            Rect::new(inner.x, filter_y, inner.width, 1),
+        );
+    }
+    if controls_height == 2 {
+        frame.render_widget(
+            Paragraph::new("↑↓ select · ⏎ attach · type to filter · esc quit").style(theme.faint()),
+            Rect::new(inner.x, inner.y + inner.height - 1, inner.width, 1),
+        );
+    }
+}
+
+fn render_rooms(frame: &mut Frame<'_>, picker: &mut Picker, theme: &PickerTheme, area: Rect) {
+    if area.height == 0 {
+        return;
+    }
+    let visible = picker.visible();
+    if visible.is_empty() {
+        let message = if picker.rows.is_empty() {
+            "No live RimZ sessions — run `rimz start` in a project".to_owned()
+        } else {
+            format!("No sessions match `{}`", picker.filter)
+        };
+        frame.render_widget(Paragraph::new(message).style(theme.muted()), area);
+        return;
+    }
+
+    let selected_index = picker
+        .selected
+        .as_deref()
+        .and_then(|selected| {
+            visible
+                .iter()
+                .position(|row| row.room.session_name == selected)
+        })
+        .unwrap_or(0);
+    let capacity = usize::from(area.height);
+    let start = selected_index.saturating_add(1).saturating_sub(capacity);
+    let shown = &visible[start..visible.len().min(start + capacity)];
+    let name_width = shown
+        .iter()
+        .map(|row| UnicodeWidthStr::width(row.room.session_name.as_str()))
+        .max()
+        .unwrap_or(0)
+        .min(28);
+    let items = shown
+        .iter()
+        .map(|row| {
+            let selected = picker.selected.as_deref() == Some(row.room.session_name.as_str());
+            let mut item = ListItem::new(Line::from(room_spans(
+                row,
+                selected,
+                name_width,
+                usize::from(area.width),
+                theme,
+            )));
+            if selected {
+                item = item.style(theme.selected());
+            }
+            item
+        })
+        .collect::<Vec<_>>();
+    frame.render_widget(List::new(items).style(theme.body()), area);
+    let hit_rows = shown
+        .iter()
+        .enumerate()
+        .filter_map(|(index, row)| {
+            let index = u16::try_from(index).ok()?;
+            Some((area.y.saturating_add(index), row.room.session_name.clone()))
+        })
+        .collect::<Vec<_>>();
+    picker.hit_rows.extend(hit_rows);
+}
+
+fn room_spans(
+    row: &RoomRow,
+    selected: bool,
+    name_width: usize,
+    total_width: usize,
+    theme: &PickerTheme,
+) -> Vec<Span<'static>> {
+    let prefix = if selected { "▸ " } else { "  " };
+    let name = pad_right(
+        &truncate_width(&row.room.session_name, name_width),
+        name_width,
+    );
+    let mux = format!("{:<7}", row.room.mux.as_str());
+    let agents_width = row.agents.as_ref().map_or(1, RoomAgents::width);
+    let fixed_width = 2 + name_width + 2 + 7 + 2 + 2 + agents_width;
+    let path_width = total_width.saturating_sub(fixed_width);
+    let path = truncate_width(
+        &crate::cli::render::home_relative(&row.room.project_root.to_string_lossy()),
+        path_width,
+    );
+    let mut spans = vec![
+        Span::styled(prefix.to_owned(), theme.accent()),
+        Span::styled(name, theme.body().add_modifier(Modifier::BOLD)),
+        Span::raw("  "),
+        Span::styled(mux, theme.meta()),
+        Span::raw("  "),
+        Span::styled(pad_right(&path, path_width), theme.muted()),
+        Span::raw("  "),
+    ];
+    push_agent_spans(&mut spans, row.agents.as_ref(), theme);
+    spans
+}
+
+fn push_agent_spans(
+    spans: &mut Vec<Span<'static>>,
+    agents: Option<&RoomAgents>,
+    theme: &PickerTheme,
+) {
+    let Some(agents) = agents.filter(|agents| !agents.is_empty()) else {
+        spans.push(Span::styled("–", theme.muted()));
+        return;
+    };
+    for (index, (kind, count)) in agents.by_kind.iter().enumerate() {
+        if index > 0 {
+            spans.push(Span::raw(" "));
+        }
+        spans.push(Span::styled(
+            format!("{} ×{count}", kind.as_str()),
+            theme.provider(kind.as_str()),
+        ));
+    }
+    if agents.attention > 0 {
+        spans.push(Span::styled(
+            format!(" ● {}", agents.attention),
+            theme.alarm().add_modifier(Modifier::BOLD),
+        ));
+    }
+}
+
+fn pad_right(text: &str, width: usize) -> String {
+    let padding = width.saturating_sub(UnicodeWidthStr::width(text));
+    format!("{text}{}", " ".repeat(padding))
+}
+
+fn truncate_width(text: &str, max_width: usize) -> String {
+    if UnicodeWidthStr::width(text) <= max_width {
+        return text.to_owned();
+    }
+    if max_width == 0 {
+        return String::new();
+    }
+    let content_width = max_width.saturating_sub(1);
+    let mut width = 0;
+    let mut out = String::new();
+    for character in text.chars() {
+        let character_width = UnicodeWidthChar::width(character).unwrap_or(0);
+        if width + character_width > content_width {
+            break;
+        }
+        width += character_width;
+        out.push(character);
+    }
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/rimz/src/cli/web/picker.rs
+++ b/crates/rimz/src/cli/web/picker.rs
@@ -1,8 +1,7 @@
 //! Interactive live-room picker for ttyd browser sessions.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::io::{self, IsTerminal};
-use std::process::Stdio;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
@@ -86,13 +85,7 @@ pub(super) fn run(rejected_session: Option<&str>) -> Result<bool> {
                     .release_keep_screen()
                     .context("releasing the web session picker")?;
                 let spec = rimz::mux::backend_for(mux).attach_existing_command(&session);
-                let outcome = spec
-                    .to_command()
-                    .stdin(Stdio::inherit())
-                    .stdout(Stdio::inherit())
-                    .stderr(Stdio::inherit())
-                    .spawn()
-                    .and_then(|mut child| child.wait());
+                let outcome = spec.to_command().spawn().and_then(|mut child| child.wait());
                 guard = Some(
                     TerminalModeGuard::enable(MouseCapture::Stdout, Screen::Alternate)
                         .context("restoring the web session picker")?,
@@ -165,9 +158,17 @@ struct RoomAgents {
 
 impl RoomAgents {
     fn from_snapshot(snapshot: &rimz::SidebarSnapshot) -> Self {
+        let live_agent_ids = snapshot
+            .agent_panes
+            .iter()
+            .filter_map(|pane_agent| pane_agent.agent_id.as_ref())
+            .collect::<HashSet<_>>();
         let mut by_kind = BTreeMap::new();
         let mut attention = 0;
-        for agent in snapshot.root_agents() {
+        for agent in snapshot
+            .root_agents()
+            .filter(|agent| live_agent_ids.contains(&agent.agent_id))
+        {
             *by_kind.entry(agent.kind.clone()).or_insert(0) += 1;
             attention += usize::from(agent.effective_status().is_attention());
         }

--- a/crates/rimz/src/cli/web/picker/tests.rs
+++ b/crates/rimz/src/cli/web/picker/tests.rs
@@ -52,6 +52,43 @@ fn rows() -> Vec<RoomRow> {
 }
 
 #[test]
+fn room_agents_count_only_pane_bound_root_sessions() {
+    let now = jiff::Timestamp::UNIX_EPOCH;
+    let mut live = rimz::testkit::agent_state("codex", "live", now);
+    live.status = rimz::agents::AgentStatus::Waiting;
+    let mut departed = rimz::testkit::agent_state("claude", "departed", now);
+    departed.status = rimz::agents::AgentStatus::Failed;
+    departed.ended_at = Some(now);
+    let mut snapshot = rimz::SidebarSnapshot::build_with_agents(
+        rimz::WorkspaceId::from_project_root(Path::new("/repo")),
+        vec![live.clone(), departed],
+        now,
+    );
+    snapshot.agent_panes.push(rimz::PaneAgent {
+        kind: live.kind.clone(),
+        kind_ordinal: None,
+        name: None,
+        name_explicit: false,
+        profile: None,
+        role: None,
+        channel: None,
+        agent_id: Some(live.agent_id),
+        pane_id: rimz::PaneId::from_parts(MuxName::Zellij, "%1"),
+        pane_pid: None,
+        worktree_path: None,
+        worktree_branch: None,
+    });
+
+    assert_eq!(
+        RoomAgents::from_snapshot(&snapshot),
+        RoomAgents {
+            by_kind: vec![(AgentKind::new_unchecked("codex"), 1)],
+            attention: 1,
+        }
+    );
+}
+
+#[test]
 fn filter_narrows_rows_and_enter_attaches_the_visible_selection() {
     let mut picker = Picker::new(None);
     picker.apply_probe(rows());

--- a/crates/rimz/src/cli/web/picker/tests.rs
+++ b/crates/rimz/src/cli/web/picker/tests.rs
@@ -1,0 +1,236 @@
+use std::path::Path;
+
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
+use ratatui::crossterm::event::{KeyEvent, MouseEvent};
+
+use super::*;
+
+fn room(name: &str, mux: MuxName, root: &str, agents: Option<RoomAgents>) -> RoomRow {
+    RoomRow {
+        room: rimz::web::LiveRoom {
+            session_name: name.to_owned(),
+            mux,
+            project_root: root.into(),
+            workspace_id: rimz::WorkspaceId::from_project_root(Path::new(root)),
+        },
+        agents,
+    }
+}
+
+fn agents(kinds: &[(&str, usize)], attention: usize) -> RoomAgents {
+    RoomAgents {
+        by_kind: kinds
+            .iter()
+            .map(|(kind, count)| (AgentKind::new_unchecked(*kind), *count))
+            .collect(),
+        attention,
+    }
+}
+
+fn key(code: KeyCode, modifiers: KeyModifiers) -> Event {
+    Event::Key(KeyEvent::new(code, modifiers))
+}
+
+fn rows() -> Vec<RoomRow> {
+    vec![
+        room(
+            "rimz-docs",
+            MuxName::Zellij,
+            "/repo/docs",
+            Some(agents(&[("claude", 2)], 1)),
+        ),
+        room(
+            "rimz-infra",
+            MuxName::Tmux,
+            "/repo/infra",
+            Some(agents(&[("codex", 1)], 0)),
+        ),
+        room("rimz-quiet", MuxName::Zellij, "/repo/quiet", None),
+    ]
+}
+
+#[test]
+fn filter_narrows_rows_and_enter_attaches_the_visible_selection() {
+    let mut picker = Picker::new(None);
+    picker.apply_probe(rows());
+
+    assert_eq!(picker.selected.as_deref(), Some("rimz-docs"));
+    assert_eq!(
+        picker.handle_event(key(KeyCode::Char('i'), KeyModifiers::NONE)),
+        None
+    );
+    assert_eq!(
+        picker.handle_event(key(KeyCode::Char('n'), KeyModifiers::NONE)),
+        None
+    );
+    assert_eq!(
+        picker
+            .visible()
+            .iter()
+            .map(|row| row.room.session_name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["rimz-infra"]
+    );
+    assert_eq!(picker.selected.as_deref(), Some("rimz-infra"));
+    assert_eq!(
+        picker.handle_event(key(KeyCode::Enter, KeyModifiers::NONE)),
+        Some(Action::Attach("rimz-infra".to_owned(), MuxName::Tmux))
+    );
+}
+
+#[test]
+fn probe_retains_a_visible_session_selection_and_clamps_a_vanished_one() {
+    let mut picker = Picker::new(None);
+    picker.apply_probe(rows());
+    picker.handle_event(key(KeyCode::Down, KeyModifiers::NONE));
+    assert_eq!(picker.selected.as_deref(), Some("rimz-infra"));
+
+    let mut refreshed = rows();
+    refreshed.reverse();
+    picker.apply_probe(refreshed);
+    assert_eq!(picker.selected.as_deref(), Some("rimz-infra"));
+
+    picker.apply_probe(vec![room("rimz-docs", MuxName::Zellij, "/repo/docs", None)]);
+    assert_eq!(picker.selected.as_deref(), Some("rimz-docs"));
+}
+
+#[test]
+fn escape_clears_filter_before_quitting_and_control_c_always_quits() {
+    let mut picker = Picker::new(None);
+    picker.apply_probe(rows());
+    picker.handle_event(key(KeyCode::Char('d'), KeyModifiers::NONE));
+
+    assert_eq!(
+        picker.handle_event(key(KeyCode::Esc, KeyModifiers::NONE)),
+        None
+    );
+    assert!(picker.filter.is_empty());
+    assert_eq!(
+        picker.handle_event(key(KeyCode::Esc, KeyModifiers::NONE)),
+        Some(Action::Quit)
+    );
+    assert_eq!(
+        picker.handle_event(key(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+        Some(Action::Quit)
+    );
+}
+
+#[test]
+fn wheel_moves_selection_and_a_second_click_on_one_row_attaches() {
+    let mut picker = Picker::new(None);
+    picker.apply_probe(rows());
+    picker.hit_rows = BTreeMap::from([(4, "rimz-docs".to_owned()), (5, "rimz-infra".to_owned())]);
+
+    picker.handle_event(Event::Mouse(MouseEvent {
+        kind: MouseEventKind::ScrollDown,
+        column: 2,
+        row: 4,
+        modifiers: KeyModifiers::NONE,
+    }));
+    assert_eq!(picker.selected.as_deref(), Some("rimz-infra"));
+
+    let click = Event::Mouse(MouseEvent {
+        kind: MouseEventKind::Down(MouseButton::Left),
+        column: 2,
+        row: 4,
+        modifiers: KeyModifiers::NONE,
+    });
+    assert_eq!(picker.handle_event(click.clone()), None);
+    assert_eq!(picker.selected.as_deref(), Some("rimz-docs"));
+    assert_eq!(
+        picker.handle_event(click),
+        Some(Action::Attach("rimz-docs".to_owned(), MuxName::Zellij))
+    );
+}
+
+#[test]
+fn picker_render_snapshots_cover_populated_filtered_empty_and_notice_frames() {
+    let mut populated = Picker::new(None);
+    populated.apply_probe(rows());
+    let mut filtered = Picker::new(None);
+    filtered.apply_probe(rows());
+    filtered.filter = "quiet".to_owned();
+    filtered.normalize_selection();
+    let mut empty = Picker::new(None);
+    let mut notice = Picker::new(Some("retired-room"));
+    notice.apply_probe(rows());
+
+    let rendered = format!(
+        "POPULATED\n{}\n\nFILTERED\n{}\n\nEMPTY\n{}\n\nNOTICE\n{}",
+        render_text(&mut populated, 76, 9),
+        render_text(&mut filtered, 76, 9),
+        render_text(&mut empty, 76, 9),
+        render_text(&mut notice, 76, 9),
+    );
+
+    insta::assert_snapshot!(rendered, @r###"
+    POPULATED
+    ╭ RimZ ── sessions ────────────────────────────────────────────────────────╮
+    │▸ rimz-docs   zellij   /repo/docs                            claude ×2 ● 1│
+    │  rimz-infra  tmux     /repo/infra                                codex ×1│
+    │  rimz-quiet  zellij   /repo/quiet                                       –│
+    │                                                                          │
+    │                                                                          │
+    │filter: _                                                                 │
+    │↑↓ select · ⏎ attach · type to filter · esc quit                          │
+    ╰──────────────────────────────────────────────────────────────────────────╯
+
+    FILTERED
+    ╭ RimZ ── sessions ────────────────────────────────────────────────────────╮
+    │▸ rimz-quiet  zellij   /repo/quiet                                       –│
+    │                                                                          │
+    │                                                                          │
+    │                                                                          │
+    │                                                                          │
+    │filter: quiet_                                                            │
+    │↑↓ select · ⏎ attach · type to filter · esc quit                          │
+    ╰──────────────────────────────────────────────────────────────────────────╯
+
+    EMPTY
+    ╭ RimZ ── sessions ────────────────────────────────────────────────────────╮
+    │No live RimZ sessions — run `rimz start` in a project                     │
+    │                                                                          │
+    │                                                                          │
+    │                                                                          │
+    │                                                                          │
+    │filter: _                                                                 │
+    │↑↓ select · ⏎ attach · type to filter · esc quit                          │
+    ╰──────────────────────────────────────────────────────────────────────────╯
+
+    NOTICE
+    ╭ RimZ ── sessions ────────────────────────────────────────────────────────╮
+    │session `retired-room` is not a live RimZ room                            │
+    │▸ rimz-docs   zellij   /repo/docs                            claude ×2 ● 1│
+    │  rimz-infra  tmux     /repo/infra                                codex ×1│
+    │  rimz-quiet  zellij   /repo/quiet                                       –│
+    │                                                                          │
+    │filter: _                                                                 │
+    │↑↓ select · ⏎ attach · type to filter · esc quit                          │
+    ╰──────────────────────────────────────────────────────────────────────────╯
+    "###);
+}
+
+fn render_text(picker: &mut Picker, width: u16, height: u16) -> String {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    let theme = PickerTheme::resolve(&ThemeConfig::default(), false, true);
+    terminal
+        .draw(|frame| render(frame, picker, &theme))
+        .expect("draw picker");
+    buffer_text(terminal.backend().buffer())
+}
+
+fn buffer_text(buffer: &Buffer) -> String {
+    (0..buffer.area.height)
+        .map(|y| {
+            let mut line = String::new();
+            for x in 0..buffer.area.width {
+                line.push_str(buffer[(x, y)].symbol());
+            }
+            line.trim_end().to_owned()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/crates/rimz/src/web/mod.rs
+++ b/crates/rimz/src/web/mod.rs
@@ -16,9 +16,11 @@ use crate::store::atomic;
 
 mod gate;
 mod share;
+mod sessions;
 mod ttyd;
 
 pub use gate::GateAuth;
+pub use sessions::{LiveRoom, live_rooms};
 
 pub const WEB_SCHEMA_VERSION: &str = "rimz.web.v2";
 pub(crate) const TTYD_PIXEL_PROTOCOL: u32 = 2;
@@ -511,9 +513,10 @@ pub fn existing_session_attach_command(session: Option<&str>) -> Result<CommandS
     let live = LiveSessions::probe();
     let target = live_session_target_with_probe(session, &live);
     let Some((session, mux)) = target else {
+        let rooms = sessions::live_rooms_with(&live)?;
         return Err(WebErr::InvalidSession(invalid_session_message(
-            session, &live,
-        )?));
+            session, &rooms,
+        )));
     };
     Ok(crate::mux::backend_for(mux).attach_existing_command(session))
 }
@@ -537,16 +540,11 @@ fn live_session_target_with_probe<'a>(
         })
 }
 
-fn invalid_session_message(session: Option<&str>, live: &LiveSessions) -> Result<String> {
-    let mut sessions = crate::workspace::known_workspaces()
-        .map_err(|source| WebErr::WorkspaceRecords { source })?
-        .into_iter()
-        .filter_map(|workspace| {
-            live.mux_of(&workspace.session_name)
-                .map(|mux| format!("  {} ({mux})", workspace.session_name))
-        })
+fn invalid_session_message(session: Option<&str>, rooms: &[LiveRoom]) -> String {
+    let sessions = rooms
+        .iter()
+        .map(|room| format!("  {} ({})", room.session_name, room.mux))
         .collect::<Vec<_>>();
-    sessions.sort();
     let requested = session.map_or_else(
         || "no session was provided".to_owned(),
         |session| format!("session `{session}` is not a live RimZ room"),
@@ -556,7 +554,7 @@ fn invalid_session_message(session: Option<&str>, live: &LiveSessions) -> Result
     } else {
         sessions.join("\n")
     };
-    Ok(format!("{requested}\n\nLive RimZ sessions:\n{listing}"))
+    format!("{requested}\n\nLive RimZ sessions:\n{listing}")
 }
 
 fn web_addressable_timeout() -> Duration {

--- a/crates/rimz/src/web/mod.rs
+++ b/crates/rimz/src/web/mod.rs
@@ -15,8 +15,8 @@ use crate::room::session::{LiveSessions, workspace_record_for_session};
 use crate::store::atomic;
 
 mod gate;
-mod share;
 mod sessions;
+mod share;
 mod ttyd;
 
 pub use gate::GateAuth;

--- a/crates/rimz/src/web/sessions.rs
+++ b/crates/rimz/src/web/sessions.rs
@@ -1,0 +1,94 @@
+//! Live RimZ room inventory for browser session selection.
+
+use std::path::PathBuf;
+
+use crate::ids::{MuxName, WorkspaceId};
+use crate::room::session::LiveSessions;
+use crate::workspace::KnownWorkspace;
+
+use super::{Result, WebErr};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LiveRoom {
+    pub session_name: String,
+    pub mux: MuxName,
+    pub project_root: PathBuf,
+    pub workspace_id: WorkspaceId,
+}
+
+pub fn live_rooms() -> Result<Vec<LiveRoom>> {
+    live_rooms_with(&LiveSessions::probe())
+}
+
+pub(super) fn live_rooms_with(live: &LiveSessions) -> Result<Vec<LiveRoom>> {
+    let known = crate::workspace::known_workspaces()
+        .map_err(|source| WebErr::WorkspaceRecords { source })?;
+    Ok(live_rooms_from(known, |session| live.mux_of(session)))
+}
+
+fn live_rooms_from(
+    known: Vec<KnownWorkspace>,
+    mux_of: impl Fn(&str) -> Option<MuxName>,
+) -> Vec<LiveRoom> {
+    let mut rooms = known
+        .into_iter()
+        .filter_map(|workspace| {
+            let mux = mux_of(&workspace.session_name)?;
+            Some(LiveRoom {
+                session_name: workspace.session_name,
+                mux,
+                project_root: workspace.project_root,
+                workspace_id: workspace.workspace_id,
+            })
+        })
+        .collect::<Vec<_>>();
+    rooms.sort_by(|left, right| left.session_name.cmp(&right.session_name));
+    rooms
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::workspace::RootClass;
+
+    use super::*;
+
+    fn known(session: &str, root: &str) -> KnownWorkspace {
+        KnownWorkspace {
+            workspace_id: WorkspaceId::from_project_root(std::path::Path::new(root)),
+            project_root: PathBuf::from(root),
+            session_name: session.to_owned(),
+            root_class: RootClass::Repo,
+            rimz_bin: None,
+        }
+    }
+
+    #[test]
+    fn live_room_join_filters_stopped_sessions_and_sorts_by_name() {
+        let rooms = live_rooms_from(
+            vec![
+                known("rimz-zulu", "/repo/zulu"),
+                known("rimz-stopped", "/repo/stopped"),
+                known("rimz-alpha", "/repo/alpha"),
+            ],
+            |session| match session {
+                "rimz-alpha" => Some(MuxName::Tmux),
+                "rimz-zulu" => Some(MuxName::Zellij),
+                _ => None,
+            },
+        );
+
+        assert_eq!(
+            rooms
+                .iter()
+                .map(|room| (room.session_name.as_str(), room.mux))
+                .collect::<Vec<_>>(),
+            vec![
+                ("rimz-alpha", MuxName::Tmux),
+                ("rimz-zulu", MuxName::Zellij),
+            ]
+        );
+        assert_eq!(rooms[0].project_root, PathBuf::from("/repo/alpha"));
+    }
+}

--- a/docs/guide/web.md
+++ b/docs/guide/web.md
@@ -54,6 +54,14 @@ The viewer link is deliberately unauthenticated. Keep the listener on loopback f
 
 tmux viewers attach read-only and with `ignore-size`, so they cannot type or resize the presenter's layout. Zellij has no read-only or size-isolated attach mode: ttyd still blocks viewer input, but a viewer window resize can influence the shared Zellij session geometry.
 
+## Session manager
+
+Open the base address without `?arg=` to choose among every live RimZ room on the machine. An unknown or stopped session argument opens the same switcher with a notice; a valid argument continues to attach directly.
+
+Use ↑/↓ or j/k and the mouse wheel to move, Enter or a second click on the selected row to attach, and printable keys to filter session names. Backspace edits the filter, Esc clears it before quitting, and Ctrl-C quits immediately.
+
+Each row shows its multiplexer and project path plus live root-agent counts by provider. The red `●` count marks agents that need attention. Leaving a room through its mux detach key returns to the live session list so the same browser tab can attach elsewhere.
+
 ## Browser appearance and input
 
 RimZ gives ttyd the active theme and configured browser font when the daemon starts. `JetBrainsMono Nerd Font Mono` and `CaskaydiaCove Nerd Font Mono` are built-in presets: RimZ downloads verified regular and bold faces and caches them under `$XDG_CACHE_HOME/rimz/web-fonts`.
@@ -153,7 +161,7 @@ style_client = true
 
 By default, RimZ invokes ttyd with write access, origin checks, mandatory Basic Auth, and an explicit loopback bind.
 
-The one machine credential authenticates the shared listener, so it grants access to every live RimZ room on that machine rather than only the room named in the first URL. An authenticated client can submit another session argument, and a missing or rejected argument lists the live RimZ rooms. A remote `--web` tunnel forwards this same machine-wide surface through its local port.
+The one machine credential authenticates the shared listener, so it grants access to every live RimZ room on that machine rather than only the room named in the first URL. An authenticated client can submit another session argument, and a missing or rejected argument opens the live-room session manager. A remote `--web` tunnel forwards this same machine-wide surface through its local port.
 
 The broadcast listener is a separate process without `-W` or `-c`: ttyd drops input and admits connections without authentication, while RimZ's per-connection shim limits attachment to the durable room allowlist and never lists other rooms. Its output can still contain secrets. Bind it to loopback or place it behind a reverse proxy and firewall before public exposure.
 

--- a/docs/internals/web.md
+++ b/docs/internals/web.md
@@ -28,7 +28,9 @@ The gate parses the configured bare IPs and IPv4 or IPv6 CIDRs before any proces
 
 Room URLs have the shape `<base>/?arg=<percent-encoded-session>`. ttyd appends the decoded session to the hidden shim as `rimz web exec <session>`.
 
-The shim accepts only a session with a durable RimZ workspace record and a matching live mux session. It never treats the browser argument as an argv fragment. A valid tmux target execs `tmux -S <managed-socket> attach -t <session>`; a valid Zellij target execs `zellij attach <session>`. A missing, unknown, or stopped target prints the currently live RimZ sessions and exits 1.
+The shim accepts only a session with a durable RimZ workspace record and a matching live mux session. It never treats the browser argument as an argv fragment. A valid tmux target execs `tmux -S <managed-socket> attach -t <session>`; a valid Zellij target execs `zellij attach <session>`.
+
+A missing, unknown, or stopped target on terminal stdio opens the themed session manager. It joins durable workspace records with one live mux probe, filters by session name, and attaches the selected room as an inherited-stdio child after releasing raw input while preserving the alternate screen; when that child ends, a fresh probe returns the browser tab to the list. The agent counts and attention tally read through `PublishedSnapshotReader`, keeping one incremental consumer cursor per live session and degrading an unreadable snapshot to an unenriched row. Non-terminal stdio prints the same live-session listing and exits 1.
 
 The ttyd binary resolves from `RIMZ_TTYD_BIN`, then `PATH`. A missing binary reports the Homebrew and apt install fix. `interface` must parse as an IP address, each trusted proxy must parse as an IP or CIDR, and an occupied configured listener returns a typed error that points to `[web] port`.
 


### PR DESCRIPTION
## Context

ttyd runs one shim per browser connection (`rimz web exec [SESSION]`). Previously, a missing or non-live `?arg=` session made the shim print a plain-text listing and exit 1, so the browser terminal showed dead error text. Anyone fronting ttyd with a reverse proxy lands on the base URL with no session and hit exactly that dead end.

This adds a full-screen, themed TUI session manager rendered in the ttyd terminal: it lists live RimZ rooms on the machine, lets you filter and pick one, and attaches — in the spirit of Zellij's session manager. On the web there is no "detach"; leaving is closing the tab, so picking from the base URL is how you switch rooms in one tab.

## Design choices

- **Trigger is narrow.** The picker runs only when the shim gets no session or a non-live one *and* both stdin and stdout are terminals. A valid `?arg=` keeps the existing fast attach path unchanged. Non-terminal stdio keeps the original plain error text, which preserves the existing piped-stdio integration tests and any scripted use.
- **Attach is spawn-and-wait, not exec.** On pick, the picker releases raw input while keeping the alternate screen, spawns the mux attach command inheriting stdio, waits, then re-enters with a fresh probe. If the room ends or the user detaches via a mux keybinding, they land back in the list instead of ttyd's dead disconnect overlay — that is what lets one tab switch rooms. Closing the tab hangs up the shim's PTY and the attach child dies with it (shared process group), so no orphan attach processes.
- **Unknown session degrades to the picker** with a notice line, so a stale bookmark becomes the switcher instead of an error page.
- **Rows are enriched from the sanctioned consumer lane.** Per live room, RimZ reads the published sidebar snapshot through `PublishedSnapshotReader` (one retained reader/cursor per session for incremental folds) and derives per-provider live root-agent counts and an attention count. Any read failure degrades that row to name/mux/path — enrichment never blocks the list.
- **One interface language.** Every color resolves through the theme core — palette at the effective depth, a module-local `Tone → ratatui::Color` edge, provider chips via `resolve_provider_brand`, attention in the alarm tone, selection via `selection_bg`. `NO_COLOR` drops styles.
- **Placement follows the CLI contract.** The session-inventory join is domain code in `web/sessions.rs`; the interactive surface is presentation in `cli/web/` (`web.rs` became a directory module).

## Implementation

- `web::sessions::live_rooms` — a sorted join of durable workspace records with one cross-backend live-session probe. The pre-existing plain invalid-session listing now builds from it; the output text is byte-identical, so the two pinned rejection tests stay green.
- `cli/web/picker.rs` — the ratatui session manager: identity-based selection retained across ~2s refreshes, case-insensitive substring filter, keyboard and mouse selection, spawn-and-wait attach with return-to-list, and theme-resolved rendering. Covered by pure state tests and populated/filtered/empty/notice `TestBackend` snapshots.
- Row enrichment derives counts from `snapshot.root_agents()` **intersected with `snapshot.agent_panes`**, matching the `rimz agents list` precedent so only live, pane-bound root agents are counted (a departed session contributes no chip and no attention).
- Docs (`docs/guide/web.md`, `docs/internals/web.md`) and a CHANGELOG entry describe the switcher, key map, attach lifecycle, and consumer-lane enrichment.

### Deviations from the plan

- The **valid**-session lookup stays on the pre-existing `workspace_record_for_session` path rather than resolving through `live_rooms()`. The inventory join deduplicates workspace records differently from the attach lookup, so reusing it for valid targets could change which duplicate record is accepted; the invalid listing reuses the already-completed live probe via `live_rooms_with` without touching valid attach semantics.
- Picker startup returns a boolean setup outcome instead of a new error enum. `false` is used only before the first paint and preserves the plain invalid-session error; runtime I/O failures remain real errors.
- The attach child relies on `Command::spawn`'s standard inherited-stdio default rather than explicit `Stdio::inherit()` calls — behavior-identical, and it keeps the repository's no-`Stdio::inherit` hook-safety invariant satisfied.

### Mainline reconciliation

Rebased onto `c87c7d186` (read-only room broadcasts), which touched the same web surface. The renamed `cli/web/mod.rs` now carries both command families: writable `web exec` enters the picker only for missing or invalid sessions, while `web exec --share` stays on the broadcast allowlist path and never exposes the picker or the live-room inventory. `web/mod.rs` keeps the broadcast helper alongside the session-inventory join; guide, internals, changelog, and integration-test behavior from both changes are merged, and the writable session manager and unauthenticated read-only broadcast stay documented as distinct security surfaces.

## Advisories

- **Lowercase `j`/`k` are navigation keys, so they cannot be typed into the filter** (uppercase `J`/`K` still filter). This is an accepted tradeoff: the requested key map lists both j/k navigation and type-to-filter, and navigation wins for those two letters, matching Zellij's manager.
- **A transient probe-error notice ("could not read live rooms…") persists until the next attach** rather than clearing on the next successful probe. Left as-is: probe failures are rare and display-only, and clearing only probe-origin notices would mean adding notice provenance for a rare case while keeping attach and rejected-session notices intentionally persistent.
- Browser-tab-close/SIGHUP cleanup relies on ttyd keeping the shim and the spawned mux attach in one foreground process group; the sandbox verified attach/detach but not a real browser tab close (no browser in the build environment).