### PR TITLE
fix(agents): verify ambiguous Cursor binary identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ RimZ is alpha software on the 0.x line. Commands, flags, config keys, and output
 
 ### Fixed
 
+- Cursor binary discovery verifies the generic `agent` executable before claiming it, launches only a verified path or the provider-unique `cursor-agent` alias, and leaves ambiguous process basenames unattributed until a native hook binds the pane. → [Cursor adapter](./docs/internals/agents/cursor.md#launch-and-resume)
 - Browser authentication now keeps ttyd behind machine-wide Basic Auth while the public gate validates trusted proxy headers and injects that credential upstream; remote `--web` tunnels work through either auth mode, `rimz web restart` applies the current browser profile, and `rimz reload` refreshes an online web daemon after upgrades. → [web](./docs/guide/web.md)
 - Browser cursors stay steady when terminal apps request a blinking cursor. → [web](./docs/guide/web.md#browser-appearance-and-input)
 - Pixel pets and the pixel context meter render as true pixels in ttyd browser attaches for qualifying tmux rooms; pets keep their native proportions, leave tmux borders and neighboring panes intact, and suppress placeholder glyphs before xterm paints them, while mixed or unsupported clients continue to fall back to sextant cell art. → [pets](./docs/guide/pets.md#crisp-pixels-and-cell-art)

--- a/crates/rimz/src/agents/adapters/amp/mod.rs
+++ b/crates/rimz/src/agents/adapters/amp/mod.rs
@@ -72,6 +72,7 @@ static AMP_DESCRIPTOR: AgentSpec = AgentSpec {
     default_model: None,
     process_names: &["amp", "node"],
     bin_names: &["amp"],
+    bin_identity: None,
     extra_bin_dirs: &[],
     thread_key: ThreadKey::PerFile,
     launch: super::LaunchSpec {

--- a/crates/rimz/src/agents/adapters/antigravity/mod.rs
+++ b/crates/rimz/src/agents/adapters/antigravity/mod.rs
@@ -193,6 +193,7 @@ static ANTIGRAVITY_DESCRIPTOR: AgentSpec = AgentSpec {
     default_model: None,
     process_names: &["agy"],
     bin_names: &["agy"],
+    bin_identity: None,
     extra_bin_dirs: &[".local/bin"],
     thread_key: ThreadKey::PerFile,
     launch: super::LaunchSpec {

--- a/crates/rimz/src/agents/adapters/claude/mod.rs
+++ b/crates/rimz/src/agents/adapters/claude/mod.rs
@@ -126,6 +126,7 @@ static CLAUDE_DESCRIPTOR: AgentSpec = AgentSpec {
     default_model: None,
     process_names: &["claude"],
     bin_names: &["claude"],
+    bin_identity: None,
     extra_bin_dirs: &[],
     // A Claude session spreads across `<session_id>/chat.jsonl` plus
     // `<session_id>/subagents/*.jsonl`; the session directory is the thread.

--- a/crates/rimz/src/agents/adapters/codex/mod.rs
+++ b/crates/rimz/src/agents/adapters/codex/mod.rs
@@ -206,6 +206,7 @@ static CODEX_DESCRIPTOR: AgentSpec = AgentSpec {
     // launcher process name beside its own.
     process_names: &["codex", "node"],
     bin_names: &["codex"],
+    bin_identity: None,
     extra_bin_dirs: &[],
     // Codex logs one rollout file per session.
     thread_key: ThreadKey::PerFile,

--- a/crates/rimz/src/agents/adapters/copilot/mod.rs
+++ b/crates/rimz/src/agents/adapters/copilot/mod.rs
@@ -90,6 +90,7 @@ static COPILOT_DESCRIPTOR: AgentSpec = AgentSpec {
     default_model: None,
     process_names: &["copilot", "node"],
     bin_names: &["copilot"],
+    bin_identity: None,
     extra_bin_dirs: &[],
     thread_key: ThreadKey::PerFile,
     launch: super::LaunchSpec {

--- a/crates/rimz/src/agents/adapters/cursor/mod.rs
+++ b/crates/rimz/src/agents/adapters/cursor/mod.rs
@@ -24,9 +24,9 @@ use serde_json::json as test_json;
 use serde_json::{Value, json};
 
 use super::definition::{
-    AgentSpec, Brand, Capabilities, CapabilityLevel, ConcernCoverage, CoverageAnnotations,
-    HookCoverage, LifecycleAnnotations, PlanLabel, RealtimeUsageChannel, RemoteControlCapability,
-    ThreadKey, ToolClassification, UserCoverage,
+    AgentSpec, BinIdentity, Brand, Capabilities, CapabilityLevel, ConcernCoverage,
+    CoverageAnnotations, HookCoverage, LifecycleAnnotations, PlanLabel, RealtimeUsageChannel,
+    RemoteControlCapability, ThreadKey, ToolClassification, UserCoverage,
 };
 use super::hook_types::{HookEventSpec, catalog_contains, decode_catalog_hook};
 use super::lifecycle::LifecycleSignal;
@@ -38,6 +38,8 @@ use super::{
 #[cfg(test)]
 use crate::harness::run::PermissionMode;
 use crate::ids::AgentSessionId;
+
+const UNAMBIGUOUS_FALLBACK_BIN: &str = "cursor-agent";
 
 static CURSOR_DESCRIPTOR: AgentSpec = AgentSpec {
     kind: "cursor",
@@ -82,6 +84,13 @@ static CURSOR_DESCRIPTOR: AgentSpec = AgentSpec {
     default_model: None,
     process_names: &["cursor-agent", "agent"],
     bin_names: &["cursor-agent", "agent"],
+    // Cursor's generic `agent` name collides with the alias Grok's installer
+    // symlinks onto `$PATH`, so a match on it is confirmed by Cursor's own
+    // version banner before discovery accepts it.
+    bin_identity: Some(BinIdentity {
+        ambiguous: &["agent"],
+        verify: agent_binary_is_cursor,
+    }),
     extra_bin_dirs: &[],
     thread_key: ThreadKey::PerFile,
     launch: super::LaunchSpec {
@@ -468,20 +477,26 @@ impl crate::agents::capabilities::LaunchCapability for CursorAdapter {
     }
 
     fn resume_command(&self, session_id: &str, _cwd: &Path) -> Option<Vec<String>> {
-        let bin = locate_binary(self.spec())
-            .map(|path| path.to_string_lossy().into_owned())
-            .unwrap_or_else(|| "agent".to_owned());
+        let bin = cursor_launch_binary(locate_binary(self.spec()));
         Some(vec![bin, "--resume".to_owned(), session_id.to_owned()])
     }
 
     fn launch_command(&self, extra_args: &[String], prompt: Option<&str>) -> Option<Vec<String>> {
-        let bin = locate_binary(self.spec())
-            .map(|path| path.to_string_lossy().into_owned())
-            .unwrap_or_else(|| "agent".to_owned());
+        let bin = cursor_launch_binary(locate_binary(self.spec()));
         let mut argv = self.spec().launch.launch_command(extra_args, prompt)?;
         argv[0] = bin;
         Some(argv)
     }
+}
+
+/// Select the verified Cursor path when discovery found one. The fallback stays
+/// provider-unique so a colliding `agent` alias can fail to resolve but can
+/// never launch another provider as Cursor.
+fn cursor_launch_binary(located: Option<PathBuf>) -> String {
+    located.map_or_else(
+        || UNAMBIGUOUS_FALLBACK_BIN.to_owned(),
+        |path| path.to_string_lossy().into_owned(),
+    )
 }
 
 impl crate::agents::capabilities::SessionCapability for CursorAdapter {
@@ -596,6 +611,16 @@ impl crate::agents::capabilities::SpendingCapability for CursorAdapter {
     fn session_transcript(&self, session_id: &str, prior_path: Option<&Path>) -> Option<PathBuf> {
         transcript::resolve_transcript(session_id, None, prior_path)
     }
+}
+
+/// Whether a binary located under Cursor's ambiguous `agent` name is genuinely
+/// Cursor. Cursor's date-build banner (`YYYY.MM.DD-hash`) is unique to Cursor,
+/// so a candidate whose `--version` parses under it is Cursor and no other CLI
+/// sharing the `agent` filename (Grok's install alias) is.
+fn agent_binary_is_cursor(stdout: &str, stderr: &str) -> bool {
+    parse_cursor_version(stdout)
+        .or_else(|| parse_cursor_version(stderr))
+        .is_some()
 }
 
 fn parse_cursor_version(output: &str) -> Option<String> {

--- a/crates/rimz/src/agents/adapters/cursor/tests.rs
+++ b/crates/rimz/src/agents/adapters/cursor/tests.rs
@@ -42,6 +42,38 @@ fn version_parser_preserves_the_cursor_date_build_token() {
     );
 }
 
+#[test]
+fn agent_identity_accepts_cursor_and_rejects_grok_alias() {
+    assert!(agent_binary_is_cursor("2026.07.17-3e2a980\n", ""));
+    assert!(agent_binary_is_cursor("", "2026.07.17-3e2a980\n"));
+    assert!(!agent_binary_is_cursor(
+        "grok 0.2.106 (bde89716f6) [stable]",
+        ""
+    ));
+    assert!(!agent_binary_is_cursor("", ""));
+
+    let identity = CursorAdapter
+        .spec()
+        .ambiguous_bin_identity("agent")
+        .expect("cursor's `agent` name is ambiguous");
+    assert!((identity.verify)("2026.07.17-3e2a980", ""));
+    assert!(
+        CursorAdapter
+            .spec()
+            .ambiguous_bin_identity("cursor-agent")
+            .is_none()
+    );
+}
+
+#[test]
+fn cursor_launch_fallback_never_reuses_the_ambiguous_agent_name() {
+    assert_eq!(cursor_launch_binary(None), "cursor-agent");
+    assert_eq!(
+        cursor_launch_binary(Some(PathBuf::from("/opt/cursor/agent"))),
+        "/opt/cursor/agent"
+    );
+}
+
 struct CursorAskFixture {
     _dir: tempfile::TempDir,
     home: PathBuf,

--- a/crates/rimz/src/agents/adapters/droid/mod.rs
+++ b/crates/rimz/src/agents/adapters/droid/mod.rs
@@ -82,6 +82,7 @@ static DROID_DESCRIPTOR: AgentSpec = AgentSpec {
     default_model: None,
     process_names: &["droid"],
     bin_names: &["droid"],
+    bin_identity: None,
     extra_bin_dirs: &[],
     thread_key: ThreadKey::PerFile,
     launch: super::LaunchSpec {

--- a/crates/rimz/src/agents/adapters/grok/mod.rs
+++ b/crates/rimz/src/agents/adapters/grok/mod.rs
@@ -76,6 +76,7 @@ static GROK_DESCRIPTOR: AgentSpec = AgentSpec {
     default_model: None,
     process_names: &["grok", "xai-grok-pager"],
     bin_names: &["grok"],
+    bin_identity: None,
     extra_bin_dirs: &[],
     thread_key: ThreadKey::PerFile,
     launch: super::LaunchSpec {

--- a/crates/rimz/src/agents/adapters/kimi/mod.rs
+++ b/crates/rimz/src/agents/adapters/kimi/mod.rs
@@ -110,6 +110,7 @@ static KIMI_DESCRIPTOR: AgentSpec = AgentSpec {
     default_model: None,
     process_names: &["kimi", "kimi-code"],
     bin_names: &["kimi"],
+    bin_identity: None,
     extra_bin_dirs: &[".kimi-code/bin"],
     thread_key: ThreadKey::SessionDir,
     launch: super::LaunchSpec {

--- a/crates/rimz/src/agents/adapters/kiro/mod.rs
+++ b/crates/rimz/src/agents/adapters/kiro/mod.rs
@@ -36,6 +36,7 @@ static KIRO_DESCRIPTOR: AgentSpec = AgentSpec {
     kind: "kiro",
     aliases: &[],
     bin_names: &["kiro-cli"],
+    bin_identity: None,
     display_name: "Kiro",
     brand: Brand {
         emblem: None,

--- a/crates/rimz/src/agents/adapters/opencode/mod.rs
+++ b/crates/rimz/src/agents/adapters/opencode/mod.rs
@@ -92,6 +92,7 @@ static OPENCODE_DESCRIPTOR: AgentSpec = AgentSpec {
     default_model: None,
     process_names: &["opencode", "bun"],
     bin_names: &["opencode"],
+    bin_identity: None,
     extra_bin_dirs: &[".opencode/bin"],
     thread_key: ThreadKey::PerFile,
     launch: super::LaunchSpec {

--- a/crates/rimz/src/agents/adapters/pi/mod.rs
+++ b/crates/rimz/src/agents/adapters/pi/mod.rs
@@ -114,6 +114,7 @@ static PI_DESCRIPTOR: AgentSpec = AgentSpec {
     default_model: None,
     process_names: &["pi"],
     bin_names: &["pi"],
+    bin_identity: None,
     extra_bin_dirs: &[],
     thread_key: ThreadKey::PerFile,
     launch: super::LaunchSpec {

--- a/crates/rimz/src/agents/adapters/plugin/mod.rs
+++ b/crates/rimz/src/agents/adapters/plugin/mod.rs
@@ -434,6 +434,7 @@ fn build_descriptor(manifest: &'static PluginManifest, plugin_dir: &'static Path
         default_model: None,
         process_names: leak_strings(&manifest.process_names),
         bin_names: leak_strings(std::slice::from_ref(&manifest.kind)),
+        bin_identity: None,
         extra_bin_dirs: &[],
         thread_key: match manifest.transcripts.as_ref().map(|value| value.thread_key) {
             Some(TranscriptThreadKey::SessionDir) => ThreadKey::SessionDir,

--- a/crates/rimz/src/agents/adapters/qwen/mod.rs
+++ b/crates/rimz/src/agents/adapters/qwen/mod.rs
@@ -44,6 +44,7 @@ static QWEN_DESCRIPTOR: AgentSpec = AgentSpec {
     aliases: &[],
     display_name: "Qwen Code",
     bin_names: &["qwen"],
+    bin_identity: None,
     brand: Brand {
         emblem: None,
         color: 99,

--- a/crates/rimz/src/agents/definition.rs
+++ b/crates/rimz/src/agents/definition.rs
@@ -250,6 +250,24 @@ pub enum StaticPresetMatcher {
     },
 }
 
+/// Provider-identity check for a [`bin_names`](AgentSpec::bin_names) entry that
+/// another provider's installer also ships under the same filename. Cursor's
+/// `agent` collides with the alias Grok's installer symlinks onto `$PATH`, so a
+/// bare filename match cannot prove the located binary is Cursor's.
+#[derive(Clone, Copy, Debug)]
+pub struct BinIdentity {
+    /// The subset of [`bin_names`](AgentSpec::bin_names) that collide with
+    /// another provider's install alias. A candidate matched by one of these is
+    /// accepted only after `verify` confirms it; every other name matches on
+    /// filename alone.
+    pub ambiguous: &'static [&'static str],
+    /// Confirms a candidate is genuinely this provider from its `--version`
+    /// stdout and stderr. The adapter's own version parser recognizes only its
+    /// own release banner, so a colliding alias fails the check and discovery
+    /// skips it.
+    pub verify: fn(&str, &str) -> bool,
+}
+
 /// Static identity, branding, capabilities, and classification tables for one
 /// agent. See the module doc for the definition-vs-trait split.
 #[derive(Debug)]
@@ -311,6 +329,12 @@ pub struct AgentSpec {
     /// kind; Cursor ships its CLI as `cursor-agent`/`agent` while `cursor` is
     /// the IDE.
     pub bin_names: &'static [&'static str],
+    /// Identity check that keeps an ambiguous [`bin_names`](Self::bin_names)
+    /// entry from resolving to a different provider's colliding install alias —
+    /// Cursor's generic `agent` collides with the alias Grok's installer
+    /// symlinks onto `$PATH`. `None` when every `bin_names` entry is
+    /// provider-unique and a filename match settles identity.
+    pub bin_identity: Option<BinIdentity>,
     /// Well-known install directories, relative to `$HOME`, where this agent's
     /// binary lives when its installer has not put
     /// it on `$PATH` — OpenCode's installer drops `opencode` in `~/.opencode/bin`
@@ -972,6 +996,16 @@ impl AgentSpec {
         self.bin_names
             .iter()
             .any(|program| program_names_kind(name, program))
+    }
+
+    /// The identity check to run against a candidate located by `name`, when
+    /// `name` is one of this agent's ambiguous [`bin_names`](Self::bin_names).
+    /// `None` for a provider-unique name, which discovery accepts on filename
+    /// alone.
+    pub(crate) fn ambiguous_bin_identity(&self, name: &str) -> Option<&BinIdentity> {
+        self.bin_identity
+            .as_ref()
+            .filter(|identity| identity.ambiguous.contains(&name))
     }
 
     /// Whether a tool-use payload names a workspace-mutating tool. The tool

--- a/crates/rimz/src/agents/locate.rs
+++ b/crates/rimz/src/agents/locate.rs
@@ -5,7 +5,7 @@
 
 use std::path::{Path, PathBuf};
 
-use super::definition::AgentSpec;
+use super::definition::{AgentSpec, BinIdentity};
 use super::{AgentErr, Result, version};
 
 pub(crate) fn probe_descriptor_version(
@@ -28,11 +28,23 @@ fn probe_descriptor_version_with_locator(
 /// definition's [`extra_bin_dirs`](AgentSpec::extra_bin_dirs) joined under
 /// `$HOME`. An installer that drops its binary in a private dir (OpenCode's
 /// `~/.opencode/bin`) and edits a shell rc the running environment never sourced
-/// leaves the agent off `$PATH` yet present; this finds it. Returns the absolute
-/// path, or `None` when the binary is nowhere RimZ knows to look.
+/// leaves the agent off `$PATH` yet present; this finds it. A name another
+/// provider's installer also ships — Cursor's `agent` versus Grok's install
+/// alias — is confirmed by the definition's
+/// [`bin_identity`](AgentSpec::bin_identity) before it is accepted, so a
+/// colliding alias never resolves as this agent. Returns the absolute path, or
+/// `None` when the binary is nowhere RimZ knows to look.
 pub fn locate_binary(definition: &AgentSpec) -> Option<PathBuf> {
     for name in definition.bin_names {
-        if let Ok(path) = which::which(name) {
+        if let Some(identity) = definition.ambiguous_bin_identity(name) {
+            let matched = first_matching_identity(
+                which::which_all(name).ok().into_iter().flatten(),
+                identity,
+            );
+            if matched.is_some() {
+                return matched;
+            }
+        } else if let Ok(path) = which::which(name) {
             return Some(path);
         }
     }
@@ -40,14 +52,45 @@ pub fn locate_binary(definition: &AgentSpec) -> Option<PathBuf> {
     binary_in_install_dirs(definition, &home)
 }
 
+/// The first candidate whose `--version` proves it is this provider. `$PATH` can
+/// carry several binaries under an ambiguous name (Cursor's `agent` and Grok's
+/// alias both), so every match is probed in order rather than trusting the
+/// first-on-`$PATH` hit.
+fn first_matching_identity(
+    candidates: impl IntoIterator<Item = PathBuf>,
+    identity: &BinIdentity,
+) -> Option<PathBuf> {
+    candidates
+        .into_iter()
+        .find(|candidate| binary_has_identity(candidate, identity))
+}
+
+/// Confirm a candidate is genuinely this provider by running its `--version` and
+/// applying the adapter's identity check. A spawn failure, timeout, nonzero
+/// exit, or unrecognized banner reads as "not this provider", so a colliding
+/// alias is skipped rather than impersonating the agent.
+fn binary_has_identity(candidate: &Path, identity: &BinIdentity) -> bool {
+    version::probe_cli_version_with(candidate, |stdout, stderr| {
+        (identity.verify)(stdout, stderr).then(String::new)
+    })
+    .is_some()
+}
+
 /// The `$PATH`-miss branch of [`locate_binary`], split out so it tests without
 /// touching process env: the first existing `<home>/<dir>/<kind>` file across
-/// the definition's [`extra_bin_dirs`](AgentSpec::extra_bin_dirs).
+/// the definition's [`extra_bin_dirs`](AgentSpec::extra_bin_dirs). A candidate
+/// matched by an ambiguous name is identity-checked, mirroring the `$PATH` path.
 fn binary_in_install_dirs(definition: &AgentSpec, home: &Path) -> Option<PathBuf> {
     definition.extra_bin_dirs.iter().find_map(|dir| {
         definition.bin_names.iter().find_map(|name| {
             let candidate = home.join(dir).join(name);
-            candidate.is_file().then_some(candidate)
+            if !candidate.is_file() {
+                return None;
+            }
+            match definition.ambiguous_bin_identity(name) {
+                Some(identity) => binary_has_identity(&candidate, identity).then_some(candidate),
+                None => Some(candidate),
+            }
         })
     })
 }
@@ -136,5 +179,37 @@ mod tests {
         );
 
         assert_eq!(version.as_deref(), Some("selected:1.17.7"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ambiguous_name_resolves_by_provider_identity_not_first_on_path() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let make = |name: &str, banner: &str| {
+            let path = dir.path().join(name);
+            std::fs::write(&path, format!("#!/bin/sh\nprintf '{banner}\\n'\n")).unwrap();
+            let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&path, permissions).unwrap();
+            path
+        };
+        let grok_alias = make("grok-agent", "grok 0.2.106 (bde89716f6) [stable]");
+        let cursor_agent = make("cursor-agent-real", "2026.07.17-3e2a980");
+
+        let cursor = spec_by_kind("cursor").unwrap();
+        let identity = cursor
+            .ambiguous_bin_identity("agent")
+            .expect("cursor's `agent` name is ambiguous");
+
+        assert!(!binary_has_identity(&grok_alias, identity));
+        assert!(binary_has_identity(&cursor_agent, identity));
+        assert_eq!(
+            first_matching_identity([grok_alias.clone(), cursor_agent.clone()], identity),
+            Some(cursor_agent),
+        );
+        assert_eq!(first_matching_identity([grok_alias], identity), None);
+        assert!(cursor.ambiguous_bin_identity("cursor-agent").is_none());
     }
 }

--- a/crates/rimz/src/agents/registry.rs
+++ b/crates/rimz/src/agents/registry.rs
@@ -161,6 +161,7 @@ fn adapter_matches_program(
     let definition = adapter.spec();
     let label = crate::proc::command::basename(program.program);
     definition.launches_as(label)
+        || (!program.from_launcher && definition.runs_as(label))
         || (program.from_launcher
             && crate::proc::command::agent_script_path_names_kind(program.program, definition.kind))
 }
@@ -304,6 +305,8 @@ mod tests {
         );
         assert!(command_may_be_agent_kind("agent", "cursor"));
         assert!(!command_may_be_agent_kind("agent", "grok"));
+        assert!(command_may_be_agent_kind("kiro-cli-chat", "kiro"));
+        assert_eq!(command_agent_kind_candidate("kiro-cli-chat"), Some("kiro"));
     }
 
     #[test]

--- a/crates/rimz/src/agents/registry.rs
+++ b/crates/rimz/src/agents/registry.rs
@@ -115,19 +115,37 @@ pub(crate) fn command_agent_kind_with_comm(
         .then(|| adapter.spec().kind)
 }
 
+/// Whether `command` can be the requested agent kind after caller-owned durable
+/// identity already established that kind. This admits an ambiguous executable
+/// basename for liveness and provider-local enrichment; generic process
+/// classification continues through [`command_agent_kind`] and abstains.
+pub(crate) fn command_may_be_agent_kind(command: &str, kind: &str) -> bool {
+    let Some(adapter) = find_definition(kind) else {
+        return false;
+    };
+    let program = crate::proc::command::effective_program_info(command);
+    adapter_matches_program(adapter, program) && adapter.is_interactive_process(command)
+}
+
+/// Candidate kind for best-effort enrichment that cannot create agent truth.
+/// Provider-local discovery uses this to find inputs for a hook-bound session;
+/// pane presence and routing stay on [`command_agent_kind`].
+pub(crate) fn command_agent_kind_candidate(command: &str) -> Option<&'static str> {
+    let program = crate::proc::command::effective_program_info(command);
+    let adapter = all_definitions().find(|adapter| adapter_matches_program(adapter, program))?;
+    adapter
+        .is_interactive_process(command)
+        .then(|| adapter.spec().kind)
+}
+
 fn adapter_for_program(
     program: crate::proc::command::EffectiveProgram<'_>,
 ) -> Option<&'static AgentDefinition> {
     let label = crate::proc::command::basename(program.program);
     all_definitions()
         .find(|adapter| {
-            let definition = adapter.spec();
-            definition.launches_as(label)
-                || (program.from_launcher
-                    && crate::proc::command::agent_script_path_names_kind(
-                        program.program,
-                        definition.kind,
-                    ))
+            adapter.spec().ambiguous_bin_identity(label).is_none()
+                && adapter_matches_program(adapter, program)
         })
         .or_else(|| {
             (!program.from_launcher)
@@ -136,12 +154,26 @@ fn adapter_for_program(
         })
 }
 
+fn adapter_matches_program(
+    adapter: &AgentDefinition,
+    program: crate::proc::command::EffectiveProgram<'_>,
+) -> bool {
+    let definition = adapter.spec();
+    let label = crate::proc::command::basename(program.program);
+    definition.launches_as(label)
+        || (program.from_launcher
+            && crate::proc::command::agent_script_path_names_kind(program.program, definition.kind))
+}
+
 fn adapter_for_comm(comm: &str) -> Option<&'static AgentDefinition> {
     let comm = crate::proc::command::basename(comm.trim());
     if crate::proc::command::is_launcher(comm) {
         return None;
     }
-    let mut matches = all_definitions().filter(|adapter| adapter.spec().runs_as(comm));
+    let mut matches = all_definitions().filter(|adapter| {
+        let definition = adapter.spec();
+        definition.ambiguous_bin_identity(comm).is_none() && definition.runs_as(comm)
+    });
     let adapter = matches.next()?;
     matches.next().is_none().then_some(adapter)
 }
@@ -243,7 +275,9 @@ mod tests {
             ("claude", Some("claude")),
             ("agy", Some("antigravity")),
             ("antigravity", None),
-            ("agent", Some("cursor")),
+            // `agent` is provider-ambiguous. Binary discovery verifies Cursor's
+            // version banner; a process basename alone abstains.
+            ("agent", None),
             ("cursor-agent", Some("cursor")),
             ("kiro-cli-chat", Some("kiro")),
             ("kiro-cli-term", None),
@@ -268,6 +302,8 @@ mod tests {
             ),
             Some("qwen")
         );
+        assert!(command_may_be_agent_kind("agent", "cursor"));
+        assert!(!command_may_be_agent_kind("agent", "grok"));
     }
 
     #[test]

--- a/crates/rimz/src/proc/pane_probe.rs
+++ b/crates/rimz/src/proc/pane_probe.rs
@@ -292,7 +292,10 @@ fn hosted_agent_absent_under_root_with(
 }
 
 fn in_pane_agent_cmdline_matches(kind: &str, cmdline: &str) -> bool {
-    crate::agents::registry::command_agent_kind(cmdline) == Some(kind)
+    // The caller already owns provider identity from a durable session or hook.
+    // Admit a colliding native basename for liveness without exposing that
+    // candidate to generic pane classification.
+    crate::agents::registry::command_may_be_agent_kind(cmdline, kind)
 }
 
 fn in_pane_agent_probe_supported(kind: &str) -> bool {

--- a/crates/rimz/src/sidebar/agent_projection.rs
+++ b/crates/rimz/src/sidebar/agent_projection.rs
@@ -40,7 +40,7 @@ impl LocalSessionInputs {
     pub fn from_panes(panes: &[PaneRef]) -> Self {
         let mut by_kind = BTreeMap::<AgentKind, BTreeSet<PathBuf>>::new();
         for pane in panes {
-            let Some(kind) = crate::store::snapshot::pane_agent_kind(pane) else {
+            let Some(kind) = candidate_pane_agent_kind(pane) else {
                 continue;
             };
             let Some(adapter) = crate::agents::find_definition(kind) else {
@@ -105,6 +105,27 @@ impl LocalSessionInputs {
             })
             .collect()
     }
+}
+
+/// Candidate identity feeds only provider-local discovery. Its observations
+/// still require an exact durable or resume binding before they can affect a
+/// card, so admitting an ambiguous basename here preserves hook-bound Cursor
+/// enrichment without turning that basename into pane presence or routing.
+fn candidate_pane_agent_kind(pane: &PaneRef) -> Option<&'static str> {
+    pane.spawn_command
+        .as_deref()
+        .and_then(crate::agents::registry::command_agent_kind_candidate)
+        .or_else(|| {
+            pane.command
+                .as_deref()
+                .and_then(crate::agents::registry::command_agent_kind_candidate)
+        })
+        .or_else(|| {
+            pane.hosted_agent_kind
+                .as_ref()
+                .and_then(|kind| crate::agents::spec_by_kind(kind.as_str()))
+                .map(|definition| definition.kind)
+        })
 }
 
 fn normalize_observations(observations: &mut Vec<LocalSessionObservation>) {

--- a/crates/rimz/src/store/snapshot/view/live.rs
+++ b/crates/rimz/src/store/snapshot/view/live.rs
@@ -333,10 +333,26 @@ impl SidebarSnapshot {
 }
 
 fn local_pane_matches(pane: &PaneRef, observation: &LocalSessionObservation) -> bool {
-    crate::store::snapshot::process::pane_agent_kind(pane) == Some(observation.kind.as_str())
+    pane_may_host_kind(pane, observation.kind.as_str())
         && crate::store::snapshot::process::pane_worktree_path(pane).is_some_and(|workspace| {
             crate::worktree::normalize_path_lexical(Path::new(workspace)) == observation.workspace
         })
+}
+
+/// Provider-local observations cannot create a card without stronger binding
+/// evidence. Once that evidence names the kind, accept its native ambiguous
+/// executable for liveness while generic pane presence continues to abstain.
+fn pane_may_host_kind(pane: &PaneRef, kind: &str) -> bool {
+    pane.spawn_command
+        .as_deref()
+        .is_some_and(|command| crate::agents::registry::command_may_be_agent_kind(command, kind))
+        || pane.command.as_deref().is_some_and(|command| {
+            crate::agents::registry::command_may_be_agent_kind(command, kind)
+        })
+        || pane
+            .hosted_agent_kind
+            .as_ref()
+            .is_some_and(|hosted| hosted.as_str() == kind)
 }
 
 fn local_observation_is_current(agent: &AgentState, observation: &LocalSessionObservation) -> bool {

--- a/crates/rimz/tests/integration/hooks.rs
+++ b/crates/rimz/tests/integration/hooks.rs
@@ -834,7 +834,11 @@ fn cursor_user_hook_uses_project_dir_for_pinned_worktree_attribution() {
         "the verified pin routes the hook into the room store"
     );
 
-    let snapshot = env.snapshot_json_with_panes(&[tmux_pane("%0", "agent", &env.project_root)]);
+    // This hook fixture carries no TMUX_PANE stamp, so use Cursor's
+    // provider-unique alias for the lazy cwd bind. The generic `agent` basename
+    // deliberately requires native hook ownership before it can bind a pane.
+    let snapshot =
+        env.snapshot_json_with_panes(&[tmux_pane("%0", "cursor-agent", &env.project_root)]);
     let agent = snapshot["agents"]
         .as_array()
         .unwrap()
@@ -1134,7 +1138,8 @@ fn cursor_concurrent_subagents_fold_independently_without_context_sidecars() {
         "model_id": "parent-model",
     }));
 
-    let snapshot = env.snapshot_json_with_panes(&[tmux_pane("%0", "agent", &env.project_root)]);
+    let snapshot =
+        env.snapshot_json_with_panes(&[tmux_pane("%0", "cursor-agent", &env.project_root)]);
     let agents = snapshot["agents"].as_array().expect("agents");
     assert_eq!(agents.len(), 3, "one parent and two children: {agents:?}");
     for (id, task, model, branch, status, transcript) in [

--- a/docs/internals/agents/cursor.md
+++ b/docs/internals/agents/cursor.md
@@ -2,7 +2,7 @@
 
 > Read [model.md](./model.md) for the provider-neutral agent model and [adapter.md](./adapter.md) for the integration layer every adapter implements. Accounts, balances, and spend are in [providers.md](./providers.md); the raw upstream protocol is in [cursor-reference.md](../../externals/agent-adapter/cursor-reference.md).
 
-Cursor runs as `agent` or its `cursor-agent` alias; `cursor` names the IDE and is intentionally outside binary discovery. RimZ installs additive user hooks in `~/.cursor/hooks.json` and a managed command statusline in `~/.cursor/cli-config.json`, launches the resolved CLI path, and keys every session on `conversation_id`. User hooks run from `~/.cursor`, so ingress accepts a nonempty absolute `CURSOR_PROJECT_DIR` as the participant start path before the shared verified-pin and `WorkspaceResolver` flow; an absent, empty, or relative value falls back to `.`.
+Cursor runs as `agent` or its `cursor-agent` alias; `cursor` names the IDE and is intentionally outside binary discovery. RimZ installs additive user hooks in `~/.cursor/hooks.json` and a managed command statusline in `~/.cursor/cli-config.json`, launches a verified resolved path or the provider-unique `cursor-agent` alias, and keys every session on `conversation_id`. User hooks run from `~/.cursor`, so ingress accepts a nonempty absolute `CURSOR_PROJECT_DIR` as the participant start path before the shared verified-pin and `WorkspaceResolver` flow; an absent, empty, or relative value falls back to `.`.
 
 ## Hooks and lifecycle
 
@@ -53,7 +53,7 @@ RimZ maps Ask to Cursor's default launch, Plan to `--mode=plan`, Auto to `--auto
 
 Fresh and supervised launches remain ordinary interactive positional argv: the launcher opens the real interactive CLI in a pane and supplies the initial prompt after `--`, and does not pass `-p` or `--print`. Cursor's native headless `--print` transport is separate and outside the hook-driven coverage contract.
 
-The shared command classifier reads adapter `bin_names`, so both stock entrypoints (`agent` and `cursor-agent`) produce Cursor presence before the first session hook; this is the first built-in whose executable basename differs from its kind. The installed Linux binary reports `MainThread` as its kernel `comm`, so hook attribution continues to use the installer-stamped `$PPID` and durable pane/session stamps rather than treating that generic runtime label as Cursor identity.
+Binary discovery accepts `cursor-agent` by its provider-unique name and accepts `agent` only after its zero-padded date-build version banner proves Cursor identity. Basename-only command and process classification abstains on `agent`, so another provider's colliding alias never creates Cursor presence; a Cursor session launched under that name binds to its pane through the first native hook, and source-known liveness retains that binding afterward. The installed Linux binary reports `MainThread` as its kernel `comm`, so hook attribution continues to use the installer-stamped `$PPID` and durable pane/session stamps rather than treating that generic runtime label as Cursor identity.
 
 ## Context and transcript
 


### PR DESCRIPTION
## Summary

- verify Cursor's generic `agent` executable by its native version banner before discovery accepts it
- fall back to the provider-unique `cursor-agent` alias and keep ambiguous basenames out of generic pane attribution
- retain source-known liveness and local-session enrichment after a native Cursor hook establishes ownership

## Testing

- `cargo xtask gate`
