### PR TITLE
test(integration): remove scheduler races from live fixtures

### DIFF
--- a/crates/rimz/tests/fixtures/ssh-trace/main.rs
+++ b/crates/rimz/tests/fixtures/ssh-trace/main.rs
@@ -37,7 +37,7 @@ fn main() {
     }
 
     if is_control_check(&argv) {
-        exit_control_check();
+        exit_control_check(&argv);
     }
 
     if is_forward_control(&argv) {
@@ -61,14 +61,14 @@ fn main() {
     }
 
     if argv.iter().any(|arg| arg == "-M") {
-        run_control_master();
+        run_control_master(&argv);
     }
 
     if argv.iter().any(|arg| arg == "-N") {
         run_web_tunnel(&argv);
     }
 
-    publish_control_master_if_requested();
+    publish_control_master_if_requested(&argv);
     wait_for_probe_if_requested(&log_path);
     record_and_enter_raw_tty_if_requested();
 
@@ -173,7 +173,7 @@ fn run_web_control_forward() -> ! {
     exit_from_plan("RIMZ_TEST_SSH_TUNNEL_PLAN");
 }
 
-fn run_control_master() -> ! {
+fn run_control_master(argv: &[String]) -> ! {
     if let Ok(stderr) = env::var("RIMZ_TEST_SSH_MASTER_STDERR") {
         let mut stream = std::io::stderr().lock();
         stream
@@ -189,7 +189,7 @@ fn run_control_master() -> ! {
         .map(|value| value != 0)
         .unwrap_or(true);
     if publish_ready {
-        publish_control_master_if_requested();
+        publish_control_master_if_requested(argv);
     }
     if let Ok(ms) = env::var("RIMZ_TEST_SSH_MASTER_EXIT_MS")
         && let Ok(ms) = ms.parse::<u64>()
@@ -246,9 +246,9 @@ fn is_forward_control(argv: &[String]) -> bool {
         .any(|args| args[0] == "-O" && matches!(args[1].as_str(), "forward" | "cancel"))
 }
 
-fn exit_control_check() -> ! {
-    let ready = env::var_os("RIMZ_TEST_CONTROL_MASTER_READY")
-        .map(|path| std::path::PathBuf::from(path).exists())
+fn exit_control_check(argv: &[String]) -> ! {
+    let ready = control_master_marker(argv)
+        .map(|path| path.exists())
         .unwrap_or(true);
     std::process::exit(if ready { 0 } else { 255 });
 }
@@ -266,8 +266,8 @@ fn record_probe_before_master_if_needed() {
     }
 }
 
-fn publish_control_master_if_requested() {
-    let Some(path) = env::var_os("RIMZ_TEST_CONTROL_MASTER_READY") else {
+fn publish_control_master_if_requested(argv: &[String]) {
+    let Some(path) = control_master_marker(argv) else {
         return;
     };
     if let Ok(ms) = env::var("RIMZ_TEST_CONTROL_MASTER_READY_DELAY_MS")
@@ -276,6 +276,25 @@ fn publish_control_master_if_requested() {
         std::thread::sleep(std::time::Duration::from_millis(ms));
     }
     std::fs::write(path, b"ready").expect("publish control-master marker");
+}
+
+/// Use an explicit test marker when one is configured. Otherwise mirror
+/// OpenSSH's socket lifecycle at the `ControlPath` itself: successful shim
+/// masters publish it, `ssh -O check` observes it, and the supervisor removes
+/// it when the owning master guard ends. This keeps a fast failed master from
+/// looking established merely because the check process won a scheduler race.
+fn control_master_marker(argv: &[String]) -> Option<std::path::PathBuf> {
+    if let Some(path) = env::var_os("RIMZ_TEST_CONTROL_MASTER_READY") {
+        return Some(path.into());
+    }
+    argv.windows(2)
+        .find(|args| args[0] == "-S")
+        .map(|args| std::path::PathBuf::from(&args[1]))
+        .or_else(|| {
+            argv.iter()
+                .find_map(|arg| arg.strip_prefix("ControlPath="))
+                .map(std::path::PathBuf::from)
+        })
 }
 
 fn wait_for_probe_if_requested(log_path: &std::ffi::OsStr) {

--- a/crates/rimz/tests/integration/backend/tmux/pane_io.rs
+++ b/crates/rimz/tests/integration/backend/tmux/pane_io.rs
@@ -150,7 +150,7 @@ fn pane_io_round_trips_keys_named_keys_and_bracketed_paste() {
         .send_keys(
             &pane_id,
             &format!(
-                "stty raw -echo; dd bs=1 count=4 of={} 2>/dev/null; stty sane",
+                "stty raw -echo; dd bs=1 count=4 of={} 2>/dev/null; stty sane; printf '\\nrimz-raw-reader-ready\\n'",
                 key_bytes.display()
             ),
         )
@@ -182,6 +182,16 @@ fn pane_io_round_trips_keys_named_keys_and_bracketed_paste() {
         thread::sleep(Duration::from_millis(25));
     };
     assert_eq!(bytes, b"\x1b\x1b[Z");
+    let capture = capture_pane_until(
+        &server.backend,
+        &pane_id,
+        "rimz-raw-reader-ready",
+        Duration::from_secs(2),
+    );
+    assert!(
+        capture.contains("rimz-raw-reader-ready"),
+        "the shell should restore cooked mode before the paste; capture was: {capture:?}",
+    );
     // Leading dash guards the `send-keys -l --` spelling: payload bytes must not
     // be re-read as tmux flags or key names.
     let payload = "-rf rimz-paste-marker";

--- a/crates/rimz/tests/integration/backend/zellij/daemon.rs
+++ b/crates/rimz/tests/integration/backend/zellij/daemon.rs
@@ -58,7 +58,10 @@ fn open_background_view_creates_named_tab_idempotently() {
     require_zellij!();
 
     let name = unique_session_name("bgview");
-    let session = ZellijSession::spawn(&name);
+    let xdg = scoped_runtime_dir();
+    let cwd = TempDir::new().expect("cwd tempdir");
+    create_plain_background_session(xdg.path(), &name, cwd.path(), "120");
+    let session = ZellijSession::attach_existing(xdg, &name);
     let backend = ZellijBackend::with_runtime_dir(session.xdg.path());
     let (_stub_dir, stub) = sidebar_command_stub();
 

--- a/crates/rimz/tests/integration/start.rs
+++ b/crates/rimz/tests/integration/start.rs
@@ -14,6 +14,9 @@ use rimz::workspace::WorkspaceResolver;
 use crate::common::{CommandTimeoutExt, Env};
 
 const MATERIALIZED_ROOM_PANES: &str = r#"[{"id":1,"is_plugin":false,"tab_id":1,"title":"rimz-sidebar"},{"id":2,"is_plugin":false,"tab_id":1,"title":"sh"}]"#;
+/// Full room birth exercises several bounded mux probes and sidebar handoffs;
+/// keep its process ceiling distinct from the 10-second control-command bound.
+const START_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn zellij_trace_shim() -> PathBuf {
     crate::common::cargo_bin("zellij-trace", env!("CARGO_BIN_EXE_zellij-trace"))
@@ -206,7 +209,7 @@ fn start_checks_hooks_on_birth_but_not_live_reattach() {
     let mut birth_command = birth.rimz();
     configure_actionable_hooks(&mut birth_command, &birth, &birth_bin, &birth_trace, "");
     let birth_output = birth_command
-        .bounded_output()
+        .bounded_output_within(START_TIMEOUT)
         .expect("run absent-room start");
     assert!(
         birth_output.status.success(),
@@ -252,7 +255,9 @@ fn start_checks_hooks_on_birth_but_not_live_reattach() {
     let live_trace = live.project_root.join("zellij-live.log");
     let mut live_command = live.rimz();
     configure_actionable_hooks(&mut live_command, &live, &live_bin, &live_trace, &sessions);
-    let live_output = live_command.bounded_output().expect("run live-room start");
+    let live_output = live_command
+        .bounded_output_within(START_TIMEOUT)
+        .expect("run live-room start");
     assert!(
         live_output.status.success(),
         "reattach failed: {}",
@@ -334,7 +339,7 @@ fn reconnect_marker_keeps_pty_start_unattended() {
         let _ = reader.read_to_end(&mut output);
         output
     });
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + START_TIMEOUT;
     let status = loop {
         if let Some(status) = child.try_wait().expect("poll reconnect start") {
             break Some(status);
@@ -349,7 +354,9 @@ fn reconnect_marker_keeps_pty_start_unattended() {
     drop(pair.master);
     let output =
         String::from_utf8_lossy(&reader_thread.join().expect("join pty reader")).into_owned();
-    let status = status.unwrap_or_else(|| panic!("reconnect start blocked on a prompt:\n{output}"));
+    let status = status.unwrap_or_else(|| {
+        panic!("reconnect start did not finish within {START_TIMEOUT:?}:\n{output}")
+    });
     assert!(status.success(), "reconnect start failed: {output}");
     assert!(
         output.contains("No terminal input — nothing installed or refreshed."),


### PR DESCRIPTION
## Summary

- wait for the tmux shell to restore cooked terminal mode before exercising bracketed paste
- create the Zellij session synchronously before attaching the long-lived PTY client
- make the SSH trace fixture publish and probe the real ControlPath lifecycle
- give complete room birth and reattach test workflows a dedicated 30-second process ceiling
- retain no-input assertions that reject hook-consent and project-trust prompts

## Why

Several integration tests observed partial or stale readiness that depended on process scheduling. Under GitHub Actions load, pasted bytes could race terminal restoration, a Zellij client could probe a session still being created, and a failed fake ControlMaster could look established when its control check ran first.

The start workflows also perform multiple bounded mux probes and sidebar handoffs and take about 7.2 seconds locally. Reusing the generic 10-second control-command ceiling left insufficient CI headroom and mislabeled load-related timeouts as blocked prompts.

## Validation

- 100 no-retry stress iterations of the original three affected tests
- 20 no-retry stress iterations of both start workflows
- full remote attach module: 24 passed
- live backend profile without retries: 76 passed
- `cargo xtask gate`
