### PR TITLE
Refactor the live multiplexer test harness around registered clients

### DIFF
--- a/crates/rimz/tests/integration/backend/single_backend_room.rs
+++ b/crates/rimz/tests/integration/backend/single_backend_room.rs
@@ -4,15 +4,10 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::Duration;
 
 use rimz::workspace::WorkspaceResolver;
 
-use crate::common::{CommandTimeoutExt, Env, ScrubSessionEnvExt};
-
-// start/reset can hold the full 8s pre-attach topology ceiling; the default
-// 10s command bound leaves no headroom under suite load.
-const START_TIMEOUT: Duration = Duration::from_secs(30);
+use crate::common::{CommandTimeoutExt, Env, ROOM_WORKFLOW_TIMEOUT, ScrubSessionEnvExt};
 
 #[test]
 fn start_refuses_when_rival_backend_runs_room() {
@@ -23,7 +18,7 @@ fn start_refuses_when_rival_backend_runs_room() {
     let output = room
         .rimz()
         .args(["--mux", "zellij", "start"])
-        .bounded_output_within(START_TIMEOUT)
+        .bounded_output_within(ROOM_WORKFLOW_TIMEOUT)
         .expect("run rival zellij start");
 
     assert!(
@@ -56,7 +51,7 @@ fn attach_from_cwd_uses_live_backend_over_ambient_backend() {
         .rimz()
         .arg("attach")
         .env("ZELLIJ", "1")
-        .bounded_output_within(START_TIMEOUT)
+        .bounded_output_within(ROOM_WORKFLOW_TIMEOUT)
         .expect("run attach from cwd");
 
     assert!(
@@ -86,7 +81,7 @@ fn start_auto_attaches_to_live_zellij_room() {
     let output = room
         .rimz()
         .arg("start")
-        .bounded_output_within(START_TIMEOUT)
+        .bounded_output_within(ROOM_WORKFLOW_TIMEOUT)
         .expect("run auto start");
 
     assert!(
@@ -127,7 +122,7 @@ fn attach_purges_corrupt_zellij_resurrection_cache() {
     let output = room
         .rimz()
         .args(["attach", "--print"])
-        .bounded_output_within(START_TIMEOUT)
+        .bounded_output_within(ROOM_WORKFLOW_TIMEOUT)
         .expect("run printed attach");
 
     assert!(
@@ -156,7 +151,7 @@ fn reset_targets_live_backend_and_rebirths_on_default() {
     let output = room
         .rimz()
         .args(["reset", "--yes"])
-        .bounded_output_within(START_TIMEOUT)
+        .bounded_output_within(ROOM_WORKFLOW_TIMEOUT)
         .expect("run auto reset");
 
     assert!(
@@ -191,7 +186,7 @@ fn reset_explicit_rival_refuses_before_teardown() {
     let output = room
         .rimz()
         .args(["--mux", "tmux", "reset", "--yes"])
-        .bounded_output_within(START_TIMEOUT)
+        .bounded_output_within(ROOM_WORKFLOW_TIMEOUT)
         .expect("run rival reset");
 
     assert!(
@@ -245,7 +240,7 @@ impl TmuxRoom {
             let mut cmd = env.rimz();
             cmd.args(["--mux", "tmux", "start"])
                 .env("TMUX_TMPDIR", &tmux_tmpdir)
-                .bounded_output_within(START_TIMEOUT)
+                .bounded_output_within(ROOM_WORKFLOW_TIMEOUT)
                 .expect("run tmux start")
         };
         assert!(
@@ -320,7 +315,7 @@ impl ZellijRoom {
             pin_zellij_shared_env(&env, &mut cmd);
             cmd.args(["--mux", "zellij", "start"])
                 .env("TMUX_TMPDIR", &tmux_tmpdir)
-                .bounded_output_within(START_TIMEOUT)
+                .bounded_output_within(ROOM_WORKFLOW_TIMEOUT)
                 .expect("run zellij start")
         };
         assert!(
@@ -417,7 +412,13 @@ impl Drop for ZellijRoom {
             .zellij()
             .args(["delete-session", &self.session_name, "--force"])
             .bounded_output();
-        let _ = tmux_output(&self.env.runtime_root, &["kill-server"]);
+        let socket = rimz::mux::tmux::managed_server_socket_path_under(&self.env.runtime_root);
+        let _ = Command::new("tmux")
+            .scrub_session_env()
+            .arg("-S")
+            .arg(socket)
+            .arg("kill-server")
+            .bounded_output();
     }
 }
 
@@ -445,6 +446,6 @@ fn tmux_output(runtime_root: &Path, args: &[&str]) -> std::process::Output {
         .arg("-S")
         .arg(&socket)
         .args(args)
-        .output()
+        .bounded_output()
         .expect("spawn tmux")
 }

--- a/crates/rimz/tests/integration/backend/tmux/server_cwd.rs
+++ b/crates/rimz/tests/integration/backend/tmux/server_cwd.rs
@@ -89,7 +89,7 @@ fn birth_refuses_a_server_whose_own_directory_was_deleted() {
         .arg("-S")
         .arg(&socket)
         .args(["new-session", "-d", "-s", "squatter", "sleep 120"])
-        .status()
+        .bounded_status()
         .expect("spawn poisoned server");
     assert!(born.success(), "poisoned server should start");
     std::fs::remove_dir(&launch).expect("unlink launch dir");

--- a/crates/rimz/tests/integration/backend/tmux/support.rs
+++ b/crates/rimz/tests/integration/backend/tmux/support.rs
@@ -19,7 +19,9 @@ pub(super) use rimz::sidebar::{SidebarLaunchOutcome, launch_sidebar_if_needed, w
 pub(super) use rimz::workspace::WorkspaceResolver;
 pub(super) use tempfile::TempDir;
 
-pub(super) use crate::common::{Env, ScrubSessionEnvExt, write_failing_agent_shim};
+pub(super) use crate::common::{
+    CommandTimeoutExt, Env, ScrubSessionEnvExt, write_failing_agent_shim,
+};
 
 pub(super) fn tiled_column(panes: Vec<PaneCmd>) -> LayoutColumn {
     LayoutColumn {
@@ -215,7 +217,7 @@ impl TmuxServer {
             .arg("-S")
             .arg(&self.socket)
             .args(args)
-            .output()
+            .bounded_output()
             .unwrap_or_else(|err| panic!("spawn tmux {args:?}: {err}"));
         assert!(
             output.status.success(),
@@ -430,12 +432,12 @@ pub(super) fn wait_for_hook_docked_window_panes(
 
 impl Drop for TmuxServer {
     fn drop(&mut self) {
-        // `.output()` captures stderr so the "no server" message from
+        // Captured stderr keeps the "no server" message from
         // tests that never started a server doesn't leak into test logs.
         let _ = Command::new("tmux")
             .scrub_session_env()
             .args(["-S", self.socket.to_str().unwrap_or(""), "kill-server"])
-            .output();
+            .bounded_output();
     }
 }
 

--- a/crates/rimz/tests/integration/backend/zellij/daemon.rs
+++ b/crates/rimz/tests/integration/backend/zellij/daemon.rs
@@ -57,12 +57,12 @@ fn background_view_opts(session: &str, stub: &Path) -> rimz::mux::BackgroundView
 fn open_background_view_creates_named_tab_idempotently() {
     require_zellij!();
 
-    let name = unique_session_name("bgview");
-    let xdg = scoped_runtime_dir();
+    let room = LiveZellijSession::new("bgview");
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
-    create_plain_background_session(xdg.path(), &name, cwd.path(), "120");
-    let session = ZellijSession::attach_existing(xdg, &name);
-    let backend = ZellijBackend::with_runtime_dir(session.xdg.path());
+    room.create_plain_background(cwd.path(), "120");
+    let _client = AttachedClient::attach(&room, 80, 24);
+    let backend = ZellijBackend::with_runtime_dir(room.path());
     let (_stub_dir, stub) = sidebar_command_stub();
 
     let opts = background_view_opts(&name, &stub);
@@ -70,7 +70,7 @@ fn open_background_view_creates_named_tab_idempotently() {
     let first = backend.open_background_view(&opts).expect("first launch");
     assert_eq!(first, rimz::mux::BackgroundViewLaunch::Launched);
     assert!(
-        wait_for_tab_named(session.xdg.path(), &name, "rimzd"),
+        wait_for_tab_named(&room, "rimzd"),
         "expected a rimzd tab after launch",
     );
 
@@ -90,12 +90,9 @@ fn open_background_view_creates_named_tab_idempotently() {
 fn open_sidebar_with_a_daemon_leads_with_the_daemon_tab() {
     require_zellij!();
 
-    let xdg = scoped_runtime_dir();
-    let name = unique_session_name("bgfirst");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("bgfirst");
+    let xdg = room.path();
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
     let (_stub_dir, stub) = sidebar_command_stub();
 
@@ -114,7 +111,7 @@ fn open_sidebar_with_a_daemon_leads_with_the_daemon_tab() {
             cwd: cwd.path().to_path_buf(),
         },
     };
-    let backend = ZellijBackend::with_runtime_dir(xdg.path());
+    let backend = ZellijBackend::with_runtime_dir(xdg);
     let sidebar = SidebarPaneOptions {
         session_name: name.clone(),
         workspace_id: WorkspaceId::from_project_root(Path::new("/tmp/rimz-bgfirst")),
@@ -131,25 +128,25 @@ fn open_sidebar_with_a_daemon_leads_with_the_daemon_tab() {
         resume_tabs: Vec::new(),
         refresh_ms: None,
     };
-    publish_room_bin(xdg.path(), &sidebar);
+    publish_room_bin(xdg, &sidebar);
     backend
         .open_sidebar(&sidebar, Some(&daemon))
         .expect("open_sidebar with daemon");
 
     assert!(
-        wait_for_tab_named(xdg.path(), &name, "rimzd"),
+        wait_for_tab_named(&room, "rimzd"),
         "expected a rimzd tab after birth",
     );
     assert!(
-        wait_for_first_tab(xdg.path(), &name, "rimzd"),
+        wait_for_first_tab(&room, "rimzd"),
         "daemon tab must lead the session; saw {:?}",
-        tab_names_in_order(xdg.path(), &name),
+        tab_names_in_order(&room),
     );
-    wait_for_tab_count(xdg.path(), &name, 2);
+    wait_for_tab_count(xdg, &name, 2);
     // Two tabs: the daemon tab and the working tab born beside it.
     let tab_names = poll_until(
         Duration::from_secs(10),
-        || Ok(tab_names_in_order(xdg.path(), &name)),
+        || Ok(tab_names_in_order(&room)),
         |names| names.len() >= 2,
         "daemon and working tab names",
     );
@@ -158,7 +155,7 @@ fn open_sidebar_with_a_daemon_leads_with_the_daemon_tab() {
         2,
         "birth layout should produce exactly the daemon + working tabs: {tab_names:?}",
     );
-    let panes = wait_for_tab_pane_count(xdg.path(), &name, "rimzd", 4);
+    let panes = wait_for_tab_pane_count(xdg, &name, "rimzd", 4);
     assert_eq!(
         panes.len(),
         4,
@@ -167,9 +164,10 @@ fn open_sidebar_with_a_daemon_leads_with_the_daemon_tab() {
 }
 
 /// The session's tab names in tab order (`query-tab-names` prints one per line).
-fn tab_names_in_order(xdg: &Path, session: &str) -> Vec<String> {
-    let out = scoped_zellij(xdg)
-        .args(["--session", session, "action", "query-tab-names"])
+fn tab_names_in_order(session: &LiveZellijSession) -> Vec<String> {
+    let out = session
+        .command()
+        .args(["--session", session.name(), "action", "query-tab-names"])
         .bounded_output();
     out.ok()
         .filter(|out| out.status.success())
@@ -200,10 +198,10 @@ fn wait_for_tab_pane_count(xdg: &Path, session: &str, tab_name: &str, want: usiz
 }
 
 /// Poll until the session's first tab is `expected`, or time out.
-fn wait_for_first_tab(xdg: &Path, session: &str, expected: &str) -> bool {
+fn wait_for_first_tab(session: &LiveZellijSession, expected: &str) -> bool {
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
-        if tab_names_in_order(xdg, session).first().map(String::as_str) == Some(expected) {
+        if tab_names_in_order(session).first().map(String::as_str) == Some(expected) {
             return true;
         }
         if Instant::now() >= deadline {
@@ -214,11 +212,12 @@ fn wait_for_first_tab(xdg: &Path, session: &str, expected: &str) -> bool {
 }
 
 /// Poll `query-tab-names` until a tab named `tab_name` appears, or time out.
-fn wait_for_tab_named(xdg: &Path, session: &str, tab_name: &str) -> bool {
+fn wait_for_tab_named(session: &LiveZellijSession, tab_name: &str) -> bool {
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
-        let listed = scoped_zellij(xdg)
-            .args(["--session", session, "action", "query-tab-names"])
+        let listed = session
+            .command()
+            .args(["--session", session.name(), "action", "query-tab-names"])
             .bounded_output();
         if let Ok(out) = listed
             && out.status.success()

--- a/crates/rimz/tests/integration/backend/zellij/launch.rs
+++ b/crates/rimz/tests/integration/backend/zellij/launch.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::time::Duration;
 
-use rimz::ids::WorkspaceId;
+use rimz::ids::{MuxName, PaneId, WorkspaceId};
 use rimz::mux::{MuxBackend, SessionHealth, SidebarPaneOptions, SidebarWidth, ZellijBackend};
 use tempfile::TempDir;
 
@@ -15,13 +15,10 @@ use super::support::*;
 fn attach_command_keeps_terminal_mouse_reporting_enabled() {
     require_zellij!();
 
-    let xdg = scoped_runtime_dir();
-    let name = unique_session_name("mouse");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
-    let spec = ZellijBackend::with_runtime_dir(xdg.path())
+    let room = LiveZellijSession::new("mouse");
+    let xdg = room.path();
+    let name = room.name().to_owned();
+    let spec = ZellijBackend::with_runtime_dir(xdg)
         .attach_command(&name, &rimz::config::MultiplexerConfig::default());
     assert!(
         !spec
@@ -55,20 +52,16 @@ fn mouse_reporting_enabled(output: &[u8]) -> bool {
 fn open_sidebar_births_native_layout_and_template() {
     require_zellij!();
 
-    let xdg = scoped_runtime_dir();
-    std::fs::write(xdg.path().join(".zshrc"), "").expect("disable zsh first-run menu");
-    let name = unique_session_name("sidebar");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("sidebar");
+    let xdg = room.path();
+    std::fs::write(xdg.join(".zshrc"), "").expect("disable zsh first-run menu");
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
 
     let (_stub_dir, stub) = sidebar_stub_alive_for(600);
-    let backend = ZellijBackend::with_runtime_dir(xdg.path());
+    let backend = ZellijBackend::with_runtime_dir(xdg);
     let mut opts = sidebar_opts(&name, cwd.path(), stub, 120);
-    let runtime =
-        rimz::RuntimePaths::under(opts.workspace_id.clone(), xdg.path()).expect("runtime paths");
+    let runtime = rimz::RuntimePaths::under(opts.workspace_id.clone(), xdg).expect("runtime paths");
     runtime.ensure_dirs().expect("runtime dirs");
     let shim_dir = TempDir::new().expect("shim tempdir");
     let marker = cwd.path().join("copilot-env.txt");
@@ -97,17 +90,17 @@ fn open_sidebar_births_native_layout_and_template() {
             "false".to_owned(),
         ),
     ]);
-    publish_room_bin(xdg.path(), &opts);
+    publish_room_bin(xdg, &opts);
     backend.open_sidebar(&opts, None).expect("open_sidebar");
 
-    let panes = wait_for_pane_count(xdg.path(), &name, 2);
+    let panes = wait_for_pane_count(xdg, &name, 2);
     assert!(
         panes.len() >= 2,
         "layout should create a sidebar + terminal pane in {name}: {panes:?}",
     );
-    assert_sidebar_is_left_thirty_percent(xdg.path(), &name);
-    assert_session_has_bottom_bar(xdg.path(), &name);
-    assert_sidebars_not_held(xdg.path(), &name, "initial tab");
+    assert_sidebar_is_left_thirty_percent(xdg, &name);
+    assert_session_has_bottom_bar(xdg, &name);
+    assert_sidebars_not_held(xdg, &name, "initial tab");
 
     let work_pane = panes
         .iter()
@@ -115,22 +108,15 @@ fn open_sidebar_births_native_layout_and_template() {
         .expect("ordinary work shell")
         .pane_id
         .clone();
-    let initial_tab_id = expect_list_panes(xdg.path(), &name)
+    let initial_tab_id = expect_list_panes(xdg, &name)
         .panes
         .iter()
         .find(|pane| pane.pane_ref(&name).pane_id == work_pane)
         .map(|pane| pane.tab_id)
         .expect("initial work tab");
-    let mut client = AttachedClient::attach(xdg.path(), &name, 120, 40);
-    wait_for_focused_client_pane(&backend, &name, &work_pane);
-    let initial_work_id = work_pane.creation_ordinal().expect("initial work pane id");
-    assert_client_input_reaches_pane(
-        xdg.path(),
-        &name,
-        initial_work_id,
-        "birth work pane",
-        |line| client.send_line(line),
-    );
+    let mut client = AttachedClient::attach(&room, 120, 40);
+    client.wait_until_focused(&work_pane, "birth work pane");
+    client.assert_input_reaches(&work_pane, "birth work pane");
     backend
         .send_keys(&work_pane, copilot.to_string_lossy().as_ref())
         .expect("type direct copilot shim");
@@ -153,7 +139,7 @@ fn open_sidebar_births_native_layout_and_template() {
     );
     assert_eq!(marker_text, expected_marker, "direct copilot shim output",);
 
-    let template = new_tab_template_dump(xdg.path(), &name);
+    let template = new_tab_template_dump(xdg, &name);
     assert!(
         template.contains("rimz-sidebar"),
         "new tab template should carry the sidebar pane:\n{template}",
@@ -163,13 +149,13 @@ fn open_sidebar_births_native_layout_and_template() {
         "new tab template should carry an explicit focused right terminal:\n{template}",
     );
 
-    open_new_tab(xdg.path(), &name);
-    wait_for_tab_count(xdg.path(), &name, 2);
-    assert_sidebars_not_held(xdg.path(), &name, "new tab");
+    open_new_tab(xdg, &name);
+    wait_for_tab_count(xdg, &name, 2);
+    assert_sidebars_not_held(xdg, &name, "new tab");
 
-    let tabs = tab_ids(xdg.path(), &name);
+    let tabs = tab_ids(xdg, &name);
     for tab in &tabs {
-        let terminals = nonplugin_titles_in_tab(xdg.path(), &name, *tab);
+        let terminals = nonplugin_titles_in_tab(xdg, &name, *tab);
         let has_sidebar = terminals.iter().any(|t| t == "rimz-sidebar");
         let has_terminal = terminals.iter().any(|t| t != "rimz-sidebar");
         assert!(
@@ -181,28 +167,17 @@ fn open_sidebar_births_native_layout_and_template() {
         .into_iter()
         .find(|tab| *tab != initial_tab_id)
         .expect("new tab id");
-    let new_work = expect_list_panes(xdg.path(), &name)
+    let new_work = expect_list_panes(xdg, &name)
         .panes
         .iter()
         .find(|pane| pane.tab_id == new_tab_id && pane.is_live_terminal() && !pane.is_sidebar())
         .map(|pane| pane.id)
         .expect("new tab work pane");
-    focus_attached_client_pane_until(
-        xdg.path(),
-        &name,
-        new_work,
-        "new-tab template work pane",
-        || client.go_to_tab(2),
-    );
-    assert_client_input_reaches_pane(
-        xdg.path(),
-        &name,
-        new_work,
-        "new-tab template work pane",
-        |line| client.send_line(line),
-    );
+    let new_work = PaneId::from_parts(MuxName::Zellij, format!("terminal_{new_work}"));
+    client.go_to_tab_until(2, &new_work, "new-tab template work pane");
+    client.assert_input_reaches(&new_work, "new-tab template work pane");
 
-    wait_for_pane_count(xdg.path(), &name, 4);
+    wait_for_pane_count(xdg, &name, 4);
 }
 /// The pre-attach health gate: an absent room is born clean and RUNNING
 /// (`Reborn`), a probe of the resulting live room reports `Healthy`, and a second
@@ -212,12 +187,9 @@ fn open_sidebar_births_native_layout_and_template() {
 fn ensure_clean_session_births_running_then_is_idempotent() {
     require_zellij!();
 
-    let xdg = scoped_runtime_dir();
-    let name = unique_session_name("cleanroom");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("cleanroom");
+    let xdg = room.path();
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
     let (_stub_dir, stub) = sidebar_command_stub();
     let opts = SidebarPaneOptions {
@@ -236,8 +208,8 @@ fn ensure_clean_session_births_running_then_is_idempotent() {
         resume_tabs: Vec::new(),
         refresh_ms: None,
     };
-    let backend = ZellijBackend::with_runtime_dir(xdg.path());
-    publish_room_bin(xdg.path(), &opts);
+    let backend = ZellijBackend::with_runtime_dir(xdg);
+    publish_room_bin(xdg, &opts);
 
     // Absent → born clean and running.
     assert_eq!(
@@ -246,13 +218,13 @@ fn ensure_clean_session_births_running_then_is_idempotent() {
             .expect("ensure_clean_session births the absent room"),
         SessionHealth::Reborn,
     );
-    let born = wait_for_pane_count(xdg.path(), &name, 2);
+    let born = wait_for_pane_count(xdg, &name, 2);
     assert!(
         born.len() >= 2,
         "the gate should birth a sidebar + terminal pane: {born:?}",
     );
     // No pane is held at a "Waiting to run" prompt — the room came up running.
-    assert_sidebars_not_held(xdg.path(), &name, "reborn room");
+    assert_sidebars_not_held(xdg, &name, "reborn room");
 
     // A read-only probe of the now-live, clean room reports healthy.
     assert_eq!(
@@ -269,7 +241,7 @@ fn ensure_clean_session_births_running_then_is_idempotent() {
             .expect("ensure_clean_session on a clean live room"),
         SessionHealth::Healthy,
     );
-    let again = wait_for_pane_count(xdg.path(), &name, 2);
+    let again = wait_for_pane_count(xdg, &name, 2);
     assert_eq!(
         again.len(),
         born.len(),
@@ -288,18 +260,15 @@ fn ensure_clean_session_births_running_then_is_idempotent() {
 fn open_sidebar_heals_a_live_session_missing_its_sidebar() {
     require_zellij!();
 
-    let xdg = scoped_runtime_dir();
-    let name = unique_session_name("nosb");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("nosb");
+    let xdg = room.path();
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
 
     // Birth a live session with a plain, sidebar-less layout. The pane runs a
     // long sleep so the unattached background session stays alive deterministically.
-    create_plain_background_session(xdg.path(), &name, cwd.path(), "60");
-    let plain = wait_for_pane_count(xdg.path(), &name, 1);
+    room.create_plain_background(cwd.path(), "60");
+    let plain = wait_for_pane_count(xdg, &name, 1);
     assert!(
         !plain.is_empty(),
         "plain session should have a pane before open_sidebar: {plain:?}",
@@ -309,16 +278,16 @@ fn open_sidebar_heals_a_live_session_missing_its_sidebar() {
     // rebirth one that carries the sidebar.
     let (_stub_dir, stub) = sidebar_command_stub();
     let opts = sidebar_opts(&name, cwd.path(), stub, 120);
-    publish_room_bin(xdg.path(), &opts);
-    write_topology_cache_from_list_panes(xdg.path(), &opts.workspace_id, &name);
-    ZellijBackend::with_runtime_dir(xdg.path())
+    publish_room_bin(xdg, &opts);
+    write_topology_cache_from_list_panes(xdg, &opts.workspace_id, &name);
+    ZellijBackend::with_runtime_dir(xdg)
         .open_sidebar(&opts, None)
         .expect("open_sidebar");
 
-    let healed = wait_for_pane_count(xdg.path(), &name, 2);
+    let healed = wait_for_pane_count(xdg, &name, 2);
     assert!(
         healed.len() >= 2,
         "open_sidebar should rebirth a sidebar-less live session with a sidebar: {healed:?}",
     );
-    assert_sidebar_is_left_thirty_percent(xdg.path(), &name);
+    assert_sidebar_is_left_thirty_percent(xdg, &name);
 }

--- a/crates/rimz/tests/integration/backend/zellij/launch.rs
+++ b/crates/rimz/tests/integration/backend/zellij/launch.rs
@@ -122,7 +122,6 @@ fn open_sidebar_births_native_layout_and_template() {
         .map(|pane| pane.tab_id)
         .expect("initial work tab");
     let mut client = AttachedClient::attach(xdg.path(), &name, 120, 40);
-    wait_for_attached_client(xdg.path(), &name);
     wait_for_focused_client_pane(&backend, &name, &work_pane);
     let initial_work_id = work_pane.creation_ordinal().expect("initial work pane id");
     assert_client_input_reaches_pane(
@@ -188,10 +187,13 @@ fn open_sidebar_births_native_layout_and_template() {
         .find(|pane| pane.tab_id == new_tab_id && pane.is_live_terminal() && !pane.is_sidebar())
         .map(|pane| pane.id)
         .expect("new tab work pane");
-    client.go_to_tab(2);
-    let new_work_pane =
-        rimz::PaneId::from_parts(rimz::MuxName::Zellij, format!("terminal_{new_work}"));
-    wait_for_focused_client_pane(&backend, &name, &new_work_pane);
+    focus_attached_client_pane_until(
+        xdg.path(),
+        &name,
+        new_work,
+        "new-tab template work pane",
+        || client.go_to_tab(2),
+    );
     assert_client_input_reaches_pane(
         xdg.path(),
         &name,

--- a/crates/rimz/tests/integration/backend/zellij/pane_io.rs
+++ b/crates/rimz/tests/integration/backend/zellij/pane_io.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::os::unix::fs::PermissionsExt;
 use std::time::{Duration, Instant};
 
+use rimz::ids::{MuxName, PaneId};
 use rimz::mux::{
     BRACKET_PASTE_CLOSE, BRACKET_PASTE_OPEN, MuxBackend, NamedKey, PaneListOptions,
     PaneReadConsistency, SplitPaneOptions, SplitPlacement, SplitTarget, ZellijBackend,
@@ -16,34 +17,30 @@ use super::support::*;
 fn sidebar_focus_command_targets_session_from_outside_room() {
     require_zellij!();
 
-    let xdg = scoped_runtime_dir();
-    let name = unique_session_name("focuscmd");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("focuscmd");
+    let xdg = room.path();
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
     let (_stub_dir, stub) = sidebar_command_stub();
-    let backend = ZellijBackend::with_runtime_dir(xdg.path());
+    let backend = ZellijBackend::with_runtime_dir(xdg);
     let opts = sidebar_opts(&name, cwd.path(), stub, 200);
-    publish_room_bin(xdg.path(), &opts);
+    publish_room_bin(xdg, &opts);
     backend.open_sidebar(&opts, None).expect("open_sidebar");
-    wait_for_pane_count(xdg.path(), &name, 2);
+    wait_for_pane_count(xdg, &name, 2);
 
-    let sidebar = raw_sidebar_pane(xdg.path(), &name);
+    let sidebar = raw_sidebar_pane(xdg, &name);
     let sidebar_id = sidebar.id;
     let tab_id = sidebar.tab_id;
-    let work_id = expect_list_panes(xdg.path(), &name)
+    let work_id = expect_list_panes(xdg, &name)
         .panes
         .iter()
         .find(|pane| !pane.is_plugin && pane.tab_id == tab_id && !pane.is_sidebar())
         .map(|pane| pane.id)
         .expect("work pane id");
 
-    let mut client = AttachedClient::attach(xdg.path(), &name, 200, 50);
-    focus_attached_client_pane_until(xdg.path(), &name, work_id, "fixture work pane", || {
-        client.press_alt('l')
-    });
+    let mut client = AttachedClient::attach(&room, 200, 50);
+    let work_pane = PaneId::from_parts(MuxName::Zellij, format!("terminal_{work_id}"));
+    client.press_alt_until('l', &work_pane, "fixture work pane");
 
     let env = Env::new();
     let workspace_root = std::path::PathBuf::from(format!("/tmp/rimz-{name}"));
@@ -53,7 +50,7 @@ fn sidebar_focus_command_targets_session_from_outside_room() {
         &workspace_root,
         &name,
     );
-    write_topology_cache_from_list_panes(xdg.path(), &opts.workspace_id, &name);
+    write_topology_cache_from_list_panes(xdg, &opts.workspace_id, &name);
     let trace = TempDir::new().expect("zellij trace tempdir");
     let trace_log = trace.path().join("zellij.log");
     let shim = trace.path().join("zellij");
@@ -71,9 +68,9 @@ fn sidebar_focus_command_targets_session_from_outside_room() {
         .expect("chmod zellij trace shim");
     let output = env
         .rimz()
-        .env("XDG_RUNTIME_DIR", xdg.path())
-        .env("XDG_CACHE_HOME", xdg.path())
-        .env("TMPDIR", xdg.path())
+        .env("XDG_RUNTIME_DIR", xdg)
+        .env("XDG_CACHE_HOME", xdg)
+        .env("TMPDIR", xdg)
         .env("RIMZ_ZELLIJ_BIN", &shim)
         .args([
             "--mux",
@@ -104,18 +101,15 @@ fn sidebar_focus_command_targets_session_from_outside_room() {
 fn split_pane_injects_env_vars() {
     require_zellij!();
 
-    let xdg = scoped_runtime_dir();
-    let name = unique_session_name("splitenv");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("splitenv");
+    let xdg = room.path();
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
     let marker_file = cwd.path().join("rimz-env-marker");
 
     // Birth a live background session with one long-lived pane to split from.
-    create_plain_background_session(xdg.path(), &name, cwd.path(), "60");
-    let target = wait_for_pane_count(xdg.path(), &name, 1)[0].pane_id.clone();
+    room.create_plain_background(cwd.path(), "60");
+    let target = wait_for_pane_count(xdg, &name, 1)[0].pane_id.clone();
     assert!(
         !target.raw().is_empty(),
         "session should have its working pane before the split",
@@ -123,7 +117,7 @@ fn split_pane_injects_env_vars() {
 
     let mut env = BTreeMap::new();
     env.insert("RIMZ_TEST_VAR".to_owned(), "marker-rimz-env".to_owned());
-    ZellijBackend::with_runtime_dir(xdg.path())
+    ZellijBackend::with_runtime_dir(xdg)
         .split_pane(SplitPaneOptions {
             target: SplitTarget::SessionPane {
                 session_name: name.clone(),
@@ -163,7 +157,7 @@ fn split_pane_injects_env_vars() {
         marker, "marker-rimz-env",
         "Zellij split pane missed the injected RIMZ_TEST_VAR",
     );
-    ZellijBackend::with_runtime_dir(xdg.path())
+    ZellijBackend::with_runtime_dir(xdg)
         .capture_pane(&target, Some(1), true)
         .expect("capture split target with scrollback and ANSI");
 }
@@ -172,18 +166,15 @@ fn split_pane_injects_env_vars() {
 fn split_pane_targets_non_focused_tab_without_moving_client_focus() {
     require_zellij!();
 
-    let xdg = scoped_runtime_dir();
-    let name = unique_session_name("splittarget");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("splittarget");
+    let xdg = room.path();
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
-    create_plain_background_session(xdg.path(), &name, cwd.path(), "60");
-    let mut client = AttachedClient::attach(xdg.path(), &name, 120, 40);
-    let backend = ZellijBackend::with_runtime_dir(xdg.path());
-    let first = wait_for_pane_count(xdg.path(), &name, 1)[0].clone();
-    scoped_zellij(xdg.path())
+    room.create_plain_background(cwd.path(), "60");
+    let mut client = AttachedClient::attach(&room, 120, 40);
+    let backend = ZellijBackend::with_runtime_dir(xdg);
+    let first = wait_for_pane_count(xdg, &name, 1)[0].clone();
+    room.command()
         .args([
             "--session",
             &name,
@@ -197,32 +188,27 @@ fn split_pane_targets_non_focused_tab_without_moving_client_focus() {
         ])
         .bounded_output()
         .expect("second target pane");
-    let target = wait_for_pane_count(xdg.path(), &name, 2)
+    let target = wait_for_pane_count(xdg, &name, 2)
         .into_iter()
         .find(|pane| pane.pane_id != first.pane_id)
         .expect("second target pane");
-    ZellijBackend::with_runtime_dir(xdg.path())
+    ZellijBackend::with_runtime_dir(xdg)
         .focus_pane(&first.pane_id, Some(&name))
         .expect("focus first pane");
-    open_new_tab(xdg.path(), &name);
-    wait_for_tab_count(xdg.path(), &name, 2);
-    let active_tab_pane = wait_for_pane_count(xdg.path(), &name, 3)
+    open_new_tab(xdg, &name);
+    wait_for_tab_count(xdg, &name, 2);
+    let active_tab_pane = wait_for_pane_count(xdg, &name, 3)
         .into_iter()
         .find(|pane| pane.pane_id != first.pane_id && pane.pane_id != target.pane_id)
         .expect("new tab pane");
+    client.go_to_tab_until(2, &active_tab_pane.pane_id, "new tab pane");
     let active_tab_pane_id = active_tab_pane
         .pane_id
         .creation_ordinal()
-        .expect("numeric new tab pane id");
-    focus_attached_client_pane_until(
-        xdg.path(),
-        &name,
-        active_tab_pane_id,
-        "new tab pane",
-        || client.go_to_tab(2),
-    );
-    let active_tab_pane_id = active_tab_pane_id.to_string();
-    let moved = scoped_zellij(xdg.path())
+        .expect("numeric new tab pane id")
+        .to_string();
+    let moved = room
+        .command()
         .env("ZELLIJ_PANE_ID", active_tab_pane_id)
         .args(["--session", &name, "action", "move-tab", "left"])
         .bounded_output()
@@ -234,7 +220,7 @@ fn split_pane_targets_non_focused_tab_without_moving_client_focus() {
     );
     let target = poll_until(
         Duration::from_secs(10),
-        || Ok(expect_list_panes(xdg.path(), &name).pane_refs()),
+        || Ok(expect_list_panes(xdg, &name).pane_refs()),
         |panes| {
             panes
                 .iter()
@@ -256,7 +242,7 @@ fn split_pane_targets_non_focused_tab_without_moving_client_focus() {
     assert!(authoritative.panes.iter().any(|pane| {
         pane.pane_id == target.pane_id && pane.view_id.as_deref() == Some(first_tab.as_str())
     }));
-    let focused_before = wait_for_client_view_count(xdg.path(), &name, 1);
+    let focused_before = wait_for_human_client_count(&backend, &name, 1).viewed_panes;
     assert_eq!(
         focused_before.len(),
         1,
@@ -285,7 +271,7 @@ fn split_pane_targets_non_focused_tab_without_moving_client_focus() {
 
     let panes = poll_until(
         Duration::from_secs(10),
-        || Ok(expect_list_panes(xdg.path(), &name).pane_refs()),
+        || Ok(expect_list_panes(xdg, &name).pane_refs()),
         |panes| {
             panes
                 .iter()
@@ -303,7 +289,7 @@ fn split_pane_targets_non_focused_tab_without_moving_client_focus() {
         3,
         "targeted split should land beside the target pane, not in the focused tab: {panes:?}",
     );
-    let snapshot = expect_list_panes(xdg.path(), &name);
+    let snapshot = expect_list_panes(xdg, &name);
     let target_id = target
         .pane_id
         .creation_ordinal()
@@ -324,7 +310,8 @@ fn split_pane_targets_non_focused_tab_without_moving_client_focus() {
         "stacked split should use the requested pane's column: {:?}",
         snapshot.panes,
     );
-    let focused_after = wait_for_focused_client_pane(&backend, &name, &focused_before[0]);
+    let focused_after =
+        client.wait_until_focused(&focused_before[0], "client focus after background split");
     assert_eq!(
         focused_after, focused_before,
         "targeting a background stack must not switch the attached client's tab",
@@ -339,12 +326,13 @@ fn split_pane_targets_non_focused_tab_without_moving_client_focus() {
 fn paste_text_delivers_the_literal_payload() {
     require_zellij!();
 
-    let xdg = scoped_runtime_dir();
-    std::fs::write(xdg.path().join(".zshrc"), "# hermetic test shell\n")
+    let room = LiveZellijSession::new("paste");
+    let xdg = room.path();
+    std::fs::write(xdg.join(".zshrc"), "# hermetic test shell\n")
         .expect("write test shell profile");
-    let session = ZellijSession::attach_pty(xdg, unique_session_name("paste"), true);
-    let backend = ZellijBackend::with_runtime_dir(session.xdg.path());
-    let panes = wait_for_pane_count(session.xdg.path(), &session.name, 1);
+    let _client = AttachedClient::create_and_attach(&room, 80, 24);
+    let backend = ZellijBackend::with_runtime_dir(xdg);
+    let panes = wait_for_pane_count(xdg, room.name(), 1);
     let pane_id = panes[0].pane_id.clone();
     let marker_dir = TempDir::new().expect("paste marker tempdir");
     let shell_ready = marker_dir.path().join("shell-ready");
@@ -415,9 +403,10 @@ fn paste_text_delivers_the_literal_payload() {
 fn semantic_answer_keys_reach_a_live_pane() {
     require_zellij!();
 
-    let session = ZellijSession::spawn(unique_session_name("answerkeys"));
-    let backend = ZellijBackend::with_runtime_dir(session.xdg.path());
-    let panes = wait_for_pane_count(session.xdg.path(), &session.name, 1);
+    let room = LiveZellijSession::new("answerkeys");
+    let _client = AttachedClient::create_and_attach(&room, 80, 24);
+    let backend = ZellijBackend::with_runtime_dir(room.path());
+    let panes = wait_for_pane_count(room.path(), room.name(), 1);
     let pane_id = panes[0].pane_id.clone();
     let marker_dir = TempDir::new().expect("marker dir");
     let key_bytes = marker_dir.path().join("named-key-bytes");
@@ -457,25 +446,13 @@ fn semantic_answer_keys_reach_a_live_pane() {
 fn client_view_tracks_the_attached_client() {
     require_zellij!();
 
-    let xdg = scoped_runtime_dir();
-    let name = unique_session_name("focus");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("focus");
+    let xdg = room.path();
+    let name = room.name().to_owned();
 
     // Birth a background session: it exists and answers actions, but has no
     // attached client yet.
-    let created = scoped_zellij(xdg.path())
-        .args(["attach", "--create-background", &name])
-        .bounded_output()
-        .expect("attach --create-background");
-    assert!(
-        created.status.success(),
-        "create-background failed: {}",
-        String::from_utf8_lossy(&created.stderr),
-    );
-    wait_until_session_ready(xdg.path(), &name);
+    room.create_background();
 
     // `--create-background` births the session without attaching, but the
     // bootstrap client that created it can still surface in `list-clients` for a
@@ -483,24 +460,24 @@ fn client_view_tracks_the_attached_client() {
     // roster drains, then assert the steady state: a background session with no
     // client focuses nothing. A real regression (a detached session that keeps a
     // focused client) never drains and still fails here.
-    let detached = wait_for_client_view_count(xdg.path(), &name, 0);
+    let detached = wait_for_human_client_count(room.backend(), &name, 0);
     assert!(
-        detached.is_empty(),
+        detached.viewed_panes.is_empty(),
         "a background session with no client focuses nothing: {detached:?}",
     );
 
-    // Attach a client; its focused terminal pane is now reported.
-    let _client = AttachedClient::attach(xdg.path(), &name, 200, 50);
-    let focused = wait_for_client_view_count(xdg.path(), &name, 1);
-    let pane_id = wait_for_pane_count(xdg.path(), &name, 1)[0].pane_id.clone();
+    // Construction guarantees registration, so one immediate read is enough.
+    let client = AttachedClient::attach(&room, 200, 50);
+    let focused = client.view();
+    let pane_id = wait_for_pane_count(xdg, &name, 1)[0].pane_id.clone();
 
     assert_eq!(
-        focused.len(),
-        1,
-        "one attached client focuses one pane: {focused:?}",
+        focused.presence.human_clients, 1,
+        "one attached human client should be registered: {focused:?}",
     );
     assert_eq!(
-        focused[0], pane_id,
+        focused.viewed_panes,
+        vec![pane_id],
         "the attached client focuses the session's lone terminal pane: {focused:?}",
     );
 }

--- a/crates/rimz/tests/integration/backend/zellij/pane_io.rs
+++ b/crates/rimz/tests/integration/backend/zellij/pane_io.rs
@@ -41,7 +41,6 @@ fn sidebar_focus_command_targets_session_from_outside_room() {
         .expect("work pane id");
 
     let mut client = AttachedClient::attach(xdg.path(), &name, 200, 50);
-    wait_for_attached_client(xdg.path(), &name);
     focus_attached_client_pane_until(xdg.path(), &name, work_id, "fixture work pane", || {
         client.press_alt('l')
     });
@@ -181,8 +180,8 @@ fn split_pane_targets_non_focused_tab_without_moving_client_focus() {
     };
     let cwd = TempDir::new().expect("cwd tempdir");
     create_plain_background_session(xdg.path(), &name, cwd.path(), "60");
-    let _client = AttachedClient::attach(xdg.path(), &name, 120, 40);
-    wait_for_attached_client(xdg.path(), &name);
+    let mut client = AttachedClient::attach(xdg.path(), &name, 120, 40);
+    let backend = ZellijBackend::with_runtime_dir(xdg.path());
     let first = wait_for_pane_count(xdg.path(), &name, 1)[0].clone();
     scoped_zellij(xdg.path())
         .args([
@@ -211,13 +210,18 @@ fn split_pane_targets_non_focused_tab_without_moving_client_focus() {
         .into_iter()
         .find(|pane| pane.pane_id != first.pane_id && pane.pane_id != target.pane_id)
         .expect("new tab pane");
-    let backend = ZellijBackend::with_runtime_dir(xdg.path());
-    wait_for_focused_client_pane(&backend, &name, &active_tab_pane.pane_id);
     let active_tab_pane_id = active_tab_pane
         .pane_id
         .creation_ordinal()
-        .expect("numeric new tab pane id")
-        .to_string();
+        .expect("numeric new tab pane id");
+    focus_attached_client_pane_until(
+        xdg.path(),
+        &name,
+        active_tab_pane_id,
+        "new tab pane",
+        || client.go_to_tab(2),
+    );
+    let active_tab_pane_id = active_tab_pane_id.to_string();
     let moved = scoped_zellij(xdg.path())
         .env("ZELLIJ_PANE_ID", active_tab_pane_id)
         .args(["--session", &name, "action", "move-tab", "left"])

--- a/crates/rimz/tests/integration/backend/zellij/presence.rs
+++ b/crates/rimz/tests/integration/backend/zellij/presence.rs
@@ -480,7 +480,6 @@ fn presence_identity_transition_keeps_global_background_updates() {
         xdg: xdg.path().to_path_buf(),
     };
     let mut client = AttachedClient::attach(xdg.path(), &name, 160, 45);
-    wait_for_attached_client(xdg.path(), &name);
 
     let backend = ZellijBackend::with_runtime_dir(xdg.path());
     let workspace_id = WorkspaceId::parse("ws_0123456789abcdef01234567").expect("fixed id");
@@ -696,7 +695,6 @@ fn tab_switch_repairs_sidebar_focus_from_attached_client_views() {
     wait_for_pane_count(xdg.path(), &name, 2);
 
     let mut client = AttachedClient::attach(xdg.path(), &name, 160, 45);
-    wait_for_attached_client(xdg.path(), &name);
     let birth_sidebar = raw_sidebar_pane(xdg.path(), &name);
     let birth_work = expect_list_panes(xdg.path(), &name)
         .panes

--- a/crates/rimz/tests/integration/backend/zellij/presence.rs
+++ b/crates/rimz/tests/integration/backend/zellij/presence.rs
@@ -6,6 +6,8 @@ use rimz::ids::{MuxName, PaneId, WorkspaceId};
 use rimz::mux::{LayoutPanes, MuxBackend, PaneCmd, TabOptions, ZellijBackend, zellij};
 use tempfile::TempDir;
 
+use crate::common::{CommandTimeoutExt, ZellijNamespace};
+
 use super::support::*;
 
 /// The presence-plugin wasm `cargo xtask build-plugin` produces, honoring
@@ -186,46 +188,6 @@ fn wait_for_focus_action(
     }
 }
 
-/// Leave the tab with its sidebar focused — the strand the next switch back has
-/// to repair. Presses the focus-left chord until the attached client's view is
-/// the sidebar alone and holds there, so the tab is provably stranded before the
-/// test switches away; a bare keypress plus a sleep leaves the precondition to
-/// chance and turns any miss into an unexplained repair timeout later.
-fn strand_sidebar_focus(
-    backend: &ZellijBackend,
-    client: &mut AttachedClient,
-    session: &str,
-    sidebar: &PaneId,
-) {
-    let deadline = Instant::now() + Duration::from_secs(10);
-    let mut holds = 0;
-    let mut last = String::new();
-    loop {
-        match client_viewed_panes(backend, session) {
-            Ok(viewed) if viewed == [sidebar.clone()] => {
-                holds += 1;
-                if holds == 3 {
-                    return;
-                }
-            }
-            Ok(viewed) => {
-                last = format!("{viewed:?}");
-                holds = 0;
-                client.press_alt('h');
-            }
-            Err(err) => {
-                last = err;
-                holds = 0;
-            }
-        }
-        assert!(
-            Instant::now() < deadline,
-            "client focus never settled on the sidebar {sidebar} in {session}; last view: {last}",
-        );
-        std::thread::sleep(Duration::from_millis(100));
-    }
-}
-
 fn accepted_focus_repairs(xdg: &Path, target_pane: &PaneId) -> usize {
     rimz::diag::focus_repair::recent(xdg)
         .iter()
@@ -328,23 +290,24 @@ fn presence_plugin_loads_pokes_and_converges_on_a_live_session() {
 
     // Seed the grant before the server is born so its permission cache read —
     // whenever it happens — sees it. Grants key on the wasm's absolute path.
-    let xdg = scoped_runtime_dir();
-    seed_presence_permissions(xdg.path(), &wasm);
+    let namespace = ZellijNamespace::new();
+    seed_presence_permissions(namespace.path(), &wasm);
 
     // A `rimz` stand-in that logs its argv: the poke's whole host surface.
-    let poke_log = xdg.path().join("poke.log");
-    let focus_exec_log = xdg.path().join("focus-exec.log");
+    let poke_log = namespace.path().join("poke.log");
+    let focus_exec_log = namespace.path().join("focus-exec.log");
     let real_rimz = crate::common::cargo_bin("rimz", env!("CARGO_BIN_EXE_rimz"));
-    let rimz_shim = write_poke_shim(xdg.path(), &poke_log, &real_rimz, &focus_exec_log);
+    let rimz_shim = write_poke_shim(namespace.path(), &poke_log, &real_rimz, &focus_exec_log);
 
     // Born on the pre-seeded dir with a PTY client attached: application
     // state flows only while a client is connected, and the cached grant is
     // proven to the plugin by exactly that flow (Zellij sends no explicit
     // permission result for a cached grant).
     let name = unique_session_name("presence");
-    let session = ZellijSession::attach_pty(xdg, name.clone(), true);
+    let room = LiveZellijSession::from_namespace(namespace, name.clone());
+    let _client = AttachedClient::create_and_attach(&room, 80, 24);
 
-    let backend = ZellijBackend::with_runtime_dir(session.xdg.path());
+    let backend = ZellijBackend::with_runtime_dir(room.path());
     let workspace_id = WorkspaceId::parse("ws_0123456789abcdef01234567").expect("fixed id");
     let mut opts = rimz::mux::PresencePluginOptions {
         session_name: name.clone(),
@@ -398,7 +361,7 @@ fn presence_plugin_loads_pokes_and_converges_on_a_live_session() {
         "the first poke carries the Zellij version: {:?}",
         lines[0],
     );
-    let runtime = rimz::store::RuntimePaths::under(workspace_id, session.xdg.path())
+    let runtime = rimz::store::RuntimePaths::under(workspace_id, room.path())
         .expect("presence runtime paths");
     let deadline = Instant::now() + SPAWN_TIMEOUT;
     let writer = loop {
@@ -424,8 +387,8 @@ fn presence_plugin_loads_pokes_and_converges_on_a_live_session() {
             .is_some_and(|hash| !hash.is_empty())
     );
 
-    let plugins_before = presence_plugin_panes(session.xdg.path(), &name)
-        .expect("presence plugin roster before converge");
+    let plugins_before =
+        presence_plugin_panes(room.path(), &name).expect("presence plugin roster before converge");
     assert_eq!(plugins_before.len(), 1);
 
     // Production reaches this path only for an identity change. The same-
@@ -443,8 +406,8 @@ fn presence_plugin_loads_pokes_and_converges_on_a_live_session() {
             .any(|line| line.contains("--reason alive")),
         "a converged plugin republishes topology; got {lines:?}",
     );
-    let plugins_after = presence_plugin_panes(session.xdg.path(), &name)
-        .expect("presence plugin roster after converge");
+    let plugins_after =
+        presence_plugin_panes(room.path(), &name).expect("presence plugin roster after converge");
     assert_eq!(plugins_after.len(), 1);
     let current_writer = rimz::sidebar::cache::read_pane_topology_cache(&runtime, &name)
         .and_then(|cache| cache.writer)
@@ -470,18 +433,15 @@ fn presence_identity_transition_keeps_global_background_updates() {
         }
     }
 
-    let xdg = scoped_runtime_dir();
-    seed_presence_permissions(xdg.path(), &wasm);
+    let room = LiveZellijSession::new("presence-upgrade");
+    let xdg = room.path();
+    seed_presence_permissions(xdg, &wasm);
     let cwd = TempDir::new().expect("session cwd tempdir");
-    let name = unique_session_name("presence-upgrade");
-    create_plain_background_session(xdg.path(), &name, cwd.path(), "600");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
-    let mut client = AttachedClient::attach(xdg.path(), &name, 160, 45);
+    let name = room.name().to_owned();
+    room.create_plain_background(cwd.path(), "600");
+    let mut client = AttachedClient::attach(&room, 160, 45);
 
-    let backend = ZellijBackend::with_runtime_dir(xdg.path());
+    let backend = ZellijBackend::with_runtime_dir(xdg);
     let workspace_id = WorkspaceId::parse("ws_0123456789abcdef01234567").expect("fixed id");
     let mut opts = rimz::mux::PresencePluginOptions {
         session_name: name.clone(),
@@ -497,7 +457,7 @@ fn presence_identity_transition_keeps_global_background_updates() {
         .ensure_presence_plugin(&opts)
         .expect("load initial presence identity");
     let runtime =
-        rimz::store::RuntimePaths::under(workspace_id, xdg.path()).expect("presence runtime paths");
+        rimz::store::RuntimePaths::under(workspace_id, xdg).expect("presence runtime paths");
     let initial_cache = poll_until(
         SPAWN_TIMEOUT,
         || {
@@ -516,8 +476,8 @@ fn presence_identity_transition_keeps_global_background_updates() {
     .expect("initial topology cache");
     let initial_writer = initial_cache.writer.expect("initial writer");
 
-    open_new_tab(xdg.path(), &name);
-    let snapshot = expect_list_panes(xdg.path(), &name);
+    open_new_tab(xdg, &name);
+    let snapshot = expect_list_panes(xdg, &name);
     let mut tab_work = snapshot
         .panes
         .iter()
@@ -529,10 +489,9 @@ fn presence_identity_transition_keeps_global_background_updates() {
     assert_eq!(tab_work.len(), 2, "expected one work pane in each tab");
     let (_, _, first_work) = tab_work[0];
     let (_, second_tab_id, second_work) = tab_work[1];
-    client.go_to_tab(1);
-    focus_attached_client_pane_until(xdg.path(), &name, first_work, "first tab", || {
-        client.go_to_tab(1);
-    });
+    let first_work = PaneId::from_parts(MuxName::Zellij, format!("terminal_{first_work}"));
+    let second_work_pane = PaneId::from_parts(MuxName::Zellij, format!("terminal_{second_work}"));
+    client.go_to_tab_until(1, &first_work, "first tab");
 
     // A configuration change is the same Zellij identity transition as a wasm
     // upgrade. Converge while tab one owns the attached client's focus.
@@ -563,7 +522,7 @@ fn presence_identity_transition_keeps_global_background_updates() {
 
     let plugins = poll_until(
         SPAWN_TIMEOUT,
-        || presence_plugin_panes(xdg.path(), &name),
+        || presence_plugin_panes(xdg, &name),
         |plugins| plugins.len() == 1,
         "one presence plugin after identity convergence",
     );
@@ -576,18 +535,15 @@ fn presence_identity_transition_keeps_global_background_updates() {
     // Move away from the tab active during convergence, then create and focus
     // a pane. A tab-scoped writer starves here; a background writer publishes
     // both the new topology and the attached client's selection.
-    client.go_to_tab(2);
-    focus_attached_client_pane_until(xdg.path(), &name, second_work, "second tab", || {
-        client.go_to_tab(2);
-    });
-    let before_ids = expect_list_panes(xdg.path(), &name)
+    client.go_to_tab_until(2, &second_work_pane, "second tab");
+    let before_ids = expect_list_panes(xdg, &name)
         .panes
         .into_iter()
         .filter(|pane| pane.is_live_terminal())
         .map(|pane| pane.id)
         .collect::<BTreeSet<_>>();
-    spawn_sleep_pane(xdg.path(), &name, cwd.path());
-    let fresh = expect_list_panes(xdg.path(), &name)
+    spawn_sleep_pane(xdg, &name, cwd.path());
+    let fresh = expect_list_panes(xdg, &name)
         .panes
         .into_iter()
         .find(|pane| {
@@ -643,16 +599,13 @@ fn tab_switch_repairs_sidebar_focus_from_attached_client_views() {
         }
     }
 
-    let xdg = scoped_runtime_dir();
-    let name = unique_session_name("switch-repair");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("switch-repair");
+    let xdg = room.path();
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("session cwd tempdir");
-    let poke_log = xdg.path().join("poke.log");
-    let focus_exec_log = xdg.path().join("focus-exec.log");
-    let rimz_shim = write_poke_shim(xdg.path(), &poke_log, &real_rimz, &focus_exec_log);
+    let poke_log = xdg.join("poke.log");
+    let focus_exec_log = xdg.join("focus-exec.log");
+    let rimz_shim = write_poke_shim(xdg, &poke_log, &real_rimz, &focus_exec_log);
     let trace = TempDir::new().expect("zellij trace tempdir");
     let trace_log = trace.path().join("zellij.log");
     let zellij_shim = trace.path().join("zellij");
@@ -689,14 +642,14 @@ fn tab_switch_repairs_sidebar_focus_from_attached_client_views() {
     sidebar
         .extra_env
         .insert("RUST_LOG".to_owned(), "rimz=debug".to_owned());
-    let backend = ZellijBackend::with_runtime_dir(xdg.path());
-    publish_room_bin(xdg.path(), &sidebar);
+    let backend = ZellijBackend::with_runtime_dir(xdg);
+    publish_room_bin(xdg, &sidebar);
     backend.open_sidebar(&sidebar, None).expect("open sidebar");
-    wait_for_pane_count(xdg.path(), &name, 2);
+    wait_for_pane_count(xdg, &name, 2);
 
-    let mut client = AttachedClient::attach(xdg.path(), &name, 160, 45);
-    let birth_sidebar = raw_sidebar_pane(xdg.path(), &name);
-    let birth_work = expect_list_panes(xdg.path(), &name)
+    let mut client = AttachedClient::attach(&room, 160, 45);
+    let birth_sidebar = raw_sidebar_pane(xdg, &name);
+    let birth_work = expect_list_panes(xdg, &name)
         .panes
         .iter()
         .find(|pane| {
@@ -706,16 +659,7 @@ fn tab_switch_repairs_sidebar_focus_from_attached_client_views() {
         })
         .map(|pane| PaneId::from_parts(MuxName::Zellij, format!("terminal_{}", pane.id)))
         .expect("birth work pane");
-    let birth_work_ordinal = birth_work
-        .creation_ordinal()
-        .expect("numeric birth work pane id");
-    focus_attached_client_pane_until(
-        xdg.path(),
-        &name,
-        birth_work_ordinal,
-        "birth work pane",
-        || client.press_alt('l'),
-    );
+    client.press_alt_until('l', &birth_work, "birth work pane");
 
     let target_tab = "switch target";
     let input_log = cwd.path().join("routed-input.log");
@@ -739,35 +683,20 @@ fn tab_switch_repairs_sidebar_focus_from_attached_client_views() {
             sidebar: sidebar.clone(),
         })
         .expect("open switch target tab");
-    let target_work = wait_for_named_work_pane_count(xdg.path(), &name, target_tab, 1)[0];
+    let target_work = wait_for_named_work_pane_count(xdg, &name, target_tab, 1)[0];
     let target_sidebar =
-        wait_for_named_sidebar_pane(xdg.path(), &name, target_tab).expect("target tab sidebar");
+        wait_for_named_sidebar_pane(xdg, &name, target_tab).expect("target tab sidebar");
     let target_work = PaneId::from_parts(MuxName::Zellij, format!("terminal_{}", target_work.id));
     let target_sidebar =
         PaneId::from_parts(MuxName::Zellij, format!("terminal_{}", target_sidebar.id));
-    let target_work_ordinal = target_work
-        .creation_ordinal()
-        .expect("numeric target work pane id");
-    focus_attached_client_pane_until(
-        xdg.path(),
-        &name,
-        target_work_ordinal,
-        "target work pane",
-        || client.go_to_tab(2),
-    );
+    client.go_to_tab_until(2, &target_work, "target work pane");
 
-    strand_sidebar_focus(&backend, &mut client, &name, &target_sidebar);
+    client.press_alt_until('h', &target_sidebar, "stranded target sidebar");
 
-    focus_attached_client_pane_until(
-        xdg.path(),
-        &name,
-        birth_work_ordinal,
-        "birth work pane before switch repair",
-        || client.go_to_tab(1),
-    );
+    client.go_to_tab_until(1, &birth_work, "birth work pane before switch repair");
     let pokes_before = poke_lines(&poke_log).len();
     let actions_before = focus_action_count(&trace_log);
-    let repairs_before = accepted_focus_repairs(xdg.path(), &target_work);
+    let repairs_before = accepted_focus_repairs(xdg, &target_work);
     client.go_to_tab(2);
     let settled = wait_for_switch_settled(&poke_log, pokes_before);
     assert!(
@@ -785,32 +714,23 @@ fn tab_switch_repairs_sidebar_focus_from_attached_client_views() {
         actions_before,
         "first switch-settled repair",
     );
-    let repairs = wait_for_accepted_focus_repair(xdg.path(), &target_work, repairs_before);
+    let repairs = wait_for_accepted_focus_repair(xdg, &target_work, repairs_before);
 
-    client.send_line("rimz-routed-first");
-    let routed = poll_until(
-        Duration::from_secs(10),
-        || std::fs::read_to_string(&input_log).map_err(|err| err.to_string()),
-        |contents| contents.contains("rimz-routed-first"),
-        "terminal input routed to repaired work pane",
-    );
-    assert!(routed.contains("rimz-routed-first"));
+    client.assert_input_reaches(&target_work, "repaired target work pane");
 
     assert!(repairs.iter().any(|record| {
         record.target == target_work
             && record.outcome == rimz::diag::focus_repair::FocusRepairOutcome::AcceptedUnconfirmed
     }));
 
-    strand_sidebar_focus(&backend, &mut client, &name, &target_sidebar);
-    focus_attached_client_pane_until(
-        xdg.path(),
-        &name,
-        birth_work_ordinal,
-        "birth work pane before presence reload",
-        || client.go_to_tab(1),
+    client.press_alt_until(
+        'h',
+        &target_sidebar,
+        "stranded target sidebar before reload",
     );
+    client.go_to_tab_until(1, &birth_work, "birth work pane before presence reload");
     let pokes_before_reload = poke_lines(&poke_log).len();
-    let room_bin = rimz::StatePaths::under(sidebar.workspace_id.clone(), xdg.path())
+    let room_bin = rimz::StatePaths::under(sidebar.workspace_id.clone(), xdg)
         .expect("room state paths")
         .room_bin;
     backend
@@ -828,7 +748,7 @@ fn tab_switch_repairs_sidebar_focus_from_attached_client_views() {
     wait_for_reload_baseline(&poke_log, pokes_before_reload, &birth_work);
     let pokes_before = poke_lines(&poke_log).len();
     let actions_before = focus_action_count(&trace_log);
-    let repairs_before = accepted_focus_repairs(xdg.path(), &target_work);
+    let repairs_before = accepted_focus_repairs(xdg, &target_work);
     client.go_to_tab(2);
     wait_for_switch_settled(&poke_log, pokes_before);
     wait_for_focus_action(
@@ -838,33 +758,20 @@ fn tab_switch_repairs_sidebar_focus_from_attached_client_views() {
         actions_before,
         "post-reload repair",
     );
-    wait_for_accepted_focus_repair(xdg.path(), &target_work, repairs_before);
-    client.send_line("rimz-routed-after-reload");
-    poll_until(
-        Duration::from_secs(10),
-        || std::fs::read_to_string(&input_log).map_err(|err| err.to_string()),
-        |contents| contents.contains("rimz-routed-after-reload"),
-        "terminal input routed after plugin reload",
-    );
+    wait_for_accepted_focus_repair(xdg, &target_work, repairs_before);
+    client.assert_input_reaches(&target_work, "repaired target after plugin reload");
 
-    strand_sidebar_focus(&backend, &mut client, &name, &target_sidebar);
-    focus_attached_client_pane_until(
-        xdg.path(),
-        &name,
-        birth_work_ordinal,
-        "birth work pane before detach",
-        || client.go_to_tab(1),
+    client.press_alt_until(
+        'h',
+        &target_sidebar,
+        "stranded target sidebar before detach",
     );
+    client.go_to_tab_until(1, &birth_work, "birth work pane before detach");
     let actions_before = focus_action_count(&trace_log);
     client.go_to_tab(2);
     drop(client);
-    let detached = poll_until(
-        Duration::from_secs(5),
-        || client_viewed_panes(&backend, &name),
-        Vec::is_empty,
-        "detached client view",
-    );
-    assert!(detached.is_empty());
+    let detached = wait_for_human_client_count(&backend, &name, 0);
+    assert!(detached.viewed_panes.is_empty());
     std::thread::sleep(Duration::from_millis(500));
     assert_eq!(
         focus_action_count(&trace_log),
@@ -892,14 +799,15 @@ fn presence_plugin_keepalive_survives_deleted_launch_cwd() {
         }
     }
 
-    let xdg = scoped_runtime_dir();
-    seed_presence_permissions(xdg.path(), &wasm);
+    let namespace = ZellijNamespace::new();
+    seed_presence_permissions(namespace.path(), &wasm);
     let real_rimz = crate::common::cargo_bin("rimz", env!("CARGO_BIN_EXE_rimz"));
     let name = unique_session_name("presence-cwd");
-    let session = ZellijSession::attach_pty(xdg, name.clone(), true);
+    let room = LiveZellijSession::from_namespace(namespace, name.clone());
+    let _client = AttachedClient::create_and_attach(&room, 80, 24);
     let launch_cwd = TempDir::new().expect("plugin launch cwd");
     let workspace_id = WorkspaceId::parse("ws_0123456789abcdef01234567").expect("fixed id");
-    let runtime = rimz::store::RuntimePaths::under(workspace_id, session.xdg.path())
+    let runtime = rimz::store::RuntimePaths::under(workspace_id, room.path())
         .expect("presence runtime paths");
     let stamp_path = rimz::sidebar::cache::presence_stamp_path(&runtime);
     let plugin_url = format!("file:{}", wasm.display());
@@ -908,7 +816,8 @@ fn presence_plugin_keepalive_survives_deleted_launch_cwd() {
         real_rimz.display(),
     );
 
-    let loaded = scoped_zellij(session.xdg.path())
+    let loaded = room
+        .command()
         .current_dir(launch_cwd.path())
         .args([
             "--session",
@@ -923,7 +832,7 @@ fn presence_plugin_keepalive_survives_deleted_launch_cwd() {
             "--",
             "load",
         ])
-        .status()
+        .bounded_status()
         .expect("load presence plugin from disposable cwd");
     assert!(loaded.success(), "presence plugin load command failed");
     let mut last_written_at_ms = None;
@@ -984,16 +893,17 @@ fn focus_key_press_from_different_cwd_pipes_sidebar_focus_through_the_plugin() {
         }
     }
 
-    let xdg = scoped_runtime_dir();
-    seed_presence_permissions(xdg.path(), &wasm);
-    let poke_log = xdg.path().join("poke.log");
-    let focus_exec_log = xdg.path().join("focus-exec.log");
+    let namespace = ZellijNamespace::new();
+    seed_presence_permissions(namespace.path(), &wasm);
+    let poke_log = namespace.path().join("poke.log");
+    let focus_exec_log = namespace.path().join("focus-exec.log");
     let real_rimz = crate::common::cargo_bin("rimz", env!("CARGO_BIN_EXE_rimz"));
-    let rimz_shim = write_poke_shim(xdg.path(), &poke_log, &real_rimz, &focus_exec_log);
+    let rimz_shim = write_poke_shim(namespace.path(), &poke_log, &real_rimz, &focus_exec_log);
     let name = unique_session_name("focuskey");
-    let mut session = ZellijSession::attach_pty(xdg, name.clone(), true);
+    let room = LiveZellijSession::from_namespace(namespace, name.clone());
+    let mut client = AttachedClient::create_and_attach(&room, 80, 24);
 
-    let backend = ZellijBackend::with_runtime_dir(session.xdg.path());
+    let backend = ZellijBackend::with_runtime_dir(room.path());
     backend
         .ensure_presence_plugin(&rimz::mux::PresencePluginOptions {
             session_name: name.clone(),
@@ -1012,28 +922,22 @@ fn focus_key_press_from_different_cwd_pipes_sidebar_focus_through_the_plugin() {
     // Regression shape: the plugin loads from the test process cwd, then the
     // user presses the key from a pane with a different cwd. Url-targeted
     // keybinds miss that running instance; id-targeted keybinds reach it.
-    let before: BTreeSet<u64> = work_pane_geometry(session.xdg.path(), &name)
+    let before: BTreeSet<u64> = work_pane_geometry(room.path(), &name)
         .into_iter()
         .map(|pane| pane.id)
         .collect();
     let pane_cwd = TempDir::new().expect("different cwd tempdir");
-    spawn_sleep_pane(session.xdg.path(), &name, pane_cwd.path());
-    let work_pane = work_pane_geometry(session.xdg.path(), &name)
+    spawn_sleep_pane(room.path(), &name, pane_cwd.path());
+    let work_pane = work_pane_geometry(room.path(), &name)
         .into_iter()
         .find(|pane| !before.contains(&pane.id))
         .unwrap_or_else(|| panic!("new different-cwd pane not found; before ids were {before:?}"));
-    let session_xdg = session.xdg.path().to_path_buf();
-    focus_attached_client_pane_until(
-        &session_xdg,
-        &name,
-        work_pane.id,
-        "different-cwd focus-key source pane",
-        || session.press_alt('l'),
-    );
+    let work_pane = PaneId::from_parts(MuxName::Zellij, format!("terminal_{}", work_pane.id));
+    client.press_alt_until('l', &work_pane, "different-cwd focus-key source pane");
 
     let deadline = Instant::now() + SPAWN_TIMEOUT;
     let focus_line = loop {
-        session.press_alt('p');
+        client.press_alt('p');
         std::thread::sleep(Duration::from_millis(150));
 
         let lines = poke_lines(&poke_log);

--- a/crates/rimz/tests/integration/backend/zellij/presence.rs
+++ b/crates/rimz/tests/integration/backend/zellij/presence.rs
@@ -706,13 +706,16 @@ fn tab_switch_repairs_sidebar_focus_from_attached_client_views() {
         })
         .map(|pane| PaneId::from_parts(MuxName::Zellij, format!("terminal_{}", pane.id)))
         .expect("birth work pane");
-    if !client_viewed_panes(&backend, &name)
-        .expect("birth client view")
-        .contains(&birth_work)
-    {
-        client.press_alt('l');
-        wait_for_focused_client_pane(&backend, &name, &birth_work);
-    }
+    let birth_work_ordinal = birth_work
+        .creation_ordinal()
+        .expect("numeric birth work pane id");
+    focus_attached_client_pane_until(
+        xdg.path(),
+        &name,
+        birth_work_ordinal,
+        "birth work pane",
+        || client.press_alt('l'),
+    );
 
     let target_tab = "switch target";
     let input_log = cwd.path().join("routed-input.log");
@@ -742,13 +745,26 @@ fn tab_switch_repairs_sidebar_focus_from_attached_client_views() {
     let target_work = PaneId::from_parts(MuxName::Zellij, format!("terminal_{}", target_work.id));
     let target_sidebar =
         PaneId::from_parts(MuxName::Zellij, format!("terminal_{}", target_sidebar.id));
-    client.go_to_tab(2);
-    wait_for_focused_client_pane(&backend, &name, &target_work);
+    let target_work_ordinal = target_work
+        .creation_ordinal()
+        .expect("numeric target work pane id");
+    focus_attached_client_pane_until(
+        xdg.path(),
+        &name,
+        target_work_ordinal,
+        "target work pane",
+        || client.go_to_tab(2),
+    );
 
     strand_sidebar_focus(&backend, &mut client, &name, &target_sidebar);
 
-    client.go_to_tab(1);
-    wait_for_focused_client_pane(&backend, &name, &birth_work);
+    focus_attached_client_pane_until(
+        xdg.path(),
+        &name,
+        birth_work_ordinal,
+        "birth work pane before switch repair",
+        || client.go_to_tab(1),
+    );
     let pokes_before = poke_lines(&poke_log).len();
     let actions_before = focus_action_count(&trace_log);
     let repairs_before = accepted_focus_repairs(xdg.path(), &target_work);
@@ -786,8 +802,13 @@ fn tab_switch_repairs_sidebar_focus_from_attached_client_views() {
     }));
 
     strand_sidebar_focus(&backend, &mut client, &name, &target_sidebar);
-    client.go_to_tab(1);
-    wait_for_focused_client_pane(&backend, &name, &birth_work);
+    focus_attached_client_pane_until(
+        xdg.path(),
+        &name,
+        birth_work_ordinal,
+        "birth work pane before presence reload",
+        || client.go_to_tab(1),
+    );
     let pokes_before_reload = poke_lines(&poke_log).len();
     let room_bin = rimz::StatePaths::under(sidebar.workspace_id.clone(), xdg.path())
         .expect("room state paths")
@@ -827,8 +848,13 @@ fn tab_switch_repairs_sidebar_focus_from_attached_client_views() {
     );
 
     strand_sidebar_focus(&backend, &mut client, &name, &target_sidebar);
-    client.go_to_tab(1);
-    wait_for_focused_client_pane(&backend, &name, &birth_work);
+    focus_attached_client_pane_until(
+        xdg.path(),
+        &name,
+        birth_work_ordinal,
+        "birth work pane before detach",
+        || client.go_to_tab(1),
+    );
     let actions_before = focus_action_count(&trace_log);
     client.go_to_tab(2);
     drop(client);

--- a/crates/rimz/tests/integration/backend/zellij/reap.rs
+++ b/crates/rimz/tests/integration/backend/zellij/reap.rs
@@ -9,33 +9,28 @@ use super::support::*;
 fn remote_lineage_reap_kills_only_the_matching_attached_client() {
     require_zellij!();
 
-    let xdg = scoped_runtime_dir();
+    let room = LiveZellijSession::new("reap");
+    let xdg = room.path();
     let cwd = tempfile::tempdir().expect("session cwd");
-    let name = unique_session_name("reap");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
+    let name = room.name().to_owned();
     // Birth the session in the background and prove it answers actions before
     // any client attaches. A PTY `attach --create` births and attaches in one
     // unchecked step, and a starved host lets that client sit forever against a
     // server that never came up — the session under test has to exist on a
     // checked command.
-    create_plain_background_session(xdg.path(), &name, cwd.path(), "600");
-    wait_until_session_ready(xdg.path(), &name);
+    room.create_plain_background(cwd.path(), "600");
 
-    let mut client =
-        AttachedClient::attach_with_lineage(xdg.path(), &name, "0123456789abcdef", 120, 40);
-    wait_for_client_count(xdg.path(), &name, 1, &mut client);
+    let mut client = AttachedClient::attach_with_lineage(&room, "0123456789abcdef", 120, 40);
+    wait_for_client_count(xdg, &name, 1, &mut client);
     let client_pid = client.pid();
     wait_for_attached_lineage_client(client_pid, &name, "0123456789abcdef");
-    let backend = ZellijBackend::with_runtime_dir(xdg.path());
+    let backend = ZellijBackend::with_runtime_dir(xdg);
 
     let other = zellij::reap_lineage_clients(&backend, &name, "fedcba9876543210")
         .expect("other-lineage reap");
     assert!(other.killed_pids.is_empty(), "other lineage: {other:?}");
     assert!(other.settled, "other lineage is a settled no-op: {other:?}");
-    wait_for_client_count(xdg.path(), &name, 1, &mut client);
+    wait_for_client_count(xdg, &name, 1, &mut client);
 
     let same = zellij::reap_lineage_clients(&backend, &name, "0123456789abcdef")
         .expect("same-lineage reap");

--- a/crates/rimz/tests/integration/backend/zellij/reconcile.rs
+++ b/crates/rimz/tests/integration/backend/zellij/reconcile.rs
@@ -140,7 +140,6 @@ fn bare_reload_preserves_stale_sidebar_panes_and_geometry() {
         "reload preservation",
     );
     let _client = AttachedClient::attach(xdg.path(), &name, 180, 50);
-    wait_for_attached_client(xdg.path(), &name);
     wait_for_pane_count(xdg.path(), &name, 6);
 
     let project_root = PathBuf::from(format!("/tmp/rimz-{name}"));
@@ -388,7 +387,6 @@ fn reconcile_redocks_an_off_spec_claimed_sidebar() {
     // trip the tolerant width trigger — at 240 columns it lands at ~120.
     let mut client = AttachedClient::attach(xdg_dir.path(), &name, 240, 60);
     let xdg = xdg_dir.path().to_path_buf();
-    wait_for_attached_client(&xdg, &name);
     let before = raw_sidebar_pane(&xdg, &name);
     let sidebar_id = before.id;
     let before_work = work_pane_geometry(&xdg, &name);
@@ -513,7 +511,6 @@ fn reconcile_repairs_a_nested_sidebar_into_a_full_height_left_column() {
 
     let mut client = AttachedClient::attach(xdg_dir.path(), &name, 240, 60);
     let xdg = xdg_dir.path().to_path_buf();
-    wait_for_attached_client(&xdg, &name);
 
     let before = raw_sidebar_pane(&xdg, &name);
     let sidebar_id = before.id;
@@ -564,6 +561,13 @@ fn reconcile_repairs_a_nested_sidebar_into_a_full_height_left_column() {
         &name,
         sidebar_id,
         "the renderer pane survives the nested-row repair",
+    );
+    focus_attached_client_pane_until(
+        &xdg,
+        &name,
+        original_id,
+        "original work pane after nested repair",
+        || client.press_alt('l'),
     );
     assert_client_input_reaches_pane(
         &xdg,
@@ -633,7 +637,6 @@ fn reconcile_reports_nested_multicolumn_sidebar_without_stacking_work_area() {
 
     let _client = AttachedClient::attach(xdg_dir.path(), &name, 240, 60);
     let xdg = xdg_dir.path().to_path_buf();
-    wait_for_attached_client(&xdg, &name);
 
     let before_sidebar = raw_sidebar_pane(&xdg, &name);
     let sidebar_id = before_sidebar.id;
@@ -736,7 +739,6 @@ fn reconcile_add_docks_sidebar_in_wide_tab() {
 
     let mut client = AttachedClient::attach(xdg_dir.path(), &name, 360, 60);
     let xdg = xdg_dir.path().to_path_buf();
-    wait_for_attached_client(&xdg, &name);
     let before = work_pane_geometry(&xdg, &name);
     let before_ids: BTreeSet<u64> = before.iter().map(|pane| pane.id).collect();
     let leftmost_x = before
@@ -827,7 +829,6 @@ fn reconcile_add_ends_docked_in_a_row_stacked_tab() {
 
     let _client = AttachedClient::attach(xdg_dir.path(), &name, 160, 60);
     let xdg = xdg_dir.path().to_path_buf();
-    wait_for_attached_client(&xdg, &name);
     let down = scoped_zellij(&xdg)
         .args([
             "--session",

--- a/crates/rimz/tests/integration/backend/zellij/reconcile.rs
+++ b/crates/rimz/tests/integration/backend/zellij/reconcile.rs
@@ -91,12 +91,9 @@ fn terminal_state(snapshot: &PaneSnapshot) -> BTreeMap<u64, TerminalState> {
 fn bare_reload_preserves_stale_sidebar_panes_and_geometry() {
     require_zellij!();
 
-    let xdg = scoped_runtime_dir();
-    let name = unique_session_name("reloadkeep");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("reloadkeep");
+    let xdg = room.path();
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
     let env = Env::new();
     let (_stub_dir, stub) = sidebar_stub_alive_for(120);
@@ -132,15 +129,9 @@ fn bare_reload_preserves_stale_sidebar_panes_and_geometry() {
 "#,
         )
     });
-    birth_kdl_session(
-        xdg.path(),
-        &name,
-        cwd.path(),
-        &layout,
-        "reload preservation",
-    );
-    let _client = AttachedClient::attach(xdg.path(), &name, 180, 50);
-    wait_for_pane_count(xdg.path(), &name, 6);
+    birth_kdl_session(&room, cwd.path(), &layout, "reload preservation");
+    let client = AttachedClient::attach(&room, 180, 50);
+    wait_for_pane_count(xdg, &name, 6);
 
     let project_root = PathBuf::from(format!("/tmp/rimz-{name}"));
     let workspace_id = WorkspaceId::from_project_root(&project_root);
@@ -154,23 +145,21 @@ fn bare_reload_preserves_stale_sidebar_panes_and_geometry() {
         .any(|workspace| workspace.session_name == name),
         "reload fixture workspace is discoverable",
     );
-    let backend = rimz::mux::ZellijBackend::with_runtime_dir(xdg.path());
+    let backend = rimz::mux::ZellijBackend::with_runtime_dir(xdg);
     assert!(
         wait_for_live_session(&backend, &name)
             .iter()
             .any(|session| session == &name),
         "reload fixture session is live",
     );
-    let runtime = RuntimePaths::under(workspace_id.clone(), xdg.path()).expect("runtime paths");
+    let runtime = RuntimePaths::under(workspace_id.clone(), xdg).expect("runtime paths");
     runtime.ensure_dirs().expect("runtime dirs");
     // A client can register before the background layout has adopted its PTY
     // size, so record a settled baseline rather than a transient birth frame.
-    let before_terminals =
-        wait_for_stable_terminal_state(xdg.path(), &name, Duration::from_millis(500));
-    let before = expect_list_panes(xdg.path(), &name);
-    let backend = rimz::mux::ZellijBackend::with_runtime_dir(xdg.path());
-    let before_client_view =
-        client_viewed_panes(&backend, &name).expect("client view before reload");
+    let before_terminals = wait_for_stable_terminal_state(xdg, &name, Duration::from_millis(500));
+    let before = expect_list_panes(xdg, &name);
+    let backend = rimz::mux::ZellijBackend::with_runtime_dir(xdg);
+    let before_client_view = client.view().viewed_panes;
     let mut receivers = Vec::new();
     for pane in before.panes.iter().filter(|pane| pane.is_sidebar()) {
         let socket = runtime.sock_dir.join(format!("reload-{}.sock", pane.id));
@@ -216,10 +205,10 @@ fn bare_reload_preserves_stale_sidebar_panes_and_geometry() {
     let preflight = env
         .rimz()
         .arg("list")
-        .env("XDG_RUNTIME_DIR", xdg.path())
-        .env("ZELLIJ_SOCKET_DIR", xdg.path().join("zellij"))
-        .env("XDG_CACHE_HOME", xdg.path())
-        .env("TMPDIR", xdg.path())
+        .env("XDG_RUNTIME_DIR", xdg)
+        .env("ZELLIJ_SOCKET_DIR", xdg.join("zellij"))
+        .env("XDG_CACHE_HOME", xdg)
+        .env("TMPDIR", xdg)
         .bounded_output_within(Duration::from_secs(10))
         .expect("list fixture through rimz");
     assert!(
@@ -231,10 +220,10 @@ fn bare_reload_preserves_stale_sidebar_panes_and_geometry() {
     let output = env
         .rimz()
         .arg("reload")
-        .env("XDG_RUNTIME_DIR", xdg.path())
-        .env("ZELLIJ_SOCKET_DIR", xdg.path().join("zellij"))
-        .env("XDG_CACHE_HOME", xdg.path())
-        .env("TMPDIR", xdg.path())
+        .env("XDG_RUNTIME_DIR", xdg)
+        .env("ZELLIJ_SOCKET_DIR", xdg.join("zellij"))
+        .env("XDG_CACHE_HOME", xdg)
+        .env("TMPDIR", xdg)
         .env("RIMZ_ZELLIJ_BIN", &zellij_shim)
         .env("RIMZ_TEST_SKIP_STATS_RELOAD", "1")
         .bounded_output_within(Duration::from_secs(30))
@@ -259,7 +248,7 @@ fn bare_reload_preserves_stale_sidebar_panes_and_geometry() {
 
     let after_terminals = poll_until(
         Duration::from_secs(10),
-        || list_panes(xdg.path(), &name).map(|snapshot| terminal_state(&snapshot)),
+        || list_panes(xdg, &name).map(|snapshot| terminal_state(&snapshot)),
         |state| state == &before_terminals,
         "terminal geometry to settle after bare reload",
     );
@@ -269,7 +258,7 @@ fn bare_reload_preserves_stale_sidebar_panes_and_geometry() {
     );
     let after_client_view = poll_until(
         Duration::from_secs(10),
-        || client_viewed_panes(&backend, &name),
+        || observe_client_view(&backend, &name).map(|view| view.viewed_panes),
         |viewed| viewed == &before_client_view,
         "client view to settle after bare reload",
     );
@@ -285,17 +274,14 @@ fn bare_reload_preserves_stale_sidebar_panes_and_geometry() {
 fn reconcile_defers_the_add_on_a_detached_session() {
     require_zellij!();
 
-    let xdg = scoped_runtime_dir();
-    let name = unique_session_name("defer");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("defer");
+    let xdg = room.path();
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
 
     // A detached background session with a working pane and no sidebar.
-    create_plain_background_session(xdg.path(), &name, cwd.path(), "60");
-    let before = wait_for_pane_count(xdg.path(), &name, 1);
+    room.create_plain_background(cwd.path(), "60");
+    let before = wait_for_pane_count(xdg, &name, 1);
     assert!(
         !before.is_empty(),
         "plain session should have a pane before reconcile: {before:?}",
@@ -303,11 +289,11 @@ fn reconcile_defers_the_add_on_a_detached_session() {
 
     let (_stub_dir, stub) = sidebar_command_stub();
     let opts = sidebar_opts(&name, cwd.path(), stub, 120);
-    write_topology_cache_from_list_panes(xdg.path(), &opts.workspace_id, &name);
+    write_topology_cache_from_list_panes(xdg, &opts.workspace_id, &name);
     // A freshly born --create-background session whose only pane is still
     // materializing is the case most prone to reconcile's transient-empty read,
     // so retry until reconcile actually observes the working pane.
-    let report = reconcile_until_observed(xdg.path(), &opts, &SidebarLiveness::default());
+    let report = reconcile_until_observed(xdg, &opts, &SidebarLiveness::default());
 
     assert_eq!(report.deferred, 1, "the detached session's add is deferred");
     assert_eq!(report.recovered, 0, "nothing is added without a client");
@@ -315,7 +301,7 @@ fn reconcile_defers_the_add_on_a_detached_session() {
     // Poll rather than read once: a recovered add would already have tripped the
     // `recovered == 0` assertion above, so here a single empty `list-panes` answer
     // under load would only flake a settled result. `before` polls for the same reason.
-    let after = wait_for_pane_count(xdg.path(), &name, 1);
+    let after = wait_for_pane_count(xdg, &name, 1);
     assert_eq!(after.len(), 1, "no pane was added detached: {after:?}");
     assert_eq!(
         serve_processes_for(&name).expect("scan sidebar serve processes"),
@@ -331,12 +317,8 @@ fn reconcile_defers_the_add_on_a_detached_session() {
 fn reconcile_redocks_an_off_spec_claimed_sidebar() {
     require_zellij!();
 
-    let xdg_dir = scoped_runtime_dir();
-    let name = unique_session_name("redock");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg_dir.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("redock");
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
 
     // A background session with a deterministic far-right sidebar, matching
@@ -375,8 +357,8 @@ fn reconcile_redocks_an_off_spec_claimed_sidebar() {
             )
         },
     );
-    birth_kdl_session(xdg_dir.path(), &name, cwd.path(), &layout, "right-sidebar");
-    let initial = wait_for_pane_count(xdg_dir.path(), &name, 7);
+    birth_kdl_session(&room, cwd.path(), &layout, "right-sidebar");
+    let initial = wait_for_pane_count(room.path(), &name, 7);
     assert_eq!(
         initial.len(),
         7,
@@ -385,8 +367,8 @@ fn reconcile_redocks_an_off_spec_claimed_sidebar() {
 
     // A wide client: the 50% mis-mount must exceed the `max_cols` cap (72) to
     // trip the tolerant width trigger — at 240 columns it lands at ~120.
-    let mut client = AttachedClient::attach(xdg_dir.path(), &name, 240, 60);
-    let xdg = xdg_dir.path().to_path_buf();
+    let mut client = AttachedClient::attach(&room, 240, 60);
+    let xdg = room.path().to_path_buf();
     let before = raw_sidebar_pane(&xdg, &name);
     let sidebar_id = before.id;
     let before_work = work_pane_geometry(&xdg, &name);
@@ -405,13 +387,8 @@ fn reconcile_redocks_an_off_spec_claimed_sidebar() {
         .max_by_key(|pane| pane.x)
         .map(|pane| pane.id)
         .expect("rightmost work pane");
-    focus_attached_client_pane_until(
-        &xdg,
-        &name,
-        focused_work_id,
-        "rightmost work pane before redock",
-        || client.press_alt('l'),
-    );
+    let focused_work = PaneId::from_parts(MuxName::Zellij, format!("terminal_{focused_work_id}"));
+    client.press_alt_until('l', &focused_work, "rightmost work pane before redock");
 
     let project_root = std::env::temp_dir();
     let opts = reconcile_opts(
@@ -448,13 +425,7 @@ fn reconcile_redocks_an_off_spec_claimed_sidebar() {
         after_work_ids, before_work_ids,
         "redock preserves every work pane",
     );
-    assert_client_input_reaches_pane(
-        &xdg,
-        &name,
-        focused_work_id,
-        "restored work pane after redock",
-        |line| client.send_line(line),
-    );
+    client.assert_input_reaches(&focused_work, "restored work pane after redock");
 }
 /// A claimed sidebar can sit at `x=0` while still not being a full-height left
 /// column: a work pane spans the whole tab below it. Reconcile detects that
@@ -464,12 +435,8 @@ fn reconcile_redocks_an_off_spec_claimed_sidebar() {
 fn reconcile_repairs_a_nested_sidebar_into_a_full_height_left_column() {
     require_zellij!();
 
-    let xdg_dir = scoped_runtime_dir();
-    let name = unique_session_name("nested");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg_dir.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("nested");
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
 
     let (_stub_dir, stub) = sidebar_command_stub();
@@ -501,16 +468,16 @@ fn reconcile_repairs_a_nested_sidebar_into_a_full_height_left_column() {
 "#,
         )
     });
-    birth_kdl_session(xdg_dir.path(), &name, cwd.path(), &layout, "nested");
-    let initial = wait_for_pane_count(xdg_dir.path(), &name, 3);
+    birth_kdl_session(&room, cwd.path(), &layout, "nested");
+    let initial = wait_for_pane_count(room.path(), &name, 3);
     assert_eq!(
         initial.len(),
         3,
         "layout should birth a sidebar and two work panes: {initial:?}",
     );
 
-    let mut client = AttachedClient::attach(xdg_dir.path(), &name, 240, 60);
-    let xdg = xdg_dir.path().to_path_buf();
+    let mut client = AttachedClient::attach(&room, 240, 60);
+    let xdg = room.path().to_path_buf();
 
     let before = raw_sidebar_pane(&xdg, &name);
     let sidebar_id = before.id;
@@ -537,13 +504,8 @@ fn reconcile_repairs_a_nested_sidebar_into_a_full_height_left_column() {
         .find(|pane| pane.x >= sidebar_cols)
         .map(|pane| pane.id)
         .expect("right-side work pane");
-    focus_attached_client_pane_until(
-        &xdg,
-        &name,
-        original_id,
-        "original work pane before reconcile",
-        || client.press_alt('l'),
-    );
+    let original_pane = PaneId::from_parts(MuxName::Zellij, format!("terminal_{original_id}"));
+    client.press_alt_until('l', &original_pane, "original work pane before reconcile");
 
     let opts = reconcile_opts(&name, "/tmp/rimz-nested", cwd.path(), cwd.path(), stub, 160);
     let liveness = claimed_liveness(sidebar_id);
@@ -562,19 +524,14 @@ fn reconcile_repairs_a_nested_sidebar_into_a_full_height_left_column() {
         sidebar_id,
         "the renderer pane survives the nested-row repair",
     );
-    focus_attached_client_pane_until(
-        &xdg,
-        &name,
-        original_id,
+    client.press_alt_until(
+        'l',
+        &original_pane,
         "original work pane after nested repair",
-        || client.press_alt('l'),
     );
-    assert_client_input_reaches_pane(
-        &xdg,
-        &name,
-        original_id,
+    client.assert_input_reaches(
+        &original_pane,
         "restored original work pane after nested repair",
-        |line| client.send_line(line),
     );
 }
 /// A nested sidebar beside a user-made multi-column work layout is detected but
@@ -584,12 +541,8 @@ fn reconcile_repairs_a_nested_sidebar_into_a_full_height_left_column() {
 fn reconcile_reports_nested_multicolumn_sidebar_without_stacking_work_area() {
     require_zellij!();
 
-    let xdg_dir = scoped_runtime_dir();
-    let name = unique_session_name("nestedwide");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg_dir.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("nestedwide");
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
 
     let (_stub_dir, stub) = sidebar_command_stub();
@@ -627,16 +580,16 @@ fn reconcile_reports_nested_multicolumn_sidebar_without_stacking_work_area() {
 "#,
         )
     });
-    birth_kdl_session(xdg_dir.path(), &name, cwd.path(), &layout, "nested-wide");
-    let initial = wait_for_pane_count(xdg_dir.path(), &name, 4);
+    birth_kdl_session(&room, cwd.path(), &layout, "nested-wide");
+    let initial = wait_for_pane_count(room.path(), &name, 4);
     assert_eq!(
         initial.len(),
         4,
         "layout should birth four panes: {initial:?}"
     );
 
-    let _client = AttachedClient::attach(xdg_dir.path(), &name, 240, 60);
-    let xdg = xdg_dir.path().to_path_buf();
+    let _client = AttachedClient::attach(&room, 240, 60);
+    let xdg = room.path().to_path_buf();
 
     let before_sidebar = raw_sidebar_pane(&xdg, &name);
     let sidebar_id = before_sidebar.id;
@@ -701,12 +654,8 @@ fn reconcile_reports_nested_multicolumn_sidebar_without_stacking_work_area() {
 fn reconcile_add_docks_sidebar_in_wide_tab() {
     require_zellij!();
 
-    let xdg_dir = scoped_runtime_dir();
-    let name = unique_session_name("wideadd");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg_dir.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("wideadd");
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
     let (_stub_dir, stub) = sidebar_stub_alive_for(120);
     let layout = write_kdl_layout(cwd.path(), &stub, "wide-add.kdl", |cwd_kdl, _| {
@@ -733,12 +682,12 @@ fn reconcile_add_docks_sidebar_in_wide_tab() {
 "#,
         )
     });
-    birth_kdl_session(xdg_dir.path(), &name, cwd.path(), &layout, "wide add");
-    let initial = wait_for_pane_count(xdg_dir.path(), &name, 6);
+    birth_kdl_session(&room, cwd.path(), &layout, "wide add");
+    let initial = wait_for_pane_count(room.path(), &name, 6);
     assert_eq!(initial.len(), 6, "fixture should birth six work panes");
 
-    let mut client = AttachedClient::attach(xdg_dir.path(), &name, 360, 60);
-    let xdg = xdg_dir.path().to_path_buf();
+    let mut client = AttachedClient::attach(&room, 360, 60);
+    let xdg = room.path().to_path_buf();
     let before = work_pane_geometry(&xdg, &name);
     let before_ids: BTreeSet<u64> = before.iter().map(|pane| pane.id).collect();
     let leftmost_x = before
@@ -758,13 +707,8 @@ fn reconcile_add_docks_sidebar_in_wide_tab() {
             .is_some_and(|pane| pane.x > leftmost_x),
         "fixture focus must be away from the left edge: {before:?}",
     );
-    focus_attached_client_pane_until(
-        &xdg,
-        &name,
-        focused_work_id,
-        "rightmost work pane before sidebar add",
-        || client.press_alt('l'),
-    );
+    let focused_work = PaneId::from_parts(MuxName::Zellij, format!("terminal_{focused_work_id}"));
+    client.press_alt_until('l', &focused_work, "rightmost work pane before sidebar add");
 
     let opts = reconcile_opts(
         &name,
@@ -801,13 +745,7 @@ fn reconcile_add_docks_sidebar_in_wide_tab() {
         .map(|pane| pane.id)
         .collect();
     assert_eq!(after_ids, before_ids, "every work pane survives the add");
-    assert_client_input_reaches_pane(
-        &xdg,
-        &name,
-        focused_work_id,
-        "restored work pane after sidebar add",
-        |line| client.send_line(line),
-    );
+    client.assert_input_reaches(&focused_work, "restored work pane after sidebar add");
 }
 /// Adding a sidebar to a tab whose work panes are already row-stacked used to
 /// birth the sidebar into only one row. The verified add path now repairs that
@@ -816,20 +754,17 @@ fn reconcile_add_docks_sidebar_in_wide_tab() {
 fn reconcile_add_ends_docked_in_a_row_stacked_tab() {
     require_zellij!();
 
-    let xdg_dir = scoped_runtime_dir();
-    let name = unique_session_name("rowadd");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg_dir.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("rowadd");
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
 
-    create_plain_background_session(xdg_dir.path(), &name, cwd.path(), "600");
-    wait_for_pane_count(xdg_dir.path(), &name, 1);
+    room.create_plain_background(cwd.path(), "600");
+    wait_for_pane_count(room.path(), &name, 1);
 
-    let _client = AttachedClient::attach(xdg_dir.path(), &name, 160, 60);
-    let xdg = xdg_dir.path().to_path_buf();
-    let down = scoped_zellij(&xdg)
+    let _client = AttachedClient::attach(&room, 160, 60);
+    let xdg = room.path().to_path_buf();
+    let down = room
+        .command()
         .args([
             "--session",
             &name,
@@ -879,16 +814,22 @@ fn write_kdl_layout(
     layout
 }
 
-fn birth_kdl_session(xdg: &Path, name: &str, cwd: &Path, layout: &Path, label: &str) {
-    let created = scoped_zellij(xdg)
-        .args(["attach", "--create-background", name, "options"])
+fn birth_kdl_session(session: &LiveZellijSession, cwd: &Path, layout: &Path, label: &str) {
+    let created = session
+        .command()
+        .args(["attach", "--create-background", session.name(), "options"])
         .arg("--default-cwd")
         .arg(cwd)
         .arg("--default-layout")
         .arg(layout)
         .bounded_status()
         .unwrap_or_else(|err| panic!("create {label} session failed to run: {err}"));
-    assert!(created.success(), "create-background failed for {name}");
+    assert!(
+        created.success(),
+        "create-background failed for {}",
+        session.name()
+    );
+    session.wait_until_ready();
 }
 
 fn reconcile_opts(

--- a/crates/rimz/tests/integration/backend/zellij/resume.rs
+++ b/crates/rimz/tests/integration/backend/zellij/resume.rs
@@ -53,7 +53,6 @@ fn closing_agent_pane_records_end_trace_when_session_survives_without_sidebar() 
     wait_for_pane_count(xdg.path(), &workspace.session_name, 2);
 
     let _client = AttachedClient::attach(xdg.path(), &workspace.session_name, 160, 40);
-    wait_for_attached_client(xdg.path(), &workspace.session_name);
 
     let agent_bin = write_sleeping_agent_shim(&env, "claude");
     let ready = env.home_root.join("zellij-agent-ready");

--- a/crates/rimz/tests/integration/backend/zellij/resume.rs
+++ b/crates/rimz/tests/integration/backend/zellij/resume.rs
@@ -6,7 +6,7 @@ use rimz::mux::{
     LayoutPanes, MuxBackend, PaneCmd, SidebarPaneOptions, SidebarWidth, TabOptions, ZellijBackend,
 };
 
-use crate::common::{CommandTimeoutExt, Env};
+use crate::common::{CommandTimeoutExt, Env, ZellijNamespace};
 
 use super::support::*;
 
@@ -25,12 +25,10 @@ fn closing_agent_pane_records_end_trace_when_session_survives_without_sidebar() 
     let before = plan_from_env(&env);
     assert_eq!(before.tabs.len(), 1, "seeded agent should be recoverable");
 
-    let xdg = scoped_runtime_dir();
-    let _cleanup = ScopedSessionCleanup {
-        name: workspace.session_name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
-    let backend = ZellijBackend::with_runtime_dir(xdg.path());
+    let room =
+        LiveZellijSession::from_namespace(ZellijNamespace::new(), workspace.session_name.clone());
+    let xdg = room.path();
+    let backend = ZellijBackend::with_runtime_dir(xdg);
     let (_stub_dir, stub) = sidebar_stub_alive_for(600);
     let sidebar = SidebarPaneOptions {
         session_name: workspace.session_name.clone(),
@@ -48,15 +46,15 @@ fn closing_agent_pane_records_end_trace_when_session_survives_without_sidebar() 
         resume_tabs: Vec::new(),
         refresh_ms: None,
     };
-    publish_room_bin(xdg.path(), &sidebar);
+    publish_room_bin(xdg, &sidebar);
     backend.open_sidebar(&sidebar, None).expect("open_sidebar");
-    wait_for_pane_count(xdg.path(), &workspace.session_name, 2);
+    wait_for_pane_count(xdg, &workspace.session_name, 2);
 
-    let _client = AttachedClient::attach(xdg.path(), &workspace.session_name, 160, 40);
+    let _client = AttachedClient::attach(&room, 160, 40);
 
     let agent_bin = write_sleeping_agent_shim(&env, "claude");
     let ready = env.home_root.join("zellij-agent-ready");
-    let command = zellij_agent_exec_command(&env, xdg.path(), &agent_bin, &ready, agent_id);
+    let command = zellij_agent_exec_command(&env, xdg, &agent_bin, &ready, agent_id);
     let tab_name = "#rimz-zellij";
     backend
         .open_tab(&TabOptions {
@@ -71,15 +69,16 @@ fn closing_agent_pane_records_end_trace_when_session_survives_without_sidebar() 
         .expect("open agent tab");
     wait_for_path(&ready, "agent shim did not start");
 
-    close_all_sidebar_panes(xdg.path(), &workspace.session_name);
+    close_all_sidebar_panes(&room);
     assert!(
         wait_for_live_session(&backend, &workspace.session_name).contains(&workspace.session_name),
         "session should stay live after removing every sidebar",
     );
 
-    let work = wait_for_named_work_pane_count(xdg.path(), &workspace.session_name, tab_name, 1);
+    let work = wait_for_named_work_pane_count(xdg, &workspace.session_name, tab_name, 1);
     let pane_id = format!("terminal_{}", work[0].id);
-    let closed = scoped_zellij(xdg.path())
+    let closed = room
+        .command()
         .args([
             "--session",
             &workspace.session_name,
@@ -189,8 +188,8 @@ fn zellij_agent_exec_command(
     argv
 }
 
-fn close_all_sidebar_panes(xdg: &Path, session: &str) {
-    let panes = expect_list_panes(xdg, session);
+fn close_all_sidebar_panes(session: &LiveZellijSession) {
+    let panes = expect_list_panes(session.path(), session.name());
     let sidebar_ids: Vec<String> = panes
         .panes
         .iter()
@@ -203,10 +202,11 @@ fn close_all_sidebar_panes(xdg: &Path, session: &str) {
         "test setup should create at least one sidebar pane",
     );
     for pane_id in sidebar_ids {
-        let output = scoped_zellij(xdg)
+        let output = session
+            .command()
             .args([
                 "--session",
-                session,
+                session.name(),
                 "action",
                 "close-pane",
                 "--pane-id",
@@ -220,7 +220,7 @@ fn close_all_sidebar_panes(xdg: &Path, session: &str) {
             String::from_utf8_lossy(&output.stderr),
         );
     }
-    wait_for_no_sidebar_panes(xdg, session);
+    wait_for_no_sidebar_panes(session.path(), session.name());
 }
 
 fn wait_for_no_sidebar_panes(xdg: &Path, session: &str) {

--- a/crates/rimz/tests/integration/backend/zellij/self_close.rs
+++ b/crates/rimz/tests/integration/backend/zellij/self_close.rs
@@ -43,20 +43,18 @@ fn sidebar_self_closes_when_its_tab_empties() {
         }
     }
 
-    let name = unique_session_name("selfclose");
+    let room = LiveZellijSession::new("selfclose");
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
-    let xdg = scoped_runtime_dir();
-    seed_presence_permissions(xdg.path(), &wasm);
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
+    let xdg = room.path();
+    seed_presence_permissions(xdg, &wasm);
 
-    let layout = self_close_layout(&name, &rimz, xdg.path());
+    let layout = self_close_layout(&name, &rimz, xdg);
     let layout_path = cwd.path().join("layout.kdl");
     std::fs::write(&layout_path, layout).expect("write layout");
 
-    let created = scoped_zellij(xdg.path())
+    let created = room
+        .command()
         .args(["attach", "--create-background", &name, "options"])
         .arg("--default-cwd")
         .arg(cwd.path())
@@ -65,10 +63,9 @@ fn sidebar_self_closes_when_its_tab_empties() {
         .bounded_status()
         .expect("create background session");
     assert!(created.success(), "create-background failed for {name}");
+    room.wait_until_ready();
 
-    let session = ZellijSession::attach_existing(xdg, name.clone());
-    let xdg = session.xdg.path();
-    wait_for_attached_client(xdg, &name);
+    let _client = AttachedClient::attach(&room, 80, 24);
     ZellijBackend::with_runtime_dir(xdg)
         .ensure_presence_plugin(&rimz::mux::PresencePluginOptions {
             session_name: name.clone(),
@@ -82,9 +79,9 @@ fn sidebar_self_closes_when_its_tab_empties() {
         })
         .expect("load presence plugin for self-close topology");
 
-    wait_for_nonplugin_panes(xdg, &name, 2, Duration::from_secs(15));
+    wait_for_nonplugin_panes(&room, 2, Duration::from_secs(15));
     wait_for_no_serve_processes(&name, Duration::from_secs(15));
-    wait_for_nonplugin_panes(xdg, &name, 0, Duration::from_secs(20));
+    wait_for_nonplugin_panes(&room, 0, Duration::from_secs(20));
 
     let heartbeat_dir = xdg
         .join("rimz")
@@ -97,18 +94,17 @@ fn sidebar_self_closes_when_its_tab_empties() {
 fn split_pane_close_on_exit_removes_a_failed_command() {
     require_zellij!();
 
-    let session = ZellijSession::spawn(unique_session_name("paneclose"));
-    let xdg = session.xdg.path();
-    let target = wait_for_pane_count(xdg, &session.name, 1)[0]
-        .pane_id
-        .clone();
+    let room = LiveZellijSession::new("paneclose");
+    let _client = AttachedClient::create_and_attach(&room, 80, 24);
+    let xdg = room.path();
+    let target = wait_for_pane_count(xdg, room.name(), 1)[0].pane_id.clone();
     let marker_dir = TempDir::new().expect("marker tempdir");
     let marker = marker_dir.path().join("started");
 
     ZellijBackend::with_runtime_dir(xdg)
         .split_pane(SplitPaneOptions {
             target: SplitTarget::SessionPane {
-                session_name: session.name.clone(),
+                session_name: room.name().to_owned(),
                 pane_id: target,
             },
             command: Some(vec![
@@ -134,7 +130,7 @@ fn split_pane_close_on_exit_removes_a_failed_command() {
     poll_until(
         Duration::from_secs(10),
         || {
-            list_panes(xdg, &session.name)
+            list_panes(xdg, room.name())
                 .map(|snapshot| snapshot.panes.iter().filter(|pane| !pane.is_plugin).count())
         },
         |count| *count == 1,
@@ -201,8 +197,10 @@ fn sidebar_serve_command_with_tick(
     )
 }
 
-fn session_nonplugin_count(xdg: &Path, name: &str) -> Result<usize, String> {
-    let output = scoped_zellij(xdg)
+fn session_nonplugin_count(session: &LiveZellijSession) -> Result<usize, String> {
+    let name = session.name();
+    let output = session
+        .command()
         .args(["--session", name, "action", "list-panes", "-j", "-a"])
         .bounded_output()
         .map_err(|err| format!("list panes for {name}: {err}"))?;
@@ -230,11 +228,11 @@ fn session_nonplugin_count(xdg: &Path, name: &str) -> Result<usize, String> {
         .count())
 }
 
-fn wait_for_nonplugin_panes(xdg: &Path, name: &str, target: usize, timeout: Duration) {
+fn wait_for_nonplugin_panes(session: &LiveZellijSession, target: usize, timeout: Duration) {
     poll_until(
         timeout,
-        || session_nonplugin_count(xdg, name),
+        || session_nonplugin_count(session),
         |count| *count == target,
-        &format!("{target} non-plugin panes in {name}"),
+        &format!("{target} non-plugin panes in {}", session.name()),
     );
 }

--- a/crates/rimz/tests/integration/backend/zellij/support/actions.rs
+++ b/crates/rimz/tests/integration/backend/zellij/support/actions.rs
@@ -5,10 +5,10 @@ use std::time::{Duration, Instant};
 
 use rimz::mux::{MuxBackend, SidebarLiveness, SidebarPaneOptions, SidebarRecovery, ZellijBackend};
 
-use crate::common::CommandTimeoutExt;
+use crate::common::{CommandTimeoutExt, ZellijNamespace};
 
 use super::panes::{PaneSnapshot, list_panes};
-use super::session::{DUMP_LAYOUT_ATTEMPTS, DUMP_LAYOUT_RETRY_DELAY, SPAWN_TIMEOUT, scoped_zellij};
+use super::session::{DUMP_LAYOUT_ATTEMPTS, DUMP_LAYOUT_RETRY_DELAY, SPAWN_TIMEOUT};
 
 pub(in crate::backend::zellij) fn poll_until<T: Debug>(
     timeout: Duration,
@@ -36,7 +36,7 @@ pub(in crate::backend::zellij) fn poll_until<T: Debug>(
 
 pub(in crate::backend::zellij) fn open_new_tab(xdg: &Path, session: &str) {
     let before = PaneSnapshot::expect(xdg, session).tab_ids();
-    let output = scoped_zellij(xdg)
+    let output = ZellijNamespace::command_at(xdg)
         .args(["--session", session, "action", "new-tab"])
         .bounded_output()
         .unwrap_or_else(|err| panic!("new-tab failed to run for {session}: {err}"));
@@ -60,7 +60,7 @@ pub(in crate::backend::zellij) fn spawn_sleep_pane(xdg: &Path, session: &str, cw
         .filter(|pane| pane.is_live_terminal() && !pane.is_sidebar())
         .map(|pane| pane.id)
         .collect();
-    let output = scoped_zellij(xdg)
+    let output = ZellijNamespace::command_at(xdg)
         .args(["--session", session, "action", "new-pane", "--cwd"])
         .arg(cwd)
         .args(["--", "sleep", "600"])
@@ -95,7 +95,7 @@ pub(in crate::backend::zellij) fn new_tab_template_dump(xdg: &Path, session: &st
         if attempt > 0 {
             std::thread::sleep(DUMP_LAYOUT_RETRY_DELAY);
         }
-        let output = scoped_zellij(xdg)
+        let output = ZellijNamespace::command_at(xdg)
             .args(["--session", session, "action", "dump-layout"])
             .bounded_output()
             .unwrap_or_else(|err| panic!("dump-layout failed to run for {session}: {err}"));

--- a/crates/rimz/tests/integration/backend/zellij/support/client.rs
+++ b/crates/rimz/tests/integration/backend/zellij/support/client.rs
@@ -1,193 +1,554 @@
 use std::collections::HashSet;
-use std::path::Path;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use rimz::ids::{MuxName, PaneId};
-use rimz::mux::{ClientFocusOptions, MuxBackend, ZellijBackend};
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+use rimz::ids::PaneId;
+use rimz::mux::{ClientFocusOptions, ClientView, MuxBackend, ZellijBackend};
 
-use super::session::SPAWN_TIMEOUT;
+use super::session::{LiveZellijSession, SPAWN_TIMEOUT};
 
-pub(in crate::backend::zellij) fn client_viewed_panes(
+const REGISTRATION_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(15);
+const OUTPUT_TAIL_BYTES: usize = 8 * 1024;
+const CLIENT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const FOCUS_TIMEOUT: Duration = Duration::from_secs(30);
+const INPUT_DELIVERY_TIMEOUT: Duration = Duration::from_secs(30);
+const MARKER_RETYPE_INTERVAL: Duration = Duration::from_millis(500);
+const MARKER_CAPTURE_LINES: u16 = 200;
+
+enum AttachMode {
+    Normal,
+    Create,
+    ExactLineage(String),
+}
+
+pub(in crate::backend::zellij) struct AttachedClient {
+    xdg: PathBuf,
+    name: String,
+    cols: u16,
+    rows: u16,
+    mode: AttachMode,
+    output_tail: Arc<Mutex<Vec<u8>>>,
+    process: AttachedClientProcess,
+}
+
+struct AttachedClientProcess {
+    _master: Box<dyn portable_pty::MasterPty + Send>,
+    writer: Box<dyn Write + Send>,
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+}
+
+impl AttachedClientProcess {
+    fn stop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl AttachedClient {
+    /// Attach to an existing session and return after one new human client is
+    /// stably registered.
+    pub(in crate::backend::zellij) fn attach(
+        session: &LiveZellijSession,
+        cols: u16,
+        rows: u16,
+    ) -> Self {
+        wait_for_human_client_count(session.backend(), session.name(), 0);
+        let mut client = Self::spawn(session, cols, rows, AttachMode::Normal);
+        client.wait_until_registered(1);
+        client
+    }
+
+    /// Create a session through the attached client and return after both the
+    /// client roster and action server are stable.
+    pub(in crate::backend::zellij) fn create_and_attach(
+        session: &LiveZellijSession,
+        cols: u16,
+        rows: u16,
+    ) -> Self {
+        let mut client = Self::spawn(session, cols, rows, AttachMode::Create);
+        client.wait_until_registered(1);
+        session.wait_until_ready();
+        client
+    }
+
+    /// Attach one exact `attach --create` process carrying remote lineage.
+    /// This mode never respawns because the reaper test asserts its PID.
+    pub(in crate::backend::zellij) fn attach_with_lineage(
+        session: &LiveZellijSession,
+        lineage: &str,
+        cols: u16,
+        rows: u16,
+    ) -> Self {
+        Self::spawn(
+            session,
+            cols,
+            rows,
+            AttachMode::ExactLineage(lineage.to_owned()),
+        )
+    }
+
+    fn spawn(session: &LiveZellijSession, cols: u16, rows: u16, mode: AttachMode) -> Self {
+        let output_tail = Arc::new(Mutex::new(Vec::new()));
+        let process = spawn_process_at(
+            session.path(),
+            session.name(),
+            cols,
+            rows,
+            &mode,
+            Arc::clone(&output_tail),
+        );
+        Self {
+            xdg: session.namespace().path().to_path_buf(),
+            name: session.name().to_owned(),
+            cols,
+            rows,
+            mode,
+            output_tail,
+            process,
+        }
+    }
+
+    fn respawn(&mut self) {
+        assert!(
+            !matches!(self.mode, AttachMode::ExactLineage(_)),
+            "exact-lineage clients cannot respawn"
+        );
+        self.process.stop();
+        self.process = spawn_process_at(
+            &self.xdg,
+            &self.name,
+            self.cols,
+            self.rows,
+            &self.mode,
+            Arc::clone(&self.output_tail),
+        );
+    }
+
+    fn wait_until_registered(&mut self, expected_clients: usize) {
+        let deadline = Instant::now() + SPAWN_TIMEOUT;
+        let mut attempt_started = Instant::now();
+        let mut attempts = 1;
+        let mut consecutive_registrations = 0;
+        let mut consecutive_terminal_views = 0;
+        let mut last_human_clients = 0;
+        let mut last_terminal_view = Vec::new();
+        let mut last_error = String::new();
+        let mut last_exit_status = None;
+        let backend = ZellijBackend::with_runtime_dir(&self.xdg);
+
+        loop {
+            if let Some(status) = self.exit_status() {
+                last_exit_status = Some(status.to_string());
+                if Instant::now() >= deadline {
+                    break;
+                }
+                std::thread::sleep(CLIENT_POLL_INTERVAL);
+                self.respawn();
+                attempts += 1;
+                attempt_started = Instant::now();
+                consecutive_registrations = 0;
+                consecutive_terminal_views = 0;
+                continue;
+            }
+
+            match observe_client_view(&backend, &self.name) {
+                Ok(view) => {
+                    last_human_clients = view.presence.human_clients;
+                    last_terminal_view = view.viewed_panes;
+                    last_error.clear();
+                    if last_human_clients == expected_clients {
+                        consecutive_registrations += 1;
+                        if consecutive_registrations >= 2 && !last_terminal_view.is_empty() {
+                            consecutive_terminal_views += 1;
+                            if consecutive_terminal_views == 2 {
+                                return;
+                            }
+                        } else {
+                            consecutive_terminal_views = 0;
+                        }
+                    } else {
+                        consecutive_registrations = 0;
+                        consecutive_terminal_views = 0;
+                    }
+                }
+                Err(error) => {
+                    last_error = error;
+                    consecutive_registrations = 0;
+                    consecutive_terminal_views = 0;
+                }
+            }
+
+            let now = Instant::now();
+            if now >= deadline {
+                break;
+            }
+            if now.duration_since(attempt_started) >= REGISTRATION_ATTEMPT_TIMEOUT {
+                self.respawn();
+                attempts += 1;
+                attempt_started = Instant::now();
+                consecutive_registrations = 0;
+                consecutive_terminal_views = 0;
+                continue;
+            }
+            std::thread::sleep(CLIENT_POLL_INTERVAL);
+        }
+
+        let current_status = self
+            .exit_status()
+            .map(|status| status.to_string())
+            .unwrap_or_else(|| "running".to_owned());
+        panic!(
+            "attached client for {} did not become registered and terminal-ready within {:?}; attempts: {attempts}; expected human clients: {expected_clients}; last human clients: {last_human_clients}; last terminal view: {last_terminal_view:?}; last probe error: {last_error}; current child status: {current_status}; last exited attempt: {last_exit_status:?}; PTY output tail: {:?}",
+            self.name,
+            SPAWN_TIMEOUT,
+            self.output_tail(),
+        );
+    }
+
+    pub(in crate::backend::zellij) fn view(&self) -> ClientView {
+        observe_client_view(&ZellijBackend::with_runtime_dir(&self.xdg), &self.name)
+            .unwrap_or_else(|error| panic!("client view for {}: {error}", self.name))
+    }
+
+    pub(in crate::backend::zellij) fn wait_until_focused(
+        &self,
+        want: &PaneId,
+        context: &str,
+    ) -> Vec<PaneId> {
+        self.wait_for_stable_focus(want, context, None)
+    }
+
+    pub(in crate::backend::zellij) fn press_alt_until(
+        &mut self,
+        key: char,
+        want: &PaneId,
+        context: &str,
+    ) -> Vec<PaneId> {
+        self.converge_focus(want, context, |client| client.press_alt(key))
+    }
+
+    pub(in crate::backend::zellij) fn go_to_tab_until(
+        &mut self,
+        tab: u8,
+        want: &PaneId,
+        context: &str,
+    ) -> Vec<PaneId> {
+        self.converge_focus(want, context, |client| client.go_to_tab(tab))
+    }
+
+    fn converge_focus(
+        &mut self,
+        want: &PaneId,
+        context: &str,
+        mut nudge: impl FnMut(&mut Self),
+    ) -> Vec<PaneId> {
+        let deadline = Instant::now() + FOCUS_TIMEOUT;
+        let backend = ZellijBackend::with_runtime_dir(&self.xdg);
+        let mut stable = 0;
+        let mut attempts = 0;
+        let mut last_view = Vec::new();
+        let mut last_error = String::new();
+        loop {
+            match observe_client_view(&backend, &self.name) {
+                Ok(view) => {
+                    last_view = view.viewed_panes;
+                    last_error.clear();
+                    if last_view.contains(want) {
+                        stable += 1;
+                        if stable == 2 {
+                            return last_view;
+                        }
+                    } else {
+                        stable = 0;
+                        nudge(self);
+                        attempts += 1;
+                    }
+                }
+                Err(error) => {
+                    last_error = error;
+                    stable = 0;
+                    nudge(self);
+                    attempts += 1;
+                }
+            }
+            if Instant::now() >= deadline {
+                panic!(
+                    "timed out focusing {context} ({want}) through the attached client in {}; attempts: {attempts}; last client view: {last_view:?}; last error: {last_error}",
+                    self.name,
+                );
+            }
+            std::thread::sleep(CLIENT_POLL_INTERVAL);
+        }
+    }
+
+    fn wait_for_stable_focus(
+        &self,
+        want: &PaneId,
+        context: &str,
+        timeout: Option<Duration>,
+    ) -> Vec<PaneId> {
+        let deadline = Instant::now() + timeout.unwrap_or(FOCUS_TIMEOUT);
+        let backend = ZellijBackend::with_runtime_dir(&self.xdg);
+        let mut stable = 0;
+        let mut last_view = Vec::new();
+        let mut last_error = String::new();
+        loop {
+            match observe_client_view(&backend, &self.name) {
+                Ok(view) => {
+                    last_view = view.viewed_panes;
+                    last_error.clear();
+                    if last_view.contains(want) {
+                        stable += 1;
+                        if stable == 2 {
+                            return last_view;
+                        }
+                    } else {
+                        stable = 0;
+                    }
+                }
+                Err(error) => {
+                    last_error = error;
+                    stable = 0;
+                }
+            }
+            if Instant::now() >= deadline {
+                panic!(
+                    "timed out waiting for {context} ({want}) in {}; last client view: {last_view:?}; last error: {last_error}",
+                    self.name,
+                );
+            }
+            std::thread::sleep(CLIENT_POLL_INTERVAL);
+        }
+    }
+
+    /// Prove stable routed input with two unique markers in target scrollback.
+    pub(in crate::backend::zellij) fn assert_input_reaches(
+        &mut self,
+        want: &PaneId,
+        context: &str,
+    ) {
+        let backend = ZellijBackend::with_runtime_dir(&self.xdg);
+        let work_panes: HashSet<_> = super::panes::PaneSnapshot::expect(&self.xdg, &self.name)
+            .panes
+            .iter()
+            .filter(|pane| pane.is_live_terminal() && !pane.is_sidebar())
+            .map(|pane| pane.pane_ref(&self.name).pane_id)
+            .collect();
+        let deadline = Instant::now() + INPUT_DELIVERY_TIMEOUT;
+        let marker = format!("rimz-routed-{}", uuid::Uuid::now_v7().simple());
+        let markers = [marker.clone(), format!("{marker}-confirmed")];
+        let mut marker_index = 0;
+        let mut next_sample_at = Instant::now();
+        let mut last_capture = String::new();
+        let mut last_view = Vec::new();
+        let mut last_capture_error = String::new();
+        let mut last_view_error = String::new();
+        loop {
+            if Instant::now() >= next_sample_at {
+                next_sample_at = Instant::now() + MARKER_RETYPE_INTERVAL;
+                match observe_client_view(&backend, &self.name) {
+                    Ok(view) => {
+                        if view
+                            .viewed_panes
+                            .iter()
+                            .any(|pane| work_panes.contains(pane))
+                        {
+                            self.send_line(&markers[marker_index]);
+                        }
+                        last_view = view.viewed_panes;
+                        last_view_error.clear();
+                    }
+                    Err(error) => last_view_error = error,
+                }
+            }
+            match backend.capture_pane(want, Some(MARKER_CAPTURE_LINES), false) {
+                Ok(capture) => {
+                    if capture.raw_text.contains(&markers[marker_index]) {
+                        if marker_index + 1 == markers.len() {
+                            return;
+                        }
+                        marker_index += 1;
+                        next_sample_at = Instant::now() + MARKER_RETYPE_INTERVAL;
+                    }
+                    last_capture = capture.raw_text;
+                    last_capture_error.clear();
+                }
+                Err(error) => last_capture_error = error.to_string(),
+            }
+            if Instant::now() >= deadline {
+                panic!(
+                    "attached input did not settle on {context} ({want}) in {}; pending marker: {}; last client view: {last_view:?}; last capture: {last_capture:?}; last view error: {last_view_error}; last capture error: {last_capture_error}",
+                    self.name, markers[marker_index],
+                );
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    pub(in crate::backend::zellij) fn press_alt(&mut self, key: char) {
+        self.process
+            .writer
+            .write_all(&[0x1b, key as u8])
+            .expect("write alt key");
+        self.process.writer.flush().expect("flush alt key");
+    }
+
+    pub(in crate::backend::zellij) fn go_to_tab(&mut self, tab: u8) {
+        assert!((1..=9).contains(&tab), "test helper supports tabs 1-9");
+        self.process
+            .writer
+            .write_all(&[0x14, b'0' + tab])
+            .expect("write tab-mode key sequence");
+        self.process
+            .writer
+            .flush()
+            .expect("flush tab-mode key sequence");
+    }
+
+    pub(in crate::backend::zellij) fn send_line(&mut self, line: &str) {
+        self.process
+            .writer
+            .write_all(line.as_bytes())
+            .expect("write line");
+        self.process.writer.write_all(b"\r").expect("write enter");
+        self.process.writer.flush().expect("flush line");
+    }
+
+    pub(in crate::backend::zellij) fn pid(&self) -> u32 {
+        self.process
+            .child
+            .process_id()
+            .expect("attached client process id")
+    }
+
+    pub(in crate::backend::zellij) fn exit_status(&mut self) -> Option<portable_pty::ExitStatus> {
+        self.process.child.try_wait().ok().flatten()
+    }
+
+    fn output_tail(&self) -> String {
+        let tail = self
+            .output_tail
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        String::from_utf8_lossy(&tail).into_owned()
+    }
+}
+
+impl Drop for AttachedClient {
+    fn drop(&mut self) {
+        self.process.stop();
+    }
+}
+
+fn spawn_process_at(
+    xdg: &std::path::Path,
+    name: &str,
+    cols: u16,
+    rows: u16,
+    mode: &AttachMode,
+    output_tail: Arc<Mutex<Vec<u8>>>,
+) -> AttachedClientProcess {
+    let pair = native_pty_system()
+        .openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("openpty");
+    let mut command = CommandBuilder::new("zellij");
+    crate::common::ZellijNamespace::pin_pty_at(xdg, &mut command);
+    if let AttachMode::ExactLineage(lineage) = mode {
+        command.env(rimz::remote::REMOTE_LINEAGE_ENV, lineage);
+    }
+    match mode {
+        AttachMode::Normal => command.args(["attach", name]),
+        AttachMode::Create | AttachMode::ExactLineage(_) => {
+            command.args(["attach", "--create", name])
+        }
+    };
+    let child = pair
+        .slave
+        .spawn_command(command)
+        .expect("spawn zellij attach");
+    drop(pair.slave);
+    let writer = pair.master.take_writer().expect("PTY writer");
+    let mut reader = pair.master.try_clone_reader().expect("clone reader");
+    std::thread::spawn(move || {
+        let mut buffer = [0u8; 4096];
+        loop {
+            match reader.read(&mut buffer) {
+                Ok(0) | Err(_) => return,
+                Ok(read) => {
+                    let mut tail = output_tail
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    tail.extend_from_slice(&buffer[..read]);
+                    let excess = tail.len().saturating_sub(OUTPUT_TAIL_BYTES);
+                    if excess > 0 {
+                        tail.drain(..excess);
+                    }
+                }
+            }
+        }
+    });
+    AttachedClientProcess {
+        _master: pair.master,
+        writer,
+        child,
+    }
+}
+
+pub(in crate::backend::zellij) fn observe_client_view(
     backend: &ZellijBackend,
     session: &str,
-) -> Result<Vec<PaneId>, String> {
+) -> Result<ClientView, String> {
     backend
         .client_view(ClientFocusOptions {
             session_name: Some(session.to_owned()),
             ..Default::default()
         })
-        .map(|view| view.viewed_panes)
-        .map_err(|err| err.to_string())
+        .map_err(|error| error.to_string())
 }
 
-pub(in crate::backend::zellij) fn wait_for_attached_client(xdg: &Path, session: &str) {
-    wait_for_client_view_count(xdg, session, 1);
-}
-
-pub(in crate::backend::zellij) fn wait_for_client_view_count(
-    xdg: &Path,
+/// Observe an explicit attached/detached client-count assertion.
+pub(in crate::backend::zellij) fn wait_for_human_client_count(
+    backend: &ZellijBackend,
     session: &str,
     want: usize,
-) -> Vec<PaneId> {
+) -> ClientView {
     let deadline = Instant::now() + SPAWN_TIMEOUT;
     let mut consecutive_matches = 0;
-    let mut last_view = Vec::new();
+    let mut last_view = ClientView::default();
     let mut last_error = String::new();
-    let backend = ZellijBackend::with_runtime_dir(xdg);
     loop {
-        match client_viewed_panes(&backend, session) {
-            Ok(view) if view.len() == want => {
+        match observe_client_view(backend, session) {
+            Ok(view) => {
+                consecutive_matches = if view.presence.human_clients == want {
+                    consecutive_matches + 1
+                } else {
+                    0
+                };
                 last_view = view;
                 last_error.clear();
-                consecutive_matches += 1;
                 if consecutive_matches == 2 {
                     return last_view;
                 }
             }
-            Ok(view) => {
-                last_view = view;
-                last_error.clear();
-                consecutive_matches = 0;
-            }
-            Err(err) => {
-                last_error = err;
+            Err(error) => {
+                last_error = error;
                 consecutive_matches = 0;
             }
         }
         if Instant::now() >= deadline {
             panic!(
-                "client view for {session} did not stabilize at {want} panes; last view: {last_view:?}; last error: {last_error}"
+                "human client count for {session} did not stabilize at {want}; last count: {}; last terminal view: {:?}; last error: {last_error}",
+                last_view.presence.human_clients, last_view.viewed_panes,
             );
         }
-        std::thread::sleep(Duration::from_millis(100));
+        std::thread::sleep(CLIENT_POLL_INTERVAL);
     }
-}
-
-pub(in crate::backend::zellij) fn focus_attached_client_pane_until(
-    xdg: &Path,
-    session: &str,
-    want: u64,
-    context: &str,
-    mut focus_next: impl FnMut(),
-) {
-    let deadline = Instant::now() + Duration::from_secs(30);
-    let backend = ZellijBackend::with_runtime_dir(xdg);
-    let pane_id = PaneId::from_parts(MuxName::Zellij, format!("terminal_{want}"));
-    let mut last_view = Vec::new();
-    let mut last_error = String::new();
-    let mut attempts = 0;
-    loop {
-        match client_viewed_panes(&backend, session) {
-            Ok(viewed) => {
-                if viewed.contains(&pane_id) {
-                    return;
-                }
-                last_view = viewed;
-            }
-            Err(err) => last_error = err.to_string(),
-        }
-        if Instant::now() >= deadline {
-            panic!(
-                "timed out focusing {context} ({pane_id}) through the attached client in {session}; attempts: {attempts}; last client view: {last_view:?}; last error: {last_error}"
-            );
-        }
-        focus_next();
-        attempts += 1;
-        std::thread::sleep(Duration::from_millis(100));
-    }
-}
-
-/// How long a typed marker has to surface in the target pane's buffer.
-const INPUT_DELIVERY_TIMEOUT: Duration = Duration::from_secs(30);
-/// Cadence for re-reading the client view and retyping the marker. Requiring a
-/// second delivery after this interval proves that routing settled rather than
-/// merely crossing the target during the relayout.
-const MARKER_RETYPE_INTERVAL: Duration = Duration::from_millis(500);
-/// Capture depth for the marker search. A `stack-panes` repair leaves every
-/// unfocused stack member one row tall, which pushes an already-echoed marker
-/// out of the viewport, so search the scrollback rather than the visible grid.
-const MARKER_CAPTURE_LINES: u16 = 200;
-
-/// Assert that what the attached client types lands in `want`.
-///
-/// Routed input and target capture are the decision channel. Zellij can route a
-/// `focus-pane-id` action before `list-clients` publishes a causally matching
-/// view, so the client view is advisory: it keeps test text away from sidebar
-/// panes and supplies failure context, but it does not gate on naming `want`.
-/// Two captured markers separated by [`MARKER_RETYPE_INTERVAL`] prove that the
-/// client settled on the target instead of crossing it during the relayout.
-pub(in crate::backend::zellij) fn assert_client_input_reaches_pane(
-    xdg: &Path,
-    session: &str,
-    want: u64,
-    context: &str,
-    mut send_line: impl FnMut(&str),
-) {
-    let pane_id = PaneId::from_parts(MuxName::Zellij, format!("terminal_{want}"));
-    let backend = ZellijBackend::with_runtime_dir(xdg);
-    let work_panes: HashSet<_> = super::panes::PaneSnapshot::expect(xdg, session)
-        .panes
-        .iter()
-        .filter(|pane| pane.is_live_terminal() && !pane.is_sidebar())
-        .map(|pane| pane.pane_ref(session).pane_id)
-        .collect();
-
-    let deadline = Instant::now() + INPUT_DELIVERY_TIMEOUT;
-    let marker = format!("rimz-routed-{}", uuid::Uuid::now_v7().simple());
-    let markers = [marker.clone(), format!("{marker}-confirmed")];
-    let mut marker_index = 0;
-    let mut next_sample_at = Instant::now();
-    let mut last_capture = String::new();
-    let mut last_view = Vec::new();
-    let mut last_capture_error = String::new();
-    let mut last_view_error = String::new();
-    loop {
-        if Instant::now() >= next_sample_at {
-            next_sample_at = Instant::now() + MARKER_RETYPE_INTERVAL;
-            match client_viewed_panes(&backend, session) {
-                Ok(viewed) => {
-                    if viewed.iter().any(|pane| work_panes.contains(pane)) {
-                        send_line(&markers[marker_index]);
-                    }
-                    last_view = viewed;
-                    last_view_error.clear();
-                }
-                Err(err) => last_view_error = err,
-            }
-        }
-        match backend.capture_pane(&pane_id, Some(MARKER_CAPTURE_LINES), false) {
-            Ok(capture) => {
-                if capture.raw_text.contains(&markers[marker_index]) {
-                    if marker_index + 1 == markers.len() {
-                        return;
-                    }
-                    marker_index += 1;
-                    next_sample_at = Instant::now() + MARKER_RETYPE_INTERVAL;
-                }
-                last_capture = capture.raw_text;
-                last_capture_error.clear();
-            }
-            Err(err) => last_capture_error = err.to_string(),
-        }
-        if Instant::now() >= deadline {
-            panic!(
-                "attached input did not settle on {context} ({pane_id}) in {session}; pending marker: {}; last client view: {last_view:?}; last capture: {last_capture:?}; last view error: {last_view_error}; last capture error: {last_capture_error}",
-                markers[marker_index],
-            );
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-}
-
-pub(in crate::backend::zellij) fn wait_for_focused_client_pane(
-    backend: &ZellijBackend,
-    session: &str,
-    want: &PaneId,
-) -> Vec<PaneId> {
-    super::actions::poll_until(
-        Duration::from_secs(30),
-        || client_viewed_panes(backend, session),
-        |focused| focused.contains(want),
-        &format!("client focus on {want}"),
-    )
 }

--- a/crates/rimz/tests/integration/backend/zellij/support/client.rs
+++ b/crates/rimz/tests/integration/backend/zellij/support/client.rs
@@ -70,7 +70,7 @@ pub(in crate::backend::zellij) fn focus_attached_client_pane_until(
     context: &str,
     mut focus_next: impl FnMut(),
 ) {
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + Duration::from_secs(30);
     let backend = ZellijBackend::with_runtime_dir(xdg);
     let pane_id = PaneId::from_parts(MuxName::Zellij, format!("terminal_{want}"));
     let mut last_view = Vec::new();
@@ -98,7 +98,7 @@ pub(in crate::backend::zellij) fn focus_attached_client_pane_until(
 }
 
 /// How long a typed marker has to surface in the target pane's buffer.
-const INPUT_DELIVERY_TIMEOUT: Duration = Duration::from_secs(10);
+const INPUT_DELIVERY_TIMEOUT: Duration = Duration::from_secs(30);
 /// Cadence for re-reading the client view and retyping the marker. Requiring a
 /// second delivery after this interval proves that routing settled rather than
 /// merely crossing the target during the relayout.
@@ -185,7 +185,7 @@ pub(in crate::backend::zellij) fn wait_for_focused_client_pane(
     want: &PaneId,
 ) -> Vec<PaneId> {
     super::actions::poll_until(
-        Duration::from_secs(10),
+        Duration::from_secs(30),
         || client_viewed_panes(backend, session),
         |focused| focused.contains(want),
         &format!("client focus on {want}"),

--- a/crates/rimz/tests/integration/backend/zellij/support/layout.rs
+++ b/crates/rimz/tests/integration/backend/zellij/support/layout.rs
@@ -70,7 +70,7 @@ pub(in crate::backend::zellij) fn wait_for_named_sidebar_pane(
     tab_name: &str,
 ) -> Option<PaneGeometry> {
     poll_until(
-        Duration::from_secs(10),
+        Duration::from_secs(30),
         || named_sidebar_pane_geometry(xdg, session, tab_name),
         Option::is_some,
         &format!("sidebar pane in {session}/{tab_name}"),
@@ -86,7 +86,7 @@ pub(in crate::backend::zellij) fn wait_for_named_work_pane_state(
 ) -> Vec<PaneGeometry> {
     let mut ready = ready;
     poll_until(
-        Duration::from_secs(10),
+        Duration::from_secs(30),
         || named_work_pane_geometry(xdg, session, tab_name),
         |work| work.len() == want && ready(work),
         &format!("{want} work panes in {session}/{tab_name}"),

--- a/crates/rimz/tests/integration/backend/zellij/support/panes.rs
+++ b/crates/rimz/tests/integration/backend/zellij/support/panes.rs
@@ -5,10 +5,10 @@ use rimz::ids::{MuxName, PaneId, ViewKind};
 use rimz::pane::PaneRef;
 use serde::Deserialize;
 
-use crate::common::CommandTimeoutExt;
+use crate::common::{CommandTimeoutExt, ZellijNamespace};
 
 use super::session::{
-    LIST_PANES_JSON_ATTEMPTS, LIST_PANES_JSON_RETRY_DELAY, LIST_PANES_JSON_TIMEOUT, scoped_zellij,
+    LIST_PANES_JSON_ATTEMPTS, LIST_PANES_JSON_RETRY_DELAY, LIST_PANES_JSON_TIMEOUT,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -114,7 +114,7 @@ impl PaneSnapshot {
     pub(in crate::backend::zellij) fn load(xdg: &Path, session: &str) -> Result<Self, String> {
         let mut last_error = "list-panes was not run".to_owned();
         for attempt in 0..LIST_PANES_JSON_ATTEMPTS {
-            match scoped_zellij(xdg)
+            match ZellijNamespace::command_at(xdg)
                 .args(["--session", session, "action", "list-panes", "-j", "-a"])
                 .bounded_output_within(LIST_PANES_JSON_TIMEOUT)
             {

--- a/crates/rimz/tests/integration/backend/zellij/support/session.rs
+++ b/crates/rimz/tests/integration/backend/zellij/support/session.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::mpsc;
+use std::sync::{Arc, Mutex, mpsc};
 use std::time::{Duration, Instant};
 
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
@@ -21,6 +21,9 @@ pub(in crate::backend::zellij) const LIST_PANES_JSON_RETRY_DELAY: Duration =
     Duration::from_millis(50);
 pub(in crate::backend::zellij) const DUMP_LAYOUT_ATTEMPTS: u32 = 10;
 pub(in crate::backend::zellij) const DUMP_LAYOUT_RETRY_DELAY: Duration = Duration::from_millis(100);
+
+const ATTACHED_CLIENT_REGISTRATION_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(15);
+const ATTACHED_CLIENT_OUTPUT_TAIL_BYTES: usize = 8 * 1024;
 
 pub(in crate::backend::zellij) fn tiled_column(panes: Vec<PaneCmd>) -> LayoutColumn {
     LayoutColumn {
@@ -253,14 +256,34 @@ impl Drop for ZellijSession {
 /// geometry (a background birth is tiny until a client attaches). Drop kills
 /// the client; session teardown stays with [`ScopedSessionCleanup`].
 pub(in crate::backend::zellij) struct AttachedClient {
+    xdg: PathBuf,
+    name: String,
+    cols: u16,
+    rows: u16,
+    lineage: Option<String>,
+    create: bool,
+    output_tail: Arc<Mutex<Vec<u8>>>,
+    process: AttachedClientProcess,
+}
+
+struct AttachedClientProcess {
     _master: Box<dyn portable_pty::MasterPty + Send>,
     writer: Box<dyn Write + Send>,
     child: Box<dyn portable_pty::Child + Send + Sync>,
 }
 
+impl AttachedClientProcess {
+    fn stop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
 impl AttachedClient {
     pub(in crate::backend::zellij) fn attach(xdg: &Path, name: &str, cols: u16, rows: u16) -> Self {
-        Self::attach_inner(xdg, name, cols, rows, None, false)
+        let mut client = Self::attach_inner(xdg, name, cols, rows, None, false);
+        client.wait_until_registered();
+        client
     }
 
     /// Attach carrying a remote lineage, under the exact `attach --create
@@ -285,6 +308,37 @@ impl AttachedClient {
         lineage: Option<&str>,
         create: bool,
     ) -> Self {
+        let output_tail = Arc::new(Mutex::new(Vec::new()));
+        let process = Self::spawn_process(
+            xdg,
+            name,
+            cols,
+            rows,
+            lineage,
+            create,
+            Arc::clone(&output_tail),
+        );
+        Self {
+            xdg: xdg.to_path_buf(),
+            name: name.to_owned(),
+            cols,
+            rows,
+            lineage: lineage.map(str::to_owned),
+            create,
+            output_tail,
+            process,
+        }
+    }
+
+    fn spawn_process(
+        xdg: &Path,
+        name: &str,
+        cols: u16,
+        rows: u16,
+        lineage: Option<&str>,
+        create: bool,
+        output_tail: Arc<Mutex<Vec<u8>>>,
+    ) -> AttachedClientProcess {
         let pair = native_pty_system()
             .openpty(PtySize {
                 rows,
@@ -316,61 +370,170 @@ impl AttachedClient {
         drop(pair.slave);
         let writer = pair.master.take_writer().expect("PTY writer");
         // Drain the PTY in the background so the kernel buffer never fills and
-        // stalls the client; the thread exits with the PTY on drop.
+        // stalls the client. Keep a bounded tail so registration failures name
+        // what the attach process reported instead of timing out silently.
         let mut reader = pair.master.try_clone_reader().expect("clone reader");
         std::thread::spawn(move || {
             let mut buf = [0u8; 4096];
             loop {
                 match reader.read(&mut buf) {
                     Ok(0) | Err(_) => return,
-                    Ok(_) => continue,
+                    Ok(read) => {
+                        let mut tail = output_tail
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        tail.extend_from_slice(&buf[..read]);
+                        let excess = tail.len().saturating_sub(ATTACHED_CLIENT_OUTPUT_TAIL_BYTES);
+                        if excess > 0 {
+                            tail.drain(..excess);
+                        }
+                    }
                 }
             }
         });
-        Self {
+        AttachedClientProcess {
             _master: pair.master,
             writer,
             child,
         }
     }
 
+    fn respawn(&mut self) {
+        self.process.stop();
+        self.process = Self::spawn_process(
+            &self.xdg,
+            &self.name,
+            self.cols,
+            self.rows,
+            self.lineage.as_deref(),
+            self.create,
+            Arc::clone(&self.output_tail),
+        );
+    }
+
+    fn wait_until_registered(&mut self) {
+        let deadline = Instant::now() + SPAWN_TIMEOUT;
+        let mut attempt_started = Instant::now();
+        let mut attempts = 1;
+        let mut consecutive_matches = 0;
+        let mut last_view = Vec::new();
+        let mut last_error = String::new();
+        let mut last_exit_status = None;
+        let backend = ZellijBackend::with_runtime_dir(&self.xdg);
+
+        loop {
+            if let Some(status) = self.exit_status() {
+                last_exit_status = Some(status.to_string());
+                if Instant::now() >= deadline {
+                    break;
+                }
+                self.respawn();
+                attempts += 1;
+                attempt_started = Instant::now();
+                consecutive_matches = 0;
+                continue;
+            }
+
+            match super::client::client_viewed_panes(&backend, &self.name) {
+                Ok(view) if !view.is_empty() => {
+                    last_view = view;
+                    last_error.clear();
+                    consecutive_matches += 1;
+                    if consecutive_matches == 2 {
+                        return;
+                    }
+                }
+                Ok(view) => {
+                    last_view = view;
+                    last_error.clear();
+                    consecutive_matches = 0;
+                }
+                Err(err) => {
+                    last_error = err;
+                    consecutive_matches = 0;
+                }
+            }
+
+            let now = Instant::now();
+            if now >= deadline {
+                break;
+            }
+            if now.duration_since(attempt_started) >= ATTACHED_CLIENT_REGISTRATION_ATTEMPT_TIMEOUT {
+                self.respawn();
+                attempts += 1;
+                attempt_started = Instant::now();
+                consecutive_matches = 0;
+                continue;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+
+        let child_exit_status = self
+            .exit_status()
+            .map(|status| status.to_string())
+            .unwrap_or_else(|| "running".to_owned());
+        let output_tail = self.output_tail();
+        panic!(
+            "attached client for {} did not register within {:?}; attempts: {attempts}; last view: {last_view:?}; last error: {last_error}; child exit status: {child_exit_status}; last exited attempt: {last_exit_status:?}; PTY output tail: {output_tail:?}",
+            self.name, SPAWN_TIMEOUT,
+        );
+    }
+
+    fn output_tail(&self) -> String {
+        let tail = self
+            .output_tail
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        String::from_utf8_lossy(&tail).into_owned()
+    }
+
     pub(in crate::backend::zellij) fn press_alt(&mut self, key: char) {
-        self.writer
+        self.process
+            .writer
             .write_all(&[0x1b, key as u8])
             .expect("write alt key");
-        self.writer.flush().expect("flush alt key");
+        self.process.writer.flush().expect("flush alt key");
     }
 
     pub(in crate::backend::zellij) fn pid(&self) -> u32 {
-        self.child.process_id().expect("attached client process id")
+        self.process
+            .child
+            .process_id()
+            .expect("attached client process id")
     }
 
     /// The client's exit status once it has stopped, and `None` while it runs.
     /// A wait that depends on this client being registered with the server can
     /// end the moment the client is gone.
     pub(in crate::backend::zellij) fn exit_status(&mut self) -> Option<portable_pty::ExitStatus> {
-        self.child.try_wait().ok().flatten()
+        self.process.child.try_wait().ok().flatten()
     }
 
     pub(in crate::backend::zellij) fn go_to_tab(&mut self, tab: u8) {
         assert!((1..=9).contains(&tab), "test helper supports tabs 1-9");
-        self.writer
+        self.process
+            .writer
             .write_all(&[0x14, b'0' + tab])
             .expect("write tab-mode key sequence");
-        self.writer.flush().expect("flush tab-mode key sequence");
+        self.process
+            .writer
+            .flush()
+            .expect("flush tab-mode key sequence");
     }
 
     pub(in crate::backend::zellij) fn send_line(&mut self, line: &str) {
-        self.writer.write_all(line.as_bytes()).expect("write line");
-        self.writer.write_all(b"\r").expect("write enter");
-        self.writer.flush().expect("flush line");
+        self.process
+            .writer
+            .write_all(line.as_bytes())
+            .expect("write line");
+        self.process.writer.write_all(b"\r").expect("write enter");
+        self.process.writer.flush().expect("flush line");
     }
 }
 
 impl Drop for AttachedClient {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        self.process.stop();
     }
 }
 

--- a/crates/rimz/tests/integration/backend/zellij/support/session.rs
+++ b/crates/rimz/tests/integration/backend/zellij/support/session.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
-use std::io::{Read, Write};
+use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, mpsc};
+use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
@@ -11,7 +11,7 @@ use rimz::mux::{
 };
 use tempfile::TempDir;
 
-use crate::common::{CommandTimeoutExt, ScrubSessionEnvExt};
+use crate::common::{CommandTimeoutExt, ScrubSessionEnvExt, ZellijNamespace};
 
 pub(in crate::backend::zellij) const SPAWN_TIMEOUT: Duration = Duration::from_secs(60);
 pub(in crate::backend::zellij) const LIST_PANES_JSON_TIMEOUT: Duration =
@@ -21,9 +21,6 @@ pub(in crate::backend::zellij) const LIST_PANES_JSON_RETRY_DELAY: Duration =
     Duration::from_millis(50);
 pub(in crate::backend::zellij) const DUMP_LAYOUT_ATTEMPTS: u32 = 10;
 pub(in crate::backend::zellij) const DUMP_LAYOUT_RETRY_DELAY: Duration = Duration::from_millis(100);
-
-const ATTACHED_CLIENT_REGISTRATION_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(15);
-const ATTACHED_CLIENT_OUTPUT_TAIL_BYTES: usize = 8 * 1024;
 
 pub(in crate::backend::zellij) fn tiled_column(panes: Vec<PaneCmd>) -> LayoutColumn {
     LayoutColumn {
@@ -84,496 +81,121 @@ pub(in crate::backend::zellij) fn publish_room_bin(state_root: &Path, opts: &Sid
     .expect("publish test workspace record");
 }
 
-pub(in crate::backend::zellij) fn create_plain_background_session(
-    xdg: &Path,
-    name: &str,
-    cwd: &Path,
-    sleep: &str,
-) {
-    let layout = cwd.join("plain.kdl");
-    std::fs::write(
-        &layout,
-        format!("layout {{\n    pane command=\"sleep\" {{\n        args \"{sleep}\"\n    }}\n}}\n"),
-    )
-    .expect("write plain layout");
-    let created = scoped_zellij(xdg)
-        .args(["attach", "--create-background", name, "options"])
-        .arg("--default-cwd")
-        .arg(cwd)
-        .arg("--default-layout")
-        .arg(&layout)
-        .bounded_status()
-        .expect("create plain session");
-    assert!(created.success(), "create-background failed for {name}");
+/// Owns one live Zellij session and the namespace all of its processes share.
+pub(in crate::backend::zellij) struct LiveZellijSession {
+    namespace: ZellijNamespace,
+    name: String,
+    backend: ZellijBackend,
 }
 
-pub(in crate::backend::zellij) fn scoped_runtime_dir() -> TempDir {
-    let dir = tempfile::Builder::new()
-        .prefix("rz")
-        .rand_bytes(6)
-        .tempdir()
-        .expect("xdg runtime tempdir");
-    let zellij_config_dir = dir.path().join(".config").join("zellij");
-    std::fs::create_dir_all(&zellij_config_dir).expect("zellij config dir");
-    std::fs::write(
-        zellij_config_dir.join("config.kdl"),
-        "// Hermetic test config: stock behavior, no first-run wizard or tips UI.\nshow_startup_tips false\nshow_release_notes false\n",
-    )
-    .expect("zellij config.kdl");
-    dir
-}
-
-/// A `zellij` command pinned to `xdg` as `XDG_RUNTIME_DIR`. Every raw `zellij`
-/// call a test makes goes through this one path to stay on the test's private
-/// server — the test-side counterpart to `ZellijBackend::cmd`. The single
-/// chokepoint, so no stray command can leak to the user's default server.
-pub(in crate::backend::zellij) fn scoped_zellij(xdg: &Path) -> std::process::Command {
-    let mut cmd = std::process::Command::new("zellij");
-    cmd.scrub_session_env();
-    // The first command against a runtime dir forks the session server, and
-    // every pane command inherits the server's env — so scope the whole home
-    // surface here, not just the socket root. A real `HOME` leaks the
-    // developer's per-machine config and fleet transcript history into
-    // renderer panes (the snapshot producer then cold-parses minutes of real
-    // `~/.claude` history), and a real `XDG_CONFIG_HOME` leaks their Zellij
-    // config into the session under test. A real `TMPDIR` leaks the test
-    // server's log lines into the user's shared Zellij log.
-    cmd.env("XDG_RUNTIME_DIR", xdg)
-        .env("XDG_STATE_HOME", xdg)
-        .env("XDG_CONFIG_HOME", xdg)
-        .env("XDG_CACHE_HOME", xdg)
-        .env("HOME", xdg)
-        .env("TMPDIR", xdg);
-    cmd
-}
-
-/// Owns a live Zellij session for the duration of one test, on its own private
-/// `XDG_RUNTIME_DIR`. Spawned via a portable-pty so the child has the terminal
-/// it expects; the master is kept alive (and silently drained) to avoid
-/// SIGHUP'ing the session. The runtime dir is held here so it outlives the
-/// session and the `Drop` teardown below.
-pub(in crate::backend::zellij) struct ZellijSession {
-    pub(in crate::backend::zellij) name: String,
-    pub(in crate::backend::zellij) xdg: TempDir,
-    _master: Box<dyn portable_pty::MasterPty + Send>,
-    writer: Box<dyn Write + Send>,
-    _child: Box<dyn portable_pty::Child + Send + Sync>,
-    _reader_thread: Option<std::thread::JoinHandle<()>>,
-}
-
-impl ZellijSession {
-    pub(in crate::backend::zellij) fn spawn(name: impl Into<String>) -> Self {
-        Self::attach_pty(scoped_runtime_dir(), name.into(), true)
+impl LiveZellijSession {
+    /// Create an isolated, not-yet-started session scope.
+    pub(in crate::backend::zellij) fn new(prefix: &str) -> Self {
+        Self::from_namespace(ZellijNamespace::new(), unique_session_name(prefix))
     }
 
-    /// Attach a PTY client to a session that already exists on `xdg` (born via
-    /// `attach --create-background`). A detached server under load can drop a
-    /// pane-exit or relayout outright and only reconciles on the next attach,
-    /// so a test asserting prompt close/resize behaviour keeps a client
-    /// attached for the session's lifetime.
-    pub(in crate::backend::zellij) fn attach_existing(
-        xdg: TempDir,
+    /// Adopt a preconfigured namespace and explicit session name.
+    pub(in crate::backend::zellij) fn from_namespace(
+        namespace: ZellijNamespace,
         name: impl Into<String>,
     ) -> Self {
-        Self::attach_pty(xdg, name.into(), false)
-    }
-
-    pub(in crate::backend::zellij) fn attach_pty(xdg: TempDir, name: String, create: bool) -> Self {
-        let pty_system = native_pty_system();
-        let pair = pty_system
-            .openpty(PtySize {
-                rows: 24,
-                cols: 80,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .expect("openpty");
-        let mut cmd = CommandBuilder::new("zellij");
-        // Pin the attaching client to the test's private server, with the same
-        // hermetic home surface as `scoped_zellij` (the client can be the one
-        // that forks the server). `CommandBuilder` seeds its env from the
-        // current process, so these override and leave PATH and friends intact.
-        cmd.scrub_session_env();
-        cmd.env("XDG_RUNTIME_DIR", xdg.path());
-        cmd.env("XDG_STATE_HOME", xdg.path());
-        cmd.env("XDG_CONFIG_HOME", xdg.path());
-        cmd.env("XDG_CACHE_HOME", xdg.path());
-        cmd.env("HOME", xdg.path());
-        cmd.env("TMPDIR", xdg.path());
-        if create {
-            cmd.args(["attach", "--create", &name]);
-        } else {
-            cmd.args(["attach", &name]);
-        }
-        let child = pair.slave.spawn_command(cmd).expect("spawn zellij");
-        drop(pair.slave);
-        let writer = pair.master.take_writer().expect("pty writer");
-
-        // Drain the PTY in the background so the kernel buffer never fills
-        // and stalls the child. We do not parse anything; the channel of
-        // record is the `zellij action ...` round-trip.
-        let mut reader = pair.master.try_clone_reader().expect("clone reader");
-        let reader_thread = std::thread::spawn(move || {
-            let mut buf = [0u8; 4096];
-            loop {
-                match reader.read(&mut buf) {
-                    Ok(0) | Err(_) => return,
-                    Ok(_) => continue,
-                }
-            }
-        });
-
-        let session = Self {
-            name,
-            xdg,
-            _master: pair.master,
-            writer,
-            _child: child,
-            _reader_thread: Some(reader_thread),
-        };
-        wait_until_session_ready(session.xdg.path(), &session.name);
-        session
-    }
-
-    pub(in crate::backend::zellij) fn press_alt(&mut self, key: char) {
-        self.writer
-            .write_all(&[0x1b, key as u8])
-            .expect("write alt key");
-        self.writer.flush().expect("flush alt key");
-    }
-}
-
-impl Drop for ZellijSession {
-    fn drop(&mut self) {
-        let _ = scoped_zellij(self.xdg.path())
-            .args(["delete-session", &self.name, "--force"])
-            .bounded_output();
-    }
-}
-
-/// A live client attached to an existing session on the test's private server,
-/// held open on a PTY of the given size so the session adopts real terminal
-/// geometry (a background birth is tiny until a client attaches). Drop kills
-/// the client; session teardown stays with [`ScopedSessionCleanup`].
-pub(in crate::backend::zellij) struct AttachedClient {
-    xdg: PathBuf,
-    name: String,
-    cols: u16,
-    rows: u16,
-    lineage: Option<String>,
-    create: bool,
-    output_tail: Arc<Mutex<Vec<u8>>>,
-    process: AttachedClientProcess,
-}
-
-struct AttachedClientProcess {
-    _master: Box<dyn portable_pty::MasterPty + Send>,
-    writer: Box<dyn Write + Send>,
-    child: Box<dyn portable_pty::Child + Send + Sync>,
-}
-
-impl AttachedClientProcess {
-    fn stop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
-    }
-}
-
-impl AttachedClient {
-    pub(in crate::backend::zellij) fn attach(xdg: &Path, name: &str, cols: u16, rows: u16) -> Self {
-        let mut client = Self::attach_inner(xdg, name, cols, rows, None, false);
-        client.wait_until_registered();
-        client
-    }
-
-    /// Attach carrying a remote lineage, under the exact `attach --create
-    /// <session>` argv a production remote attach spawns — the reaper selects
-    /// its victims on that argv, so the fixture reproduces it. Birth the
-    /// session first; `--create` here attaches to what already exists.
-    pub(in crate::backend::zellij) fn attach_with_lineage(
-        xdg: &Path,
-        name: &str,
-        lineage: &str,
-        cols: u16,
-        rows: u16,
-    ) -> Self {
-        Self::attach_inner(xdg, name, cols, rows, Some(lineage), true)
-    }
-
-    fn attach_inner(
-        xdg: &Path,
-        name: &str,
-        cols: u16,
-        rows: u16,
-        lineage: Option<&str>,
-        create: bool,
-    ) -> Self {
-        let output_tail = Arc::new(Mutex::new(Vec::new()));
-        let process = Self::spawn_process(
-            xdg,
-            name,
-            cols,
-            rows,
-            lineage,
-            create,
-            Arc::clone(&output_tail),
-        );
+        let backend = ZellijBackend::with_runtime_dir(namespace.path());
         Self {
-            xdg: xdg.to_path_buf(),
-            name: name.to_owned(),
-            cols,
-            rows,
-            lineage: lineage.map(str::to_owned),
-            create,
-            output_tail,
-            process,
+            namespace,
+            name: name.into(),
+            backend,
         }
     }
 
-    fn spawn_process(
-        xdg: &Path,
-        name: &str,
-        cols: u16,
-        rows: u16,
-        lineage: Option<&str>,
-        create: bool,
-        output_tail: Arc<Mutex<Vec<u8>>>,
-    ) -> AttachedClientProcess {
-        let pair = native_pty_system()
-            .openpty(PtySize {
-                rows,
-                cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .expect("openpty");
-        let mut cmd = CommandBuilder::new("zellij");
-        // The test process may itself run inside a Zellij pane (a client
-        // refuses to attach when it believes it is already in a session), and
-        // the server captures the spawning env for every pane it creates.
-        cmd.scrub_session_env();
-        cmd.env("XDG_RUNTIME_DIR", xdg);
-        cmd.env("XDG_STATE_HOME", xdg);
-        cmd.env("XDG_CONFIG_HOME", xdg);
-        cmd.env("XDG_CACHE_HOME", xdg);
-        cmd.env("HOME", xdg);
-        cmd.env("TMPDIR", xdg);
-        if let Some(lineage) = lineage {
-            cmd.env(rimz::remote::REMOTE_LINEAGE_ENV, lineage);
-        }
-        if create {
-            cmd.args(["attach", "--create", name]);
-        } else {
-            cmd.args(["attach", name]);
-        }
-        let child = pair.slave.spawn_command(cmd).expect("spawn zellij attach");
-        drop(pair.slave);
-        let writer = pair.master.take_writer().expect("PTY writer");
-        // Drain the PTY in the background so the kernel buffer never fills and
-        // stalls the client. Keep a bounded tail so registration failures name
-        // what the attach process reported instead of timing out silently.
-        let mut reader = pair.master.try_clone_reader().expect("clone reader");
-        std::thread::spawn(move || {
-            let mut buf = [0u8; 4096];
-            loop {
-                match reader.read(&mut buf) {
-                    Ok(0) | Err(_) => return,
-                    Ok(read) => {
-                        let mut tail = output_tail
-                            .lock()
-                            .unwrap_or_else(std::sync::PoisonError::into_inner);
-                        tail.extend_from_slice(&buf[..read]);
-                        let excess = tail.len().saturating_sub(ATTACHED_CLIENT_OUTPUT_TAIL_BYTES);
-                        if excess > 0 {
-                            tail.drain(..excess);
-                        }
-                    }
-                }
-            }
-        });
-        AttachedClientProcess {
-            _master: pair.master,
-            writer,
-            child,
-        }
+    pub(in crate::backend::zellij) fn name(&self) -> &str {
+        &self.name
     }
 
-    fn respawn(&mut self) {
-        self.process.stop();
-        self.process = Self::spawn_process(
-            &self.xdg,
-            &self.name,
-            self.cols,
-            self.rows,
-            self.lineage.as_deref(),
-            self.create,
-            Arc::clone(&self.output_tail),
-        );
+    pub(in crate::backend::zellij) fn path(&self) -> &Path {
+        self.namespace.path()
     }
 
-    fn wait_until_registered(&mut self) {
-        let deadline = Instant::now() + SPAWN_TIMEOUT;
-        let mut attempt_started = Instant::now();
-        let mut attempts = 1;
-        let mut consecutive_matches = 0;
-        let mut last_view = Vec::new();
-        let mut last_error = String::new();
-        let mut last_exit_status = None;
-        let backend = ZellijBackend::with_runtime_dir(&self.xdg);
-
-        loop {
-            if let Some(status) = self.exit_status() {
-                last_exit_status = Some(status.to_string());
-                if Instant::now() >= deadline {
-                    break;
-                }
-                self.respawn();
-                attempts += 1;
-                attempt_started = Instant::now();
-                consecutive_matches = 0;
-                continue;
-            }
-
-            match super::client::client_viewed_panes(&backend, &self.name) {
-                Ok(view) if !view.is_empty() => {
-                    last_view = view;
-                    last_error.clear();
-                    consecutive_matches += 1;
-                    if consecutive_matches == 2 {
-                        return;
-                    }
-                }
-                Ok(view) => {
-                    last_view = view;
-                    last_error.clear();
-                    consecutive_matches = 0;
-                }
-                Err(err) => {
-                    last_error = err;
-                    consecutive_matches = 0;
-                }
-            }
-
-            let now = Instant::now();
-            if now >= deadline {
-                break;
-            }
-            if now.duration_since(attempt_started) >= ATTACHED_CLIENT_REGISTRATION_ATTEMPT_TIMEOUT {
-                self.respawn();
-                attempts += 1;
-                attempt_started = Instant::now();
-                consecutive_matches = 0;
-                continue;
-            }
-            std::thread::sleep(Duration::from_millis(100));
-        }
-
-        let child_exit_status = self
-            .exit_status()
-            .map(|status| status.to_string())
-            .unwrap_or_else(|| "running".to_owned());
-        let output_tail = self.output_tail();
-        panic!(
-            "attached client for {} did not register within {:?}; attempts: {attempts}; last view: {last_view:?}; last error: {last_error}; child exit status: {child_exit_status}; last exited attempt: {last_exit_status:?}; PTY output tail: {output_tail:?}",
-            self.name, SPAWN_TIMEOUT,
-        );
+    pub(in crate::backend::zellij) fn namespace(&self) -> &ZellijNamespace {
+        &self.namespace
     }
 
-    fn output_tail(&self) -> String {
-        let tail = self
-            .output_tail
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        String::from_utf8_lossy(&tail).into_owned()
+    pub(in crate::backend::zellij) fn backend(&self) -> &ZellijBackend {
+        &self.backend
     }
 
-    pub(in crate::backend::zellij) fn press_alt(&mut self, key: char) {
-        self.process
-            .writer
-            .write_all(&[0x1b, key as u8])
-            .expect("write alt key");
-        self.process.writer.flush().expect("flush alt key");
+    pub(in crate::backend::zellij) fn command(&self) -> std::process::Command {
+        self.namespace.command()
     }
 
-    pub(in crate::backend::zellij) fn pid(&self) -> u32 {
-        self.process
-            .child
-            .process_id()
-            .expect("attached client process id")
-    }
-
-    /// The client's exit status once it has stopped, and `None` while it runs.
-    /// A wait that depends on this client being registered with the server can
-    /// end the moment the client is gone.
-    pub(in crate::backend::zellij) fn exit_status(&mut self) -> Option<portable_pty::ExitStatus> {
-        self.process.child.try_wait().ok().flatten()
-    }
-
-    pub(in crate::backend::zellij) fn go_to_tab(&mut self, tab: u8) {
-        assert!((1..=9).contains(&tab), "test helper supports tabs 1-9");
-        self.process
-            .writer
-            .write_all(&[0x14, b'0' + tab])
-            .expect("write tab-mode key sequence");
-        self.process
-            .writer
-            .flush()
-            .expect("flush tab-mode key sequence");
-    }
-
-    pub(in crate::backend::zellij) fn send_line(&mut self, line: &str) {
-        self.process
-            .writer
-            .write_all(line.as_bytes())
-            .expect("write line");
-        self.process.writer.write_all(b"\r").expect("write enter");
-        self.process.writer.flush().expect("flush line");
-    }
-}
-
-impl Drop for AttachedClient {
-    fn drop(&mut self) {
-        self.process.stop();
-    }
-}
-
-/// Tear down a runtime-scoped session even if an assertion panics first. Used by
-/// tests that birth a background session directly (no attached PTY client). The
-/// test owns the `XDG_RUNTIME_DIR` tempdir; this only needs its path.
-pub(in crate::backend::zellij) struct ScopedSessionCleanup {
-    pub(in crate::backend::zellij) name: String,
-    pub(in crate::backend::zellij) xdg: PathBuf,
-}
-
-impl Drop for ScopedSessionCleanup {
-    fn drop(&mut self) {
-        let _ = scoped_zellij(&self.xdg)
-            .args(["delete-session", &self.name, "--force"])
-            .bounded_output();
-    }
-}
-
-/// Poll until `session` is active enough to answer `action` commands, not just
-/// listed. A freshly `attach --create`d session can appear in `list-sessions` a
-/// beat before its server accepts actions; under the parallelism this file now
-/// enables, that gap is real, so gate on a lightweight action (`query-tab-names`,
-/// which a default session always answers) succeeding rather than on the bare
-/// listing. Sessions take 300–800 ms to come up on a quiet host; starved CI can
-/// exceed 30 s, so widen the in-test window rather than burn a full retry cycle.
-pub(in crate::backend::zellij) fn wait_until_session_ready(xdg: &Path, name: &str) {
-    let deadline = Instant::now() + SPAWN_TIMEOUT;
-    loop {
-        let ready = scoped_zellij(xdg)
-            .args(["--session", name, "action", "query-tab-names"])
+    /// Birth a detached session with Zellij's default shell pane.
+    pub(in crate::backend::zellij) fn create_background(&self) {
+        let output = self
+            .command()
+            .args(["attach", "--create-background", self.name()])
             .bounded_output()
-            .is_ok_and(|out| out.status.success());
-        if ready {
-            return;
+            .expect("create background session");
+        assert!(
+            output.status.success(),
+            "create-background failed for {}: {}",
+            self.name,
+            String::from_utf8_lossy(&output.stderr),
+        );
+        self.wait_until_ready();
+    }
+
+    /// Birth a detached session with one long-lived work pane.
+    pub(in crate::backend::zellij) fn create_plain_background(&self, cwd: &Path, sleep: &str) {
+        let layout = cwd.join(format!("{}.kdl", self.name));
+        std::fs::write(
+            &layout,
+            format!(
+                "layout {{\n    pane command=\"sleep\" {{\n        args \"{sleep}\"\n    }}\n}}\n"
+            ),
+        )
+        .expect("write plain layout");
+        let created = self
+            .command()
+            .args(["attach", "--create-background", self.name(), "options"])
+            .arg("--default-cwd")
+            .arg(cwd)
+            .arg("--default-layout")
+            .arg(&layout)
+            .bounded_status()
+            .expect("create plain session");
+        assert!(
+            created.success(),
+            "create-background failed for {}",
+            self.name
+        );
+        self.wait_until_ready();
+    }
+
+    /// Gate on the session action server rather than its earlier listing.
+    pub(in crate::backend::zellij) fn wait_until_ready(&self) {
+        let deadline = Instant::now() + SPAWN_TIMEOUT;
+        loop {
+            let ready = self
+                .command()
+                .args(["--session", self.name(), "action", "query-tab-names"])
+                .bounded_output()
+                .is_ok_and(|out| out.status.success());
+            if ready {
+                return;
+            }
+            if Instant::now() > deadline {
+                panic!(
+                    "zellij session {} never became ready for actions",
+                    self.name
+                );
+            }
+            std::thread::sleep(Duration::from_millis(150));
         }
-        if Instant::now() > deadline {
-            panic!("zellij session {name} never became ready for actions");
-        }
-        std::thread::sleep(Duration::from_millis(150));
+    }
+}
+
+impl Drop for LiveZellijSession {
+    fn drop(&mut self) {
+        self.namespace.delete_session(&self.name);
     }
 }
 
@@ -594,8 +216,7 @@ pub(in crate::backend::zellij) fn capture_pty_output_until(
     timeout: Duration,
     mut ready: impl FnMut(&[u8]) -> bool,
 ) -> Vec<u8> {
-    let pty_system = native_pty_system();
-    let pair = pty_system
+    let pair = native_pty_system()
         .openpty(PtySize {
             rows: 24,
             cols: 80,
@@ -650,12 +271,8 @@ pub(in crate::backend::zellij) fn capture_pty_output_until(
     output
 }
 
-/// A session name no concurrent test can also draw. The leading 48 bits of a v7
-/// UUID are its millisecond clock, so a name cut from the front alone repeats
-/// across tests that start in the same millisecond — and a repeat is visible to
-/// anything that scans the process table by session name rather than by runtime
-/// dir, the reaper included. Pair the clock tail with random bytes so the name
-/// stays roughly time-ordered and still unique.
+/// A session name no concurrent test can also draw. Keep random UUID bits
+/// because the lineage reaper scans `/proc` outside the namespace boundary.
 pub(in crate::backend::zellij) fn unique_session_name(prefix: &str) -> String {
     let id = uuid::Uuid::now_v7().simple().to_string();
     format!("rimz-{prefix}-{}-{}", &id[6..12], &id[26..32])
@@ -665,9 +282,6 @@ pub(in crate::backend::zellij) fn sidebar_command_stub() -> (TempDir, PathBuf) {
     sidebar_stub_alive_for(30)
 }
 
-/// A renderer stand-in that sleeps for `seconds` then exits. The width tests
-/// wait through an attach and a tab open, which can outlive the shared 30s
-/// stub, so they ask for a longer life.
 pub(in crate::backend::zellij) fn sidebar_stub_alive_for(seconds: u32) -> (TempDir, PathBuf) {
     let dir = TempDir::new().expect("stub dir");
     let path = dir.path().join("rimz-stub");

--- a/crates/rimz/tests/integration/backend/zellij/tabs.rs
+++ b/crates/rimz/tests/integration/backend/zellij/tabs.rs
@@ -44,7 +44,6 @@ fn open_tab_unfocused_routes_input_back_to_source() {
     wait_for_pane_count(xdg.path(), &name, 2);
 
     let mut client = AttachedClient::attach(xdg.path(), &name, 200, 50);
-    wait_for_attached_client(xdg.path(), &name);
 
     let source_tab = "focus source";
     let input_log = cwd.path().join("source-input.log");
@@ -154,7 +153,6 @@ fn open_tab_can_omit_sidebar_for_gallery_layout() {
     backend.open_sidebar(&sidebar, None).expect("open_sidebar");
     wait_for_pane_count(xdg.path(), &name, 2);
     let _client = AttachedClient::attach(xdg.path(), &name, 220, 40);
-    wait_for_attached_client(xdg.path(), &name);
 
     let tab_name = "sidebar gallery";
     let work_pane = || PaneCmd {
@@ -226,7 +224,6 @@ fn native_focused_split_preserves_docked_sidebar() {
     let client_columns: u16 = 380;
     let client_rows: u16 = 46;
     let mut client = AttachedClient::attach(xdg.path(), &name, client_columns, client_rows);
-    wait_for_attached_client(xdg.path(), &name);
     write_topology_cache_from_list_panes(xdg.path(), &sidebar.workspace_id, &name);
     let _mirror = topology_cache_mirror(xdg.path(), &sidebar.workspace_id, &name);
     let work_pane = || PaneCmd {
@@ -249,7 +246,9 @@ fn native_focused_split_preserves_docked_sidebar() {
             sidebar: sidebar.clone(),
         })
         .expect("open backend split tab layout");
-    let work = wait_for_named_work_pane_count(xdg.path(), &name, split_tab, 3);
+    let work = wait_for_named_work_pane_state(xdg.path(), &name, split_tab, 3, |work| {
+        work.iter().map(|pane| pane.x + pane.columns).max() == Some(u64::from(client_columns))
+    });
     let focused_before = work[1];
     let focused_before_id =
         PaneId::from_parts(MuxName::Zellij, format!("terminal_{}", focused_before.id));
@@ -284,22 +283,26 @@ fn native_focused_split_preserves_docked_sidebar() {
         let work_stays_right_of_sidebar = work
             .iter()
             .all(|pane| pane.x >= sidebar_before.x + sidebar_before.columns);
-        let sidebar_unchanged = named_sidebar_pane_geometry(xdg.path(), &name, split_tab)
-            .ok()
-            .flatten()
-            .is_some_and(|sidebar| {
-                sidebar.x == sidebar_before.x
-                    && sidebar.y == sidebar_before.y
-                    && sidebar.columns == sidebar_before.columns
-                    && sidebar.rows == sidebar_before.rows
-            });
         let focused_pane_was_split = work
             .iter()
             .filter(|pane| focused_bounds_hold_two_panes(pane))
             .count()
             == 2;
-        work_stays_right_of_sidebar && sidebar_unchanged && focused_pane_was_split
+        work_stays_right_of_sidebar && focused_pane_was_split
     });
+    poll_until(
+        Duration::from_secs(30),
+        || named_sidebar_pane_geometry(xdg.path(), &name, split_tab),
+        |sidebar| {
+            sidebar.is_some_and(|sidebar| {
+                sidebar.x == sidebar_before.x
+                    && sidebar.y == sidebar_before.y
+                    && sidebar.columns == sidebar_before.columns
+                    && sidebar.rows == sidebar_before.rows
+            })
+        },
+        &format!("unchanged sidebar geometry in {name}/{split_tab}"),
+    );
     assert_eq!(
         split
             .iter()

--- a/crates/rimz/tests/integration/backend/zellij/tabs.rs
+++ b/crates/rimz/tests/integration/backend/zellij/tabs.rs
@@ -13,12 +13,9 @@ use super::support::*;
 fn open_tab_unfocused_routes_input_back_to_source() {
     require_zellij!();
 
-    let xdg = scoped_runtime_dir();
-    let name = unique_session_name("tabfocus");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("tabfocus");
+    let xdg = room.path();
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
     let (_stub_dir, stub) = sidebar_stub_alive_for(600);
     let workspace_id = WorkspaceId::from_project_root(Path::new("/tmp/rimz-tabfocus"));
@@ -38,12 +35,12 @@ fn open_tab_unfocused_routes_input_back_to_source() {
         resume_tabs: Vec::new(),
         refresh_ms: None,
     };
-    let backend = ZellijBackend::with_runtime_dir(xdg.path());
-    publish_room_bin(xdg.path(), &sidebar);
+    let backend = ZellijBackend::with_runtime_dir(xdg);
+    publish_room_bin(xdg, &sidebar);
     backend.open_sidebar(&sidebar, None).expect("open_sidebar");
-    wait_for_pane_count(xdg.path(), &name, 2);
+    wait_for_pane_count(xdg, &name, 2);
 
-    let mut client = AttachedClient::attach(xdg.path(), &name, 200, 50);
+    let mut client = AttachedClient::attach(&room, 200, 50);
 
     let source_tab = "focus source";
     let input_log = cwd.path().join("source-input.log");
@@ -68,7 +65,7 @@ fn open_tab_unfocused_routes_input_back_to_source() {
         })
         .expect("open focused source tab");
 
-    let source_panes = wait_for_named_work_pane_count(xdg.path(), &name, source_tab, 1);
+    let source_panes = wait_for_named_work_pane_count(xdg, &name, source_tab, 1);
     assert_eq!(
         source_panes.len(),
         1,
@@ -76,7 +73,7 @@ fn open_tab_unfocused_routes_input_back_to_source() {
     );
     let source_pane =
         PaneId::from_parts(MuxName::Zellij, format!("terminal_{}", source_panes[0].id));
-    let focused = wait_for_focused_client_pane(&backend, &name, &source_pane);
+    let focused = client.wait_until_focused(&source_pane, "focused source tab");
     assert_eq!(
         focused,
         vec![source_pane.clone()],
@@ -98,21 +95,14 @@ fn open_tab_unfocused_routes_input_back_to_source() {
         })
         .expect("open unfocused background tab");
     assert_eq!(
-        wait_for_named_work_pane_count(xdg.path(), &name, background_tab, 1).len(),
+        wait_for_named_work_pane_count(xdg, &name, background_tab, 1).len(),
         1,
         "background tab should open one work pane",
     );
 
-    client.send_line("rimz-source-route");
-    let routed = poll_until(
-        Duration::from_secs(5),
-        || std::fs::read_to_string(&input_log).map_err(|err| err.to_string()),
-        |contents| contents.contains("rimz-source-route"),
-        "unfocused tab input routed to source pane",
-    );
-    assert!(routed.contains("rimz-source-route"));
+    client.assert_input_reaches(&source_pane, "source pane after unfocused tab open");
 
-    let runtime = rimz::store::RuntimePaths::under(workspace_id, xdg.path()).expect("runtime");
+    let runtime = rimz::store::RuntimePaths::under(workspace_id, xdg).expect("runtime");
     let intent = rimz::sidebar::focus_anchor::load(&runtime).expect("applied focus intent");
     assert_eq!(intent.pane_id, source_pane);
     assert_eq!(
@@ -124,12 +114,9 @@ fn open_tab_unfocused_routes_input_back_to_source() {
 fn open_tab_can_omit_sidebar_for_gallery_layout() {
     require_zellij!();
 
-    let xdg = scoped_runtime_dir();
-    let name = unique_session_name("gallery");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("gallery");
+    let xdg = room.path();
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
     let (_stub_dir, stub) = sidebar_stub_alive_for(600);
     let sidebar = SidebarPaneOptions {
@@ -148,11 +135,11 @@ fn open_tab_can_omit_sidebar_for_gallery_layout() {
         resume_tabs: Vec::new(),
         refresh_ms: None,
     };
-    let backend = ZellijBackend::with_runtime_dir(xdg.path());
-    publish_room_bin(xdg.path(), &sidebar);
+    let backend = ZellijBackend::with_runtime_dir(xdg);
+    publish_room_bin(xdg, &sidebar);
     backend.open_sidebar(&sidebar, None).expect("open_sidebar");
-    wait_for_pane_count(xdg.path(), &name, 2);
-    let _client = AttachedClient::attach(xdg.path(), &name, 220, 40);
+    wait_for_pane_count(xdg, &name, 2);
+    let _client = AttachedClient::attach(&room, 220, 40);
 
     let tab_name = "sidebar gallery";
     let work_pane = || PaneCmd {
@@ -171,12 +158,12 @@ fn open_tab_can_omit_sidebar_for_gallery_layout() {
         .expect("open gallery tab");
 
     assert_eq!(
-        wait_for_named_work_pane_count(xdg.path(), &name, tab_name, 1).len(),
+        wait_for_named_work_pane_count(xdg, &name, tab_name, 1).len(),
         1,
         "gallery tab should hold one work pane",
     );
     assert_eq!(
-        named_sidebar_pane_geometry(xdg.path(), &name, tab_name)
+        named_sidebar_pane_geometry(xdg, &name, tab_name)
             .expect("list gallery sidebar panes")
             .map(|pane| pane.id),
         None,
@@ -190,12 +177,9 @@ fn open_tab_can_omit_sidebar_for_gallery_layout() {
 fn native_focused_split_preserves_docked_sidebar() {
     require_zellij!();
 
-    let xdg = scoped_runtime_dir();
-    let name = unique_session_name("worksplit");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("worksplit");
+    let xdg = room.path();
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
 
     let (_stub_dir, stub) = sidebar_stub_alive_for(600);
@@ -216,16 +200,16 @@ fn native_focused_split_preserves_docked_sidebar() {
         resume_tabs: Vec::new(),
         refresh_ms: None,
     };
-    let backend = ZellijBackend::with_runtime_dir(xdg.path());
-    publish_room_bin(xdg.path(), &sidebar);
+    let backend = ZellijBackend::with_runtime_dir(xdg);
+    publish_room_bin(xdg, &sidebar);
     backend.open_sidebar(&sidebar, None).expect("open_sidebar");
-    wait_for_pane_count(xdg.path(), &name, 2);
+    wait_for_pane_count(xdg, &name, 2);
 
     let client_columns: u16 = 380;
     let client_rows: u16 = 46;
-    let mut client = AttachedClient::attach(xdg.path(), &name, client_columns, client_rows);
-    write_topology_cache_from_list_panes(xdg.path(), &sidebar.workspace_id, &name);
-    let _mirror = topology_cache_mirror(xdg.path(), &sidebar.workspace_id, &name);
+    let mut client = AttachedClient::attach(&room, client_columns, client_rows);
+    write_topology_cache_from_list_panes(xdg, &sidebar.workspace_id, &name);
+    let _mirror = topology_cache_mirror(xdg, &sidebar.workspace_id, &name);
     let work_pane = || PaneCmd {
         argv: vec!["sleep".to_owned(), "600".to_owned()],
     };
@@ -246,40 +230,38 @@ fn native_focused_split_preserves_docked_sidebar() {
             sidebar: sidebar.clone(),
         })
         .expect("open backend split tab layout");
-    let work = wait_for_named_work_pane_state(xdg.path(), &name, split_tab, 3, |work| {
+    let work = wait_for_named_work_pane_state(xdg, &name, split_tab, 3, |work| {
         work.iter().map(|pane| pane.x + pane.columns).max() == Some(u64::from(client_columns))
     });
     let focused_before = work[1];
     let focused_before_id =
         PaneId::from_parts(MuxName::Zellij, format!("terminal_{}", focused_before.id));
-    focus_attached_client_pane_until(
-        xdg.path(),
-        &name,
-        focused_before.id,
+    client.press_alt_until(
+        'l',
+        &focused_before_id,
         "chosen work pane before native split",
-        || client.press_alt('l'),
     );
-    let focused = wait_for_focused_client_pane(&backend, &name, &focused_before_id);
+    let focused = client.wait_until_focused(&focused_before_id, "chosen work pane");
     assert!(
         focused.iter().any(|pane| pane == &focused_before_id),
         "backend tab should focus the chosen work pane before native split; \
          focused client panes: {focused:?}",
     );
-    let sidebar_before = wait_for_named_sidebar_pane(xdg.path(), &name, split_tab)
-        .expect("backend tab keeps its sidebar");
+    let sidebar_before =
+        wait_for_named_sidebar_pane(xdg, &name, split_tab).expect("backend tab keeps its sidebar");
     assert_eq!(
         sidebar_before.x, 0,
         "backend tab starts with the sidebar docked left: {sidebar_before:?}",
     );
 
-    spawn_sleep_pane(xdg.path(), &name, cwd.path());
+    spawn_sleep_pane(xdg, &name, cwd.path());
     let focused_bounds_hold_two_panes = |pane: &PaneGeometry| {
         pane.x + 2 >= focused_before.x
             && pane.y + 2 >= focused_before.y
             && pane.x + pane.columns <= focused_before.x + focused_before.columns + 2
             && pane.y + pane.rows <= focused_before.y + focused_before.rows + 2
     };
-    let split = wait_for_named_work_pane_state(xdg.path(), &name, split_tab, 4, |work| {
+    let split = wait_for_named_work_pane_state(xdg, &name, split_tab, 4, |work| {
         let work_stays_right_of_sidebar = work
             .iter()
             .all(|pane| pane.x >= sidebar_before.x + sidebar_before.columns);
@@ -292,7 +274,7 @@ fn native_focused_split_preserves_docked_sidebar() {
     });
     poll_until(
         Duration::from_secs(30),
-        || named_sidebar_pane_geometry(xdg.path(), &name, split_tab),
+        || named_sidebar_pane_geometry(xdg, &name, split_tab),
         |sidebar| {
             sidebar.is_some_and(|sidebar| {
                 sidebar.x == sidebar_before.x
@@ -311,7 +293,7 @@ fn native_focused_split_preserves_docked_sidebar() {
         2,
         "native split should divide only the focused pane, got {split:?}",
     );
-    let sidebar_after = named_sidebar_pane_geometry(xdg.path(), &name, split_tab)
+    let sidebar_after = named_sidebar_pane_geometry(xdg, &name, split_tab)
         .expect("list backend tab sidebar")
         .expect("backend tab keeps its sidebar");
     assert_eq!(

--- a/crates/rimz/tests/integration/backend/zellij/width.rs
+++ b/crates/rimz/tests/integration/backend/zellij/width.rs
@@ -22,7 +22,6 @@ fn sidebar_width_steps_resize_birth_and_explicit_layout_panes() {
     backend.open_sidebar(&sidebar, None).expect("open sidebar");
     wait_for_pane_count(xdg.path(), &name, 2);
     let _client = AttachedClient::attach(xdg.path(), &name, 120, 40);
-    wait_for_attached_client(xdg.path(), &name);
     let listed = raw_sidebar_pane(xdg.path(), &name);
     let pane = PaneId::from_parts(MuxName::Zellij, format!("terminal_{}", listed.id));
     let initial = listed.pane_columns;
@@ -142,7 +141,6 @@ fn sidebar_widths_converge_after_resize_new_tab_and_override() {
     // is only 210 columns wide. The detached percentage seed therefore lands
     // near 44 columns while the live narrow-view target is 52.
     let _client = AttachedClient::attach(xdg.path(), &name, 210, 60);
-    wait_for_attached_client(xdg.path(), &name);
     write_topology_cache_from_list_panes(xdg.path(), &sidebar.workspace_id, &name);
     let _mirror = topology_cache_mirror(xdg.path(), &sidebar.workspace_id, &name);
     assert!(

--- a/crates/rimz/tests/integration/backend/zellij/width.rs
+++ b/crates/rimz/tests/integration/backend/zellij/width.rs
@@ -8,21 +8,18 @@ use super::support::*;
 fn sidebar_width_steps_resize_birth_and_explicit_layout_panes() {
     require_zellij!();
 
-    let xdg = scoped_runtime_dir();
-    let name = unique_session_name("widthstep");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("widthstep");
+    let xdg = room.path();
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
     let (_stub_dir, stub) = sidebar_stub_alive_for(600);
     let sidebar = sidebar_opts(&name, cwd.path(), stub, 120);
-    let backend = ZellijBackend::with_runtime_dir(xdg.path());
-    publish_room_bin(xdg.path(), &sidebar);
+    let backend = ZellijBackend::with_runtime_dir(xdg);
+    publish_room_bin(xdg, &sidebar);
     backend.open_sidebar(&sidebar, None).expect("open sidebar");
-    wait_for_pane_count(xdg.path(), &name, 2);
-    let _client = AttachedClient::attach(xdg.path(), &name, 120, 40);
-    let listed = raw_sidebar_pane(xdg.path(), &name);
+    wait_for_pane_count(xdg, &name, 2);
+    let _client = AttachedClient::attach(&room, 120, 40);
+    let listed = raw_sidebar_pane(xdg, &name);
     let pane = PaneId::from_parts(MuxName::Zellij, format!("terminal_{}", listed.id));
     let initial = listed.pane_columns;
     let initial_cols = u16::try_from(initial).expect("sidebar width fits u16");
@@ -31,7 +28,7 @@ fn sidebar_width_steps_resize_birth_and_explicit_layout_panes() {
         .nudge_sidebar_width(&name, &pane, initial_cols, u16::MAX)
         .expect("widen sidebar");
     let wider = wait_for_sidebar_columns_matching(
-        xdg.path(),
+        xdg,
         &name,
         listed.id,
         |columns| columns > initial,
@@ -47,7 +44,7 @@ fn sidebar_width_steps_resize_birth_and_explicit_layout_panes() {
         .nudge_sidebar_width(&name, &pane, wider_cols, 1)
         .expect("narrow sidebar");
     let narrower = wait_for_sidebar_columns_matching(
-        xdg.path(),
+        xdg,
         &name,
         listed.id,
         |columns| columns < wider,
@@ -75,15 +72,15 @@ fn sidebar_width_steps_resize_birth_and_explicit_layout_panes() {
             sidebar: sidebar.clone(),
         })
         .expect("open explicit tab");
-    let explicit = wait_for_named_sidebar_pane(xdg.path(), &name, tab_name)
-        .expect("explicit tab carries sidebar");
+    let explicit =
+        wait_for_named_sidebar_pane(xdg, &name, tab_name).expect("explicit tab carries sidebar");
     let pane = PaneId::from_parts(MuxName::Zellij, format!("terminal_{}", explicit.id));
     let explicit_cols = u16::try_from(explicit.columns).expect("sidebar width fits u16");
     backend
         .nudge_sidebar_width(&name, &pane, explicit_cols, u16::MAX)
         .expect("widen explicit-layout sidebar");
     let resized = wait_for_sidebar_columns_matching(
-        xdg.path(),
+        xdg,
         &name,
         explicit.id,
         |columns| columns > explicit.columns,
@@ -122,93 +119,90 @@ fn wait_for_sidebar_columns_matching(
 fn sidebar_widths_converge_after_resize_new_tab_and_override() {
     require_zellij!();
 
-    let xdg = scoped_runtime_dir();
-    let name = unique_session_name("fixedw");
-    let _cleanup = ScopedSessionCleanup {
-        name: name.clone(),
-        xdg: xdg.path().to_path_buf(),
-    };
+    let room = LiveZellijSession::new("fixedw");
+    let xdg = room.path();
+    let name = room.name().to_owned();
     let cwd = TempDir::new().expect("cwd tempdir");
 
     let (_stub_dir, stub) = sidebar_stub_alive_for(600);
     let sidebar = sidebar_opts(&name, cwd.path(), stub, 340);
-    let backend = ZellijBackend::with_runtime_dir(xdg.path());
-    publish_room_bin(xdg.path(), &sidebar);
+    let backend = ZellijBackend::with_runtime_dir(xdg);
+    publish_room_bin(xdg, &sidebar);
     backend.open_sidebar(&sidebar, None).expect("open_sidebar");
-    wait_for_pane_count(xdg.path(), &name, 2);
+    wait_for_pane_count(xdg, &name, 2);
 
     // The launch seed came from a 340-column terminal, but this attached client
     // is only 210 columns wide. The detached percentage seed therefore lands
     // near 44 columns while the live narrow-view target is 52.
-    let _client = AttachedClient::attach(xdg.path(), &name, 210, 60);
-    write_topology_cache_from_list_panes(xdg.path(), &sidebar.workspace_id, &name);
-    let _mirror = topology_cache_mirror(xdg.path(), &sidebar.workspace_id, &name);
+    let _client = AttachedClient::attach(&room, 210, 60);
+    write_topology_cache_from_list_panes(xdg, &sidebar.workspace_id, &name);
+    let _mirror = topology_cache_mirror(xdg, &sidebar.workspace_id, &name);
     assert!(
-        wait_for_sidebar_columns(xdg.path(), &name, &[42..=46]),
+        wait_for_sidebar_columns(xdg, &name, &[42..=46]),
         "the capped launch seed rescales onto the smaller client, got {:?}",
-        sidebar_columns_by_tab(xdg.path(), &name),
+        sidebar_columns_by_tab(xdg, &name),
     );
 
     assert_eq!(
-        converge_each_sidebar_with_nudges(&backend, xdg.path(), &name, 52, 5),
+        converge_each_sidebar_with_nudges(&backend, xdg, &name, 52, 5),
         1,
     );
     assert!(
-        wait_for_sidebar_columns(xdg.path(), &name, &[47..=57]),
+        wait_for_sidebar_columns(xdg, &name, &[47..=57]),
         "the birth pane converges near the smaller view's 52-column target, got {:?}",
-        sidebar_columns_by_tab(xdg.path(), &name),
+        sidebar_columns_by_tab(xdg, &name),
     );
 
     // A native tab inherits the 340-column launch probe's cap-aware 21% seed,
     // then live convergence applies the narrow-view policy.
-    open_new_tab(xdg.path(), &name);
-    wait_for_tab_count(xdg.path(), &name, 2);
+    open_new_tab(xdg, &name);
+    wait_for_tab_count(xdg, &name, 2);
     assert!(
-        wait_for_sidebar_columns(xdg.path(), &name, &[47..=57, 42..=46]),
+        wait_for_sidebar_columns(xdg, &name, &[47..=57, 42..=46]),
         "the native template births the new tab from the cap-aware launch seed, got {:?}",
-        sidebar_columns_by_tab(xdg.path(), &name),
+        sidebar_columns_by_tab(xdg, &name),
     );
     assert_eq!(
-        converge_each_sidebar_with_nudges(&backend, xdg.path(), &name, 52, 5),
+        converge_each_sidebar_with_nudges(&backend, xdg, &name, 52, 5),
         1,
     );
     assert!(
-        wait_for_sidebar_columns(xdg.path(), &name, &[47..=57, 47..=57]),
+        wait_for_sidebar_columns(xdg, &name, &[47..=57, 47..=57]),
         "both tabs converge near the 25% live target, got {:?}",
-        sidebar_columns_by_tab(xdg.path(), &name),
+        sidebar_columns_by_tab(xdg, &name),
     );
 
     // Keep one tab active while the two converged tabs need the room override;
     // the launch-seeded tab is already within its tolerance.
-    open_new_tab(xdg.path(), &name);
-    wait_for_tab_count(xdg.path(), &name, 3);
+    open_new_tab(xdg, &name);
+    wait_for_tab_count(xdg, &name, 3);
     assert!(
-        wait_for_sidebar_columns(xdg.path(), &name, &[47..=57, 47..=57, 42..=46]),
+        wait_for_sidebar_columns(xdg, &name, &[47..=57, 47..=57, 42..=46]),
         "the new tab starts at the launch seed while converged tabs stay narrow, got {:?}",
-        sidebar_columns_by_tab(xdg.path(), &name),
+        sidebar_columns_by_tab(xdg, &name),
     );
 
     // A room override becomes the target for every existing tab, including
     // the two background tabs, and every future tab.
     assert_eq!(
-        converge_each_sidebar_with_nudges(&backend, xdg.path(), &name, 40, 5),
+        converge_each_sidebar_with_nudges(&backend, xdg, &name, 40, 5),
         2,
     );
     assert!(wait_for_sidebar_columns(
-        xdg.path(),
+        xdg,
         &name,
         &[35..=45, 35..=45, 35..=45]
     ));
-    open_new_tab(xdg.path(), &name);
-    wait_for_tab_count(xdg.path(), &name, 4);
+    open_new_tab(xdg, &name);
+    wait_for_tab_count(xdg, &name, 4);
     assert_eq!(
-        converge_each_sidebar_with_nudges(&backend, xdg.path(), &name, 40, 5),
+        converge_each_sidebar_with_nudges(&backend, xdg, &name, 40, 5),
         0,
     );
     assert!(
-        wait_for_sidebar_columns(xdg.path(), &name, &[35..=45, 35..=45, 35..=45, 35..=45]),
+        wait_for_sidebar_columns(xdg, &name, &[35..=45, 35..=45, 35..=45, 35..=45]),
         "the override propagates to every tab, got {:?}",
-        sidebar_columns_by_tab(xdg.path(), &name),
+        sidebar_columns_by_tab(xdg, &name),
     );
 }
 

--- a/crates/rimz/tests/integration/common/command.rs
+++ b/crates/rimz/tests/integration/common/command.rs
@@ -222,19 +222,25 @@ mod tests {
         let error = Command::new("sh")
             .args([
                 "-c",
-                "head -c 9000 /dev/zero | tr '\\0' x; printf rimz-stdout-marker; head -c 9000 /dev/zero | tr '\\0' y >&2; printf rimz-stderr-marker >&2; sleep 30 & child=$!; printf '%s' \"$child\" > \"$1\"; wait \"$child\"",
+                "sleep 30 & child=$!; printf '%s' \"$child\" > \"$1\"; printf '%09000d' 0; printf 'rimz-%s-marker' stdout; printf '%09000d' 0 >&2; printf 'rimz-%s-marker' stderr >&2; wait \"$child\"",
                 "sh",
             ])
             .arg(&pid_file)
-            .bounded_output_within(Duration::from_millis(100))
+            .bounded_output_within(Duration::from_secs(1))
             .expect_err("sleeping command should time out");
 
         assert_eq!(error.kind(), io::ErrorKind::TimedOut);
         let message = error.to_string();
         assert!(message.contains("sh"), "missing command: {message}");
-        assert!(message.contains("100ms"), "missing budget: {message}");
-        assert!(message.contains("rimz-stdout-marker"), "{message}");
-        assert!(message.contains("rimz-stderr-marker"), "{message}");
+        assert!(message.contains("1s"), "missing budget: {message}");
+        let (_, output_tails) = message
+            .split_once("stdout tail: ")
+            .expect("stdout tail label");
+        let (stdout_tail, stderr_tail) = output_tails
+            .split_once("; stderr tail: ")
+            .expect("stderr tail label");
+        assert!(stdout_tail.contains("rimz-stdout-marker"), "{message}");
+        assert!(stderr_tail.contains("rimz-stderr-marker"), "{message}");
         assert!(
             message.len() < 18_000,
             "timeout diagnostics were not bounded: {} bytes",
@@ -242,9 +248,14 @@ mod tests {
         );
 
         let pid = std::fs::read_to_string(&pid_file).expect("child pid");
+        let child_proc = std::path::Path::new("/proc").join(pid.trim());
+        let reap_deadline = Instant::now() + Duration::from_secs(5);
+        while child_proc.exists() && Instant::now() < reap_deadline {
+            thread::sleep(Duration::from_millis(10));
+        }
         assert!(
-            !std::path::Path::new("/proc").join(pid.trim()).exists(),
-            "timed-out child {pid} was not killed and reaped",
+            !child_proc.exists(),
+            "timed-out descendant {pid} remained after process-group kill",
         );
     }
 }

--- a/crates/rimz/tests/integration/common/command.rs
+++ b/crates/rimz/tests/integration/common/command.rs
@@ -75,7 +75,10 @@ fn profile_sink() -> &'static str {
 /// Maximum wall time for a mux control command in tests. Healthy control
 /// commands answer in milliseconds; this only catches wedged children.
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+/// Full room workflows run several bounded mux probes and sidebar handoffs.
+pub const ROOM_WORKFLOW_TIMEOUT: Duration = Duration::from_secs(30);
 const POLL_STEP: Duration = Duration::from_millis(10);
+const TIMEOUT_OUTPUT_CONTEXT_BYTES: usize = 8 * 1024;
 
 pub trait CommandTimeoutExt {
     fn bounded_output(&mut self) -> io::Result<Output>;
@@ -94,6 +97,7 @@ impl CommandTimeoutExt for Command {
 
     fn bounded_output_within(&mut self, timeout: Duration) -> io::Result<Output> {
         let debug = format!("{self:?}");
+        isolate_process_group(self);
         let mut child = self
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
@@ -112,11 +116,11 @@ impl CommandTimeoutExt for Command {
                 });
             }
             if Instant::now() >= deadline {
-                let _ = child.kill();
+                kill_process_group(&mut child);
                 let _ = child.wait();
-                drop(stdout);
-                drop(stderr);
-                return Err(timeout_error(&debug, timeout));
+                let stdout = join_pipe(stdout);
+                let stderr = join_pipe(stderr);
+                return Err(timeout_error(&debug, timeout, &stdout, &stderr));
             }
             thread::sleep(POLL_STEP);
         }
@@ -124,6 +128,7 @@ impl CommandTimeoutExt for Command {
 
     fn bounded_status(&mut self) -> io::Result<ExitStatus> {
         let debug = format!("{self:?}");
+        isolate_process_group(self);
         let mut child = self
             .stdin(Stdio::null())
             .stdout(Stdio::null())
@@ -135,9 +140,9 @@ impl CommandTimeoutExt for Command {
                 return Ok(status);
             }
             if Instant::now() >= deadline {
-                let _ = child.kill();
+                kill_process_group(&mut child);
                 let _ = child.wait();
-                return Err(timeout_error(&debug, COMMAND_TIMEOUT));
+                return Err(timeout_error(&debug, COMMAND_TIMEOUT, &[], &[]));
             }
             thread::sleep(POLL_STEP);
         }
@@ -150,6 +155,27 @@ impl CommandTimeoutExt for Command {
         assert!(status.success(), "{label} exited with {status}");
         status
     }
+}
+
+fn isolate_process_group(command: &mut Command) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt as _;
+
+        command.process_group(0);
+    }
+}
+
+fn kill_process_group(child: &mut std::process::Child) {
+    #[cfg(unix)]
+    {
+        use nix::sys::signal::{Signal, killpg};
+        use nix::unistd::Pid;
+
+        let _ = killpg(Pid::from_raw(child.id() as i32), Signal::SIGKILL);
+    }
+    #[cfg(not(unix))]
+    let _ = child.kill();
 }
 
 fn drain_pipe<R>(mut pipe: R) -> thread::JoinHandle<Vec<u8>>
@@ -169,9 +195,56 @@ fn join_pipe(handle: Option<thread::JoinHandle<Vec<u8>>>) -> Vec<u8> {
         .unwrap_or_default()
 }
 
-fn timeout_error(command: &str, timeout: Duration) -> io::Error {
+fn timeout_error(command: &str, timeout: Duration, stdout: &[u8], stderr: &[u8]) -> io::Error {
+    let stdout = lossy_tail(stdout);
+    let stderr = lossy_tail(stderr);
     io::Error::new(
         io::ErrorKind::TimedOut,
-        format!("{command} did not finish within {timeout:?}; killed"),
+        format!(
+            "{command} did not finish within {timeout:?}; killed; stdout tail: {stdout:?}; stderr tail: {stderr:?}"
+        ),
     )
+}
+
+fn lossy_tail(bytes: &[u8]) -> String {
+    let start = bytes.len().saturating_sub(TIMEOUT_OUTPUT_CONTEXT_BYTES);
+    String::from_utf8_lossy(&bytes[start..]).into_owned()
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_output_timeout_kills_reaps_and_keeps_both_output_streams() {
+        let tempdir = tempfile::TempDir::new().expect("tempdir");
+        let pid_file = tempdir.path().join("child.pid");
+        let error = Command::new("sh")
+            .args([
+                "-c",
+                "head -c 9000 /dev/zero | tr '\\0' x; printf rimz-stdout-marker; head -c 9000 /dev/zero | tr '\\0' y >&2; printf rimz-stderr-marker >&2; sleep 30 & child=$!; printf '%s' \"$child\" > \"$1\"; wait \"$child\"",
+                "sh",
+            ])
+            .arg(&pid_file)
+            .bounded_output_within(Duration::from_millis(100))
+            .expect_err("sleeping command should time out");
+
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        let message = error.to_string();
+        assert!(message.contains("sh"), "missing command: {message}");
+        assert!(message.contains("100ms"), "missing budget: {message}");
+        assert!(message.contains("rimz-stdout-marker"), "{message}");
+        assert!(message.contains("rimz-stderr-marker"), "{message}");
+        assert!(
+            message.len() < 18_000,
+            "timeout diagnostics were not bounded: {} bytes",
+            message.len(),
+        );
+
+        let pid = std::fs::read_to_string(&pid_file).expect("child pid");
+        assert!(
+            !std::path::Path::new("/proc").join(pid.trim()).exists(),
+            "timed-out child {pid} was not killed and reaped",
+        );
+    }
 }

--- a/crates/rimz/tests/integration/common/mod.rs
+++ b/crates/rimz/tests/integration/common/mod.rs
@@ -16,8 +16,9 @@ mod env;
 mod harness;
 mod payloads;
 mod shim;
+mod zellij;
 
-pub use command::{CommandTimeoutExt, ScrubSessionEnvExt};
+pub use command::{CommandTimeoutExt, ROOM_WORKFLOW_TIMEOUT, ScrubSessionEnvExt};
 pub use env::{Env, af_unix_bind_sandboxed, canonical, tmux_pane};
 pub use harness::Harness;
 pub use payloads::{
@@ -31,6 +32,7 @@ pub use shim::{
     path_with_front, write_env_dump_shim, write_failing_agent_shim, write_fake_bash_shell,
     write_fake_login_shell, write_hook_firing_agent,
 };
+pub use zellij::ZellijNamespace;
 
 pub fn exec_args(request: &rimz::harness::launch::ExecRequest) -> Vec<String> {
     rimz::harness::launch::exec_argv(std::path::Path::new("rimz"), request)

--- a/crates/rimz/tests/integration/common/zellij.rs
+++ b/crates/rimz/tests/integration/common/zellij.rs
@@ -1,0 +1,93 @@
+//! Hermetic process namespace for live Zellij integration tests.
+
+use std::path::Path;
+use std::process::Command;
+
+use portable_pty::CommandBuilder;
+use tempfile::TempDir;
+
+use super::{CommandTimeoutExt, ScrubSessionEnvExt};
+
+/// Owns the private HOME, XDG, and temporary-file surface shared by one
+/// Zellij test server and all of its clients.
+pub struct ZellijNamespace {
+    root: TempDir,
+}
+
+impl ZellijNamespace {
+    pub fn new() -> Self {
+        let root = tempfile::Builder::new()
+            .prefix("rz")
+            .rand_bytes(6)
+            .tempdir()
+            .expect("zellij namespace tempdir");
+        let config_dir = root.path().join(".config/zellij");
+        std::fs::create_dir_all(&config_dir).expect("zellij config dir");
+        std::fs::write(
+            config_dir.join("config.kdl"),
+            "// Hermetic test config: stock behavior, no first-run wizard or tips UI.\nshow_startup_tips false\nshow_release_notes false\n",
+        )
+        .expect("zellij config.kdl");
+        Self { root }
+    }
+
+    pub fn path(&self) -> &Path {
+        self.root.path()
+    }
+
+    /// Build a short-lived control command scoped to this namespace.
+    pub fn command(&self) -> Command {
+        Self::command_at(self.path())
+    }
+
+    /// Build a control command from a path retained by a managed client or
+    /// helper while the owning namespace remains alive.
+    pub(crate) fn command_at(path: &Path) -> Command {
+        let mut command = Command::new("zellij");
+        command.scrub_session_env();
+        Self::pin_command_at(path, &mut command);
+        command
+    }
+
+    /// Scope a long-lived PTY child to the same namespace as control calls.
+    pub fn pin_pty(&self, command: &mut CommandBuilder) {
+        Self::pin_pty_at(self.path(), command);
+    }
+
+    /// Reapply an owned namespace path when a self-healing client respawns.
+    pub(crate) fn pin_pty_at(path: &Path, command: &mut CommandBuilder) {
+        command.scrub_session_env();
+        command.env("XDG_RUNTIME_DIR", path);
+        command.env("XDG_STATE_HOME", path);
+        command.env("XDG_CONFIG_HOME", path);
+        command.env("XDG_CACHE_HOME", path);
+        command.env("HOME", path);
+        command.env("TMPDIR", path);
+        command.env("ZELLIJ_CONFIG_DIR", path.join(".config/zellij"));
+    }
+
+    /// Best-effort teardown for an owned session.
+    pub fn delete_session(&self, name: &str) {
+        let _ = self
+            .command()
+            .args(["delete-session", name, "--force"])
+            .bounded_output();
+    }
+
+    fn pin_command_at(path: &Path, command: &mut Command) {
+        command
+            .env("XDG_RUNTIME_DIR", path)
+            .env("XDG_STATE_HOME", path)
+            .env("XDG_CONFIG_HOME", path)
+            .env("XDG_CACHE_HOME", path)
+            .env("HOME", path)
+            .env("TMPDIR", path)
+            .env("ZELLIJ_CONFIG_DIR", path.join(".config/zellij"));
+    }
+}
+
+impl Default for ZellijNamespace {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/rimz/tests/integration/journey/deep.rs
+++ b/crates/rimz/tests/integration/journey/deep.rs
@@ -18,7 +18,8 @@ use tempfile::TempDir;
 
 use super::{rimz_bin, session_start_at};
 use crate::common::{
-    CommandTimeoutExt, Env, ScrubSessionEnvExt, path_with_front, write_hook_firing_agent,
+    CommandTimeoutExt, Env, ScrubSessionEnvExt, ZellijNamespace, path_with_front,
+    write_hook_firing_agent,
 };
 
 const CAPTURE_BUDGET: Duration = Duration::from_secs(30);
@@ -344,22 +345,19 @@ fn zellij_room_shows_agent_after_hook() {
         return;
     }
 
-    let runtime = tempfile::Builder::new()
-        .prefix("rz")
-        .rand_bytes(6)
-        .tempdir()
-        .expect("short runtime dir");
+    let namespace = ZellijNamespace::new();
     let cwd = TempDir::new().expect("cwd dir");
     let fake_codex = fake_codex_bin(cwd.path());
     let name = "rimz-deep-zellij";
-    let _cleanup = ZellijSessionGuard {
+    let cleanup = ZellijSessionGuard {
         name: name.to_owned(),
-        runtime: runtime.path().to_path_buf(),
+        namespace,
     };
+    let runtime = cleanup.namespace.path();
 
     // Birth a background session whose left pane is a real renderer over the
     // shared store (the self-close layout shape from `backend/zellij.rs`).
-    let serve = sidebar_serve_line(&env, &rimz, runtime.path(), "zellij", name, &[]);
+    let serve = sidebar_serve_line(&env, &rimz, runtime, "zellij", name, &[]);
     let layout = format!(
         r#"layout {{
     tab name="room" {{
@@ -381,7 +379,9 @@ fn zellij_room_shows_agent_after_hook() {
     );
     let layout_path = cwd.path().join("layout.kdl");
     std::fs::write(&layout_path, layout).expect("write layout");
-    let created = scoped_zellij(runtime.path())
+    let created = cleanup
+        .namespace
+        .command()
         .args(["attach", "--create-background", name, "options"])
         .arg("--default-cwd")
         .arg(&env.project_root)
@@ -417,7 +417,7 @@ fn zellij_room_shows_agent_after_hook() {
     // Attach a real client so panes get a usable size and render (a
     // never-attached background session draws into a placeholder pane). Read
     // the composited screen the user would see and look for the agent row.
-    let screen = attach_and_read_until(runtime.path(), name, "codex", CAPTURE_BUDGET);
+    let screen = attach_and_read_until(&cleanup.namespace, name, "codex", CAPTURE_BUDGET);
     assert!(
         screen.contains("codex"),
         "the live zellij sidebar pane should show the agent row:\n{screen}"
@@ -627,7 +627,12 @@ fn tmux_supervised_print_returns_failed_when_agent_binary_exits_nonzero() {
 /// Attach a `portable-pty` client to `session` and poll the composited screen
 /// (vt100-parsed master output) until it contains `needle` or the budget
 /// elapses.
-fn attach_and_read_until(runtime: &Path, session: &str, needle: &str, budget: Duration) -> String {
+fn attach_and_read_until(
+    namespace: &ZellijNamespace,
+    session: &str,
+    needle: &str,
+    budget: Duration,
+) -> String {
     const ROWS: u16 = 40;
     const COLS: u16 = 120;
     let pair = native_pty_system()
@@ -640,7 +645,7 @@ fn attach_and_read_until(runtime: &Path, session: &str, needle: &str, budget: Du
         .expect("openpty");
     let mut cmd = CommandBuilder::new("zellij");
     cmd.args(["attach", session]);
-    pin_zellij_pty_env(&mut cmd, runtime);
+    namespace.pin_pty(&mut cmd);
     let mut child = pair.slave.spawn_command(cmd).expect("attach zellij");
     drop(pair.slave);
 
@@ -837,7 +842,7 @@ fn tmux_capture(socket: &Path, args: &[&str]) -> String {
         .arg("-S")
         .arg(socket)
         .args(args)
-        .output()
+        .bounded_output()
         .expect("spawn tmux");
     assert!(
         out.status.success(),
@@ -864,7 +869,7 @@ fn capture_until(
             .arg("-S")
             .arg(socket)
             .args(["capture-pane", "-p", "-t", session])
-            .output()
+            .bounded_output()
             .expect("spawn tmux capture-pane");
         if out.status.success() {
             last = String::from_utf8_lossy(&out.stdout).into_owned();
@@ -893,7 +898,7 @@ fn capture_all_until(
             .arg("-S")
             .arg(socket)
             .args(["list-panes", "-t", session, "-F", "#{pane_id}"])
-            .output()
+            .bounded_output()
             .expect("spawn tmux list-panes");
         if panes.status.success() {
             let mut frame = String::new();
@@ -948,7 +953,7 @@ fn tmux_pane_alive(socket: &Path, session: &str, pane: &str) -> bool {
         .arg("-S")
         .arg(socket)
         .args(["list-panes", "-t", session, "-F", "#{pane_id}"])
-        .output()
+        .bounded_output()
         .expect("spawn tmux list-panes");
     out.status.success()
         && String::from_utf8_lossy(&out.stdout)
@@ -991,47 +996,17 @@ impl Drop for TmuxServerGuard {
             .arg("-S")
             .arg(&self.socket)
             .arg("kill-server")
-            .output();
+            .bounded_output();
     }
-}
-
-// --- zellij helpers ---
-
-fn scoped_zellij(runtime: &Path) -> Command {
-    let mut cmd = Command::new("zellij");
-    cmd.scrub_session_env();
-    pin_zellij_command_env(&mut cmd, runtime);
-    cmd
-}
-
-fn pin_zellij_command_env(cmd: &mut Command, runtime: &Path) {
-    cmd.env("XDG_RUNTIME_DIR", runtime)
-        .env("XDG_STATE_HOME", runtime)
-        .env("XDG_CONFIG_HOME", runtime)
-        .env("XDG_CACHE_HOME", runtime)
-        .env("HOME", runtime)
-        .env("TMPDIR", runtime);
-}
-
-fn pin_zellij_pty_env(cmd: &mut CommandBuilder, runtime: &Path) {
-    cmd.scrub_session_env();
-    cmd.env("XDG_RUNTIME_DIR", runtime);
-    cmd.env("XDG_STATE_HOME", runtime);
-    cmd.env("XDG_CONFIG_HOME", runtime);
-    cmd.env("XDG_CACHE_HOME", runtime);
-    cmd.env("HOME", runtime);
-    cmd.env("TMPDIR", runtime);
 }
 
 struct ZellijSessionGuard {
     name: String,
-    runtime: std::path::PathBuf,
+    namespace: ZellijNamespace,
 }
 
 impl Drop for ZellijSessionGuard {
     fn drop(&mut self) {
-        let _ = scoped_zellij(&self.runtime)
-            .args(["delete-session", &self.name, "--force"])
-            .bounded_output();
+        self.namespace.delete_session(&self.name);
     }
 }

--- a/crates/rimz/tests/integration/start.rs
+++ b/crates/rimz/tests/integration/start.rs
@@ -11,12 +11,9 @@ use std::time::{Duration, Instant};
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use rimz::workspace::WorkspaceResolver;
 
-use crate::common::{CommandTimeoutExt, Env};
+use crate::common::{CommandTimeoutExt, Env, ROOM_WORKFLOW_TIMEOUT};
 
 const MATERIALIZED_ROOM_PANES: &str = r#"[{"id":1,"is_plugin":false,"tab_id":1,"title":"rimz-sidebar"},{"id":2,"is_plugin":false,"tab_id":1,"title":"sh"}]"#;
-/// Full room birth exercises several bounded mux probes and sidebar handoffs;
-/// keep its process ceiling distinct from the 10-second control-command bound.
-const START_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn zellij_trace_shim() -> PathBuf {
     crate::common::cargo_bin("zellij-trace", env!("CARGO_BIN_EXE_zellij-trace"))
@@ -209,7 +206,7 @@ fn start_checks_hooks_on_birth_but_not_live_reattach() {
     let mut birth_command = birth.rimz();
     configure_actionable_hooks(&mut birth_command, &birth, &birth_bin, &birth_trace, "");
     let birth_output = birth_command
-        .bounded_output_within(START_TIMEOUT)
+        .bounded_output_within(ROOM_WORKFLOW_TIMEOUT)
         .expect("run absent-room start");
     assert!(
         birth_output.status.success(),
@@ -256,7 +253,7 @@ fn start_checks_hooks_on_birth_but_not_live_reattach() {
     let mut live_command = live.rimz();
     configure_actionable_hooks(&mut live_command, &live, &live_bin, &live_trace, &sessions);
     let live_output = live_command
-        .bounded_output_within(START_TIMEOUT)
+        .bounded_output_within(ROOM_WORKFLOW_TIMEOUT)
         .expect("run live-room start");
     assert!(
         live_output.status.success(),
@@ -339,7 +336,7 @@ fn reconnect_marker_keeps_pty_start_unattended() {
         let _ = reader.read_to_end(&mut output);
         output
     });
-    let deadline = Instant::now() + START_TIMEOUT;
+    let deadline = Instant::now() + ROOM_WORKFLOW_TIMEOUT;
     let status = loop {
         if let Some(status) = child.try_wait().expect("poll reconnect start") {
             break Some(status);
@@ -355,7 +352,7 @@ fn reconnect_marker_keeps_pty_start_unattended() {
     let output =
         String::from_utf8_lossy(&reader_thread.join().expect("join pty reader")).into_owned();
     let status = status.unwrap_or_else(|| {
-        panic!("reconnect start did not finish within {START_TIMEOUT:?}:\n{output}")
+        panic!("reconnect start did not finish within {ROOM_WORKFLOW_TIMEOUT:?}:\n{output}")
     });
     assert!(status.success(), "reconnect start failed: {output}");
     assert!(

--- a/crates/rimz/tests/integration/zellij_health.rs
+++ b/crates/rimz/tests/integration/zellij_health.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use rimz::workspace::WorkspaceResolver;
 use tempfile::TempDir;
 
-use crate::common::{CommandTimeoutExt, Env};
+use crate::common::{CommandTimeoutExt, Env, ROOM_WORKFLOW_TIMEOUT};
 
 #[test]
 fn uninspectable_live_zellij_room_attaches_as_is() {
@@ -27,7 +27,7 @@ fn uninspectable_live_zellij_room_attaches_as_is() {
         // The uninspectable room legitimately holds `start` for the full
         // pre-attach topology ceiling before attaching as-is, so keep the outer
         // test bound roomy while shortening the fake-shim probe.
-        .bounded_output_within(Duration::from_secs(30))
+        .bounded_output_within(ROOM_WORKFLOW_TIMEOUT)
         .expect("run rimz start");
 
     assert!(output.status.success(), "live room should attach as-is");
@@ -140,7 +140,7 @@ fn tmux_start_skips_wedged_rival_zellij_session_probe() {
         // scheduler-sensitive when nextest runs the gate under load.
         .env("RIMZ_TEST_ZELLIJ_LIST_SESSIONS_SLEEP", "60")
         .env("RIMZ_TEST_SESSION_PROBE_MS", "100")
-        .bounded_output_within(Duration::from_secs(30))
+        .bounded_output_within(ROOM_WORKFLOW_TIMEOUT)
         .expect("run rimz start");
 
     assert!(
@@ -181,7 +181,7 @@ fn zellij_start_fails_fast_when_selected_session_probe_wedges() {
         // probe deadlines ran and killed their children.
         .env("RIMZ_TEST_ZELLIJ_LIST_SESSIONS_SLEEP", "60")
         .env("RIMZ_TEST_SESSION_PROBE_MS", "100")
-        .bounded_output_within(Duration::from_secs(30))
+        .bounded_output_within(ROOM_WORKFLOW_TIMEOUT)
         .expect("run rimz start");
 
     assert!(


### PR DESCRIPTION
## Context

Five Zellij live-backend integration tests flaked in GitHub Actions. They were fixture races against a loaded CI runner, not product bugs; nextest retries masked them until they burned every try. The failure modes:

1. `open_sidebar_births_native_layout_and_template` — the attached-client fixture never checked whether the `zellij attach` child died or wedged, so a client that failed to register burned the full spawn timeout with zero diagnostics.
2. `split_pane_targets_non_focused_tab_without_moving_client_focus` and `tab_switch_repairs_sidebar_focus_from_attached_client_views` — a single client keystroke to move between tabs was followed by a *passive* wait for the client to land on the target pane. Under load Zellij drops the keystroke, and a passive wait cannot re-send it, so the client parked on the old tab until the deadline.
3. `native_focused_split_preserves_docked_sidebar` — the "before" geometry was captured mid-resize, while the tab was still growing from its birth size to the client width, so later "sidebar unchanged" comparisons ran against stale geometry.
4. `reconcile_repairs_a_nested_sidebar_into_a_full_height_left_column` — the test implicitly asserted that best-effort post-repair focus restoration always lands, but that restoration is best-effort by product doctrine ("pane focus is latency, never truth").

The deeper problem was that every live test hand-coded its own PTY coordination, session registration, scheduler timing, and teardown, so the same class of race kept reappearing per test. This change fixes the flakes and then refactors the harness so the causal contract lives in the fixture: a live test states its scenario, performs the product action once, and waits on an observable invariant. It is test infrastructure only — no product code under `crates/rimz/src/` or the Zellij plugin changes.

## Design choices

- **Registration is construction.** `AttachedClient::attach` / `create_and_attach` return only once a new human client is stably registered, defined by `ClientView.presence.human_clients` (not non-empty `viewed_panes`, which excludes plugin views and cannot define registration), then gated on a stable non-empty terminal view. A dead or 15-second-wedged attach respawns within the existing 60-second budget; every failure message carries attempt count, last human-client count, last terminal view, child exit status, and a bounded 8 KiB PTY tail. Re-attach cannot mask a product bug — the fixture is a raw `zellij attach` PTY and all product assertions come afterward. A live run demonstrated why registration and terminal-readiness are separate states: a client was human-registered while its terminal view was still empty, so immediate setup keystrokes were lost.
- **Setup converges; the action under test stays one-shot.** Idempotent preconditions (select a known tab, move to a known pane) re-send the nudge each poll until the client view names the target pane (`press_alt_until` / `go_to_tab_until`). The product-event tab switches that trigger presence focus repair stay a single raw `go_to_tab`, so the fixture never retries the behavior under assertion.
- **One bounded-subprocess module.** Short mux control commands run in an isolated process group with a 10-second ceiling; a timeout kills the whole command tree, reaps the child, joins both pipe drainers, and reports bounded stdout/stderr tails. Full room workflows share one `ROOM_WORKFLOW_TIMEOUT` (30 s). Process-group isolation (beyond a plain direct-child kill) is what makes the pipe joins genuinely bounded when a command spawns descendants.
- **One hermetic namespace, one session owner, one client.** `ZellijNamespace` owns the disposable HOME/XDG/TMP surface, the explicit Zellij config path, PTY pinning, and cleanup; `LiveZellijSession` owns that namespace plus the session name and backend; `AttachedClient` is the single managed PTY client with three named construction modes (normal, create-and-attach, exact-lineage) and no boolean flags. Exact-lineage attach preserves one process and PID and never respawns, because the reaper test asserts on it.
- **Settle-gated geometry and best-effort focus.** The focused-split baseline is captured only after the tab spans the attached client's width; the reconcile test drives focus onto the original pane before asserting input routing (approved at the plan's design gate), keeping every durable assertion — redocked, geometry, identity, pane typable — and dropping only the assertion that best-effort focus restoration always wins.
- **CI headroom.** Focus, input-delivery, and named-pane deadlines are 30 seconds; the 60-second spawn budget is unchanged.

## Implementation

- `common/command.rs` — `CommandTimeoutExt` (`bounded_output` / `bounded_output_within` / `bounded_status`), the public `ROOM_WORKFLOW_TIMEOUT`, process-group isolation and kill, and a Linux regression test that holds both pipes open through a background child and asserts the timeout kills, reaps, and returns bounded per-stream diagnostics. The test is written to stay deterministic on a saturated runner: it records the child PID before emitting any output, times out with scheduler headroom rather than on a knife-edge, and polls for the reparented grandchild's teardown instead of checking `/proc` once — the killed grandchild is reparented to init and reaped asynchronously.
- `common/zellij.rs` — new `ZellijNamespace`: scrubbed `Command`/`CommandBuilder` construction, the hermetic `config.kdl`, and best-effort `delete_session`.
- `support/session.rs` — `LiveZellijSession` replaces the old client-owning `ZellijSession`; background/plain births, action-server readiness, and `Drop`-time deletion.
- `support/client.rs` — `AttachedClient` and its private PTY process; registration, semantic focus/input methods, and the two-marker (500 ms, 200-line) `assert_input_reaches` routed-input proof.
- Migrated `launch.rs`, `pane_io.rs`, `reconcile.rs`, `tabs.rs`, `presence.rs`, `reap.rs`, `daemon.rs`, `self_close.rs`, `width.rs`, `resume.rs` to the session/client fixtures; `pane_io::client_view_tracks_the_attached_client` deepened into the constructor contract (one human client on one immediate read, terminal view asserted separately).
- Bounded the touched tmux/room controls (`single_backend_room.rs`, `tmux/support.rs`, `server_cwd.rs`, `journey/deep.rs`) and rehomed the room-workflow timeout (`start.rs`, `zellij_health.rs`).

Deviations from the plan, each deliberate: the PTY tail is shared across respawn attempts (preserves a failed incarnation's output when a later one wedges); `ZELLIJ_CONFIG_DIR` is pinned explicitly in addition to the planned XDG/HOME set (Zellij 0.44.3 showed its first-run wizard without it); process-group isolation extends the planned direct-child kill; `single_backend_room.rs` keeps its `Env`-owned Zellij roots because the product process and mux must share that broader room fixture.

## Advisories

- **Minor cleanup (non-blocking).** After the migration to scrollback-based `assert_input_reaches`, two tests still spawn a shell pane that appends stdin to an input-log file nobody reads (`presence.rs` `routed-input.log`, `tabs.rs` `source-input.log`). Harmless — the pane still serves as a live input target — but dead scaffolding worth simplifying to a plain stdin sink.
- **Design decision (approved).** The reconcile test no longer asserts that best-effort post-repair focus restoration always lands, consistent with the "pane focus is latency, never truth" doctrine.
- **Weak spots.** The forced 15-second respawn branch did not trigger naturally in the green stress runs, so it is the least-exercised path (its exit-status variant now backs off 100 ms before respawn to avoid a fork storm). The deep Zellij journey can self-skip when the execution sandbox rejects its `AF_UNIX` bind probe; the backend Zellij suite and full live tier exercise real local Zellij independently.

Verification: `cargo xtask gate` and `cargo xtask test -P live` (both backends) pass; the historically-flaky `tab_switch_repairs_sidebar_focus_from_attached_client_views` passes 6 consecutive runs at `--retries 0`, and the full `backend::zellij` live suite passes at `--retries 0` with no retries.
