### PR TITLE
fix(web): drop the browser leave-site confirmation on ttyd tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ RimZ is beta software on the 0.x line. Commands, flags, config keys, and output 
 
 ## Unreleased
 
+### Fixed
+
+- Closing a RimZ browser tab no longer asks for leave-site confirmation; reconnecting reattaches the same room.
+
 ## [0.4.2] (2026-07-22)
 
 The browser gets a real front door: the web daemon's base URL opens a themed live-session manager that lists and ranks your rooms, and `rimz web share` broadcasts a room read-only through a second, input-blocked daemon. Around it, agent lifecycle transitions stream as JSON Lines, layout cells accept any executable on PATH, the sidebar shows branch CI before a pull request exists, and a broad pass steadies browser fonts, cursors, input, and remote tunnel auth.

--- a/crates/rimz/src/web/ttyd/client.rs
+++ b/crates/rimz/src/web/ttyd/client.rs
@@ -47,6 +47,8 @@ pub(in crate::web) fn profile(config: &MachineConfig, ttyd_program: &Path) -> Cl
             "cursorBlink=false".to_owned(),
             "-t".to_owned(),
             "titleFixed=RimZ".to_owned(),
+            "-t".to_owned(),
+            "disableLeaveAlert=true".to_owned(),
         ],
         warnings: Vec::new(),
         pixel_protocol: None,
@@ -962,6 +964,8 @@ mod tests {
                 "cursorBlink=false",
                 "-t",
                 "titleFixed=RimZ",
+                "-t",
+                "disableLeaveAlert=true",
             ]
         );
         assert!(profile.warnings.is_empty());

--- a/docs/internals/web.md
+++ b/docs/internals/web.md
@@ -70,7 +70,7 @@ Rotation stops and restarts the live writable daemon so the old secret stops wor
 
 Credential creation, rotation, listing, and revocation have the same behavior in Basic and trusted-header modes. Rotation restarts both ttyd and its gate, so the gate's startup read receives the new secret.
 
-The daemon always passes `macOptionIsMeta=true`, `cursorBlink=false`, and `titleFixed=RimZ`. With `style_client = true`, it also projects the shared theme into xterm.js options and resolves the configured font.
+The daemon always passes `macOptionIsMeta=true`, `cursorBlink=false`, `titleFixed=RimZ`, and `disableLeaveAlert=true`. With `style_client = true`, it also projects the shared theme into xterm.js options and resolves the configured font.
 
 The built-in Nerd Font families use SHA-256-pinned regular and bold faces. HTTPS custom sources use a URL-hashed cache entry, local sources are read directly, and supported files end in `.ttf`, `.otf`, `.woff`, or `.woff2`. Font bytes live under `$XDG_CACHE_HOME/rimz/web-fonts`; `RIMZ_WEB_FONTS_OFFLINE` makes resolution cache-only.
 


### PR DESCRIPTION
## Context

Closing a RimZ browser tab pops the browser's "leave site?" confirmation. That dialog comes from ttyd's stock front-end, which registers a `beforeunload` guard while the WebSocket is open. RimZ sessions are durable multiplexer rooms — closing the tab loses nothing and reconnecting reattaches the same work — so the prompt is pure friction with no in-browser state to protect.

## Design choices

ttyd exposes this exactly as the client option `disableLeaveAlert` (boolean, default `false`), which removes the `beforeunload` listener. Client options are passed on the daemon argv as `-t key=value`, the same channel already carrying `macOptionIsMeta`, `cursorBlink`, and `titleFixed`.

The option is set unconditionally in the base args of `client::profile()` rather than behind a config knob: RimZ room state survives tab closure, so there is no scenario where the alert protects a user and a toggle would be dead surface. It lives in the base block (before the styling gate), because suppressing the dialog is browser behavior, not styling — so it applies even with `[web] enabled = false` styling off.

One edit covers both daemons: the writable daemon (`web/ttyd.rs:703`) and the read-only broadcast daemon (`web/share.rs:236`) both build their `-t` argv from the single `client::profile()` in `web/ttyd/client.rs`.

## Implementation

- `crates/rimz/src/web/ttyd/client.rs` — append `-t disableLeaveAlert=true` to the base `args` vec in `profile()`, grouped with the other safety options; update the `browser_safety_options_survive_disabled_web` test to pin the new pair.
- `docs/internals/web.md` — add `disableLeaveAlert=true` to the sentence listing the always-passed client options.
- `CHANGELOG.md` — one `### Fixed` line under `## Unreleased`.

The option is available on every supported daemon: `MIN_TTYD_VERSION` is `1.7.5` and `disableLeaveAlert` predates it. RimZ serves a custom index (`-I`) that is the stock ttyd front-end with the RimZ shim spliced in, so the stock JS that reads `disableLeaveAlert` and owns the guard remains intact; the option reaches the browser through the same path as the already-working `titleFixed=RimZ`. No behavior deviates from the plan.

## Advisories

The optional live browser check (start a room, open it, close the tab, confirm no dialog) was not run — it needs a manual interaction. Coverage is the focused unit test plus the full gate; the argument and its disabled-web path are pinned by `browser_safety_options_survive_disabled_web`.