### PR TITLE
fix(sidebar): transmit context-meter pixels in the gallery

### DIFF
--- a/crates/rimz/src/cli/sidebar.rs
+++ b/crates/rimz/src/cli/sidebar.rs
@@ -925,6 +925,7 @@ fn gallery_render_columns(
         .map(|(index, (state, selector))| {
             let mut snapshot = sidebar_fixture_snapshot(state)?;
             snapshot.theme.mode = theme.mode;
+            snapshot.theme.display.pixel = theme.display.pixel;
             snapshot.theme.glyphs = theme.glyphs.clone();
             snapshot.theme.pets.glyphs = theme.pets.glyphs;
             snapshot.theme.pets.enabled = pets;

--- a/crates/rimz/src/cli/sidebar/tests.rs
+++ b/crates/rimz/src/cli/sidebar/tests.rs
@@ -348,8 +348,9 @@ fn gallery_columns_follow_requested_order_and_selection() {
 
 #[test]
 fn gallery_render_columns_apply_pets_override() {
-    let columns =
-        super::gallery_render_columns(true, &rimz::config::ThemeConfig::default()).unwrap();
+    let mut theme = rimz::config::ThemeConfig::default();
+    theme.display.pixel = rimz::config::PixelMode::Off;
+    let columns = super::gallery_render_columns(true, &theme).unwrap();
     assert_eq!(
         columns
             .iter()
@@ -365,9 +366,13 @@ fn gallery_render_columns_apply_pets_override() {
             (true, "bsod")
         ],
     );
+    assert!(
+        columns
+            .iter()
+            .all(|(snapshot, _)| snapshot.theme.display.pixel == rimz::config::PixelMode::Off)
+    );
 
-    let disabled =
-        super::gallery_render_columns(false, &rimz::config::ThemeConfig::default()).unwrap();
+    let disabled = super::gallery_render_columns(false, &theme).unwrap();
     assert!(
         disabled
             .iter()

--- a/crates/rimz/src/sidebar_pane/app/demo.rs
+++ b/crates/rimz/src/sidebar_pane/app/demo.rs
@@ -103,6 +103,11 @@ pub fn serve_gallery(
                     .ensure_pixel_transmitted(terminal.backend_mut(), &state.ui, now_ms)?;
             }
             draw_gallery_to_terminal(&mut terminal, &mut states)?;
+            for state in &mut states {
+                state
+                    .paint
+                    .ensure_meters_transmitted(terminal.backend_mut(), &state.ui, now_ms)?;
+            }
             Ok(())
         })();
         let end_result = terminal.backend_mut().write_all(END_SYNC);

--- a/crates/rimz/src/sidebar_pane/app/paint.rs
+++ b/crates/rimz/src/sidebar_pane/app/paint.rs
@@ -188,16 +188,7 @@ impl FramePainter {
                 .saturating_mul(ui.animation_phase);
             self.ensure_pixel_transmitted(terminal.backend_mut(), ui, now_ms)?;
             render::draw_to_terminal_with_ui(terminal, snapshot, alert, ui)?;
-            if let Some(pixels) = &ui.meter_pixels {
-                for (image_id, raster) in pixels.visible_rasters() {
-                    self.meter_painter.ensure_transmitted(
-                        terminal.backend_mut(),
-                        image_id,
-                        raster,
-                        now_ms,
-                    )?;
-                }
-            }
+            self.ensure_meters_transmitted(terminal.backend_mut(), ui, now_ms)?;
             Ok(())
         })();
         let end_result = terminal.backend_mut().write_all(END_SYNC);
@@ -216,6 +207,21 @@ impl FramePainter {
         {
             self.painter
                 .ensure_transmitted(writer, pixel, frame, now_ms)?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn ensure_meters_transmitted<W: Write>(
+        &mut self,
+        writer: &mut W,
+        ui: &UiState,
+        now_ms: u64,
+    ) -> io::Result<()> {
+        if let Some(pixels) = &ui.meter_pixels {
+            for (image_id, raster) in pixels.visible_rasters() {
+                self.meter_painter
+                    .ensure_transmitted(writer, image_id, raster, now_ms)?;
+            }
         }
         Ok(())
     }

--- a/crates/rimz/src/sidebar_pane/app/tests.rs
+++ b/crates/rimz/src/sidebar_pane/app/tests.rs
@@ -397,6 +397,63 @@ fn refresh_view_gates_pixel_meter_frame_with_caps_and_master_switch() {
 }
 
 #[test]
+fn meter_transmission_paints_visible_rasters_once() {
+    let ws = workspace();
+    let snapshot = snapshot(&ws);
+    let mut ui = UiState::default();
+    let mut painter = paint::FramePainter::new(
+        PixelRenderCaps {
+            pixel_transport: true,
+            kitty_clients: true,
+        },
+        false,
+    );
+
+    painter.refresh_view(&mut ui, &snapshot, false);
+    let image_id = ui
+        .meter_pixels
+        .as_mut()
+        .expect("meter pixels")
+        .intern(crate::sidebar_pane::pixel::meter::MeterRaster::new(
+            2,
+            0.5,
+            [1, 2, 3],
+            Vec::new(),
+            [4, 5, 6],
+        ))
+        .expect("meter raster");
+    let placeholder = ratatui::text::Line::from(ratatui::text::Span::styled(
+        placeholder_cluster(0, 0),
+        ratatui::style::Style::default().fg(crate::sidebar_pane::pixel::image_id_color(image_id)),
+    ));
+    ui.meter_pixels
+        .as_mut()
+        .expect("meter pixels")
+        .observe_visible(&[placeholder]);
+
+    let mut first = Vec::new();
+    painter
+        .ensure_meters_transmitted(&mut first, &ui, 0)
+        .expect("transmit visible meter");
+    let text = String::from_utf8_lossy(&first);
+    assert!(text.contains("a=t"));
+    assert!(text.contains(&format!("i={image_id}")));
+
+    let mut repeat = Vec::new();
+    painter
+        .ensure_meters_transmitted(&mut repeat, &ui, 1)
+        .expect("deduplicate resident meter");
+    assert!(repeat.is_empty());
+
+    ui.meter_pixels = None;
+    let mut disabled = Vec::new();
+    painter
+        .ensure_meters_transmitted(&mut disabled, &ui, 2)
+        .expect("skip disabled meters");
+    assert!(disabled.is_empty());
+}
+
+#[test]
 fn pixel_layout_shift_uses_ratatui_diff_without_full_clear() {
     let ws = workspace();
     let mut snapshot = snapshot(&ws);


### PR DESCRIPTION
## Context

`rimz sidebar gallery` renders agent cards whose context progress bar shows empty on kitty-graphics-capable terminals, even though the same fixtures render a filled bar in the snapshot tests and the live sidebar. On the pixel path the bar is drawn as kitty image *placeholders* — cells carrying an image id in their foreground color — that stay invisible until the matching image bytes are transmitted to the terminal. The live sidebar transmits them after each draw; the gallery compositor, which builds its own frame loop to compose N columns into one terminal draw, never did, so the meter row showed only the glyph and the percentage with a blank middle.

A second gap on the same path: the gallery copied the user's theme mode, glyphs, and pet settings into each fixture snapshot but not `display.pixel`, so a user who had set `pixel = "off"` (for a terminal that garbles kitty passthrough) still got the pixel path in the gallery.

## Design choices

- Mirror the exact transmission step the live path already performs rather than inventing gallery-specific transport. The meter-transmit loop is extracted from `FramePainter::draw_and_paint` into one shared `FramePainter::ensure_meters_transmitted`, and both the live path and the gallery loop call it — the two stay bit-identical by construction.
- Transmit after the draw, inside the gallery's existing synchronized-output bracket. Placeholder observation (`observe_visible`) runs during composition inside the draw, so the frame's visible raster set is only correct afterwards; transmitting earlier would use stale visibility. This matches the live path's ordering.
- Per-column image-id spacing was already collision-safe (each column's painter id base is offset by `index << 12`, meter ids start at `+0x4000` with capacity 512), so no id-allocation change was needed.

## Implementation

- `sidebar_pane/app/paint.rs` — extract the meter loop into `pub(super) ensure_meters_transmitted(writer, ui, now_ms)`; `draw_and_paint` calls it in place of the inline loop, same writer and `now_ms`.
- `sidebar_pane/app/demo.rs` — `serve_gallery` calls `ensure_meters_transmitted` for each column after `draw_gallery_to_terminal`, still inside the `BEGIN_SYNC`/`END_SYNC` bracket.
- `cli/sidebar.rs` — `gallery_render_columns` propagates `theme.display.pixel` into each fixture snapshot alongside the existing `theme.mode` line, so the documented `pixel = "off"` kill switch is honored in the gallery.
- Tests: a new `sidebar_pane` unit test asserts a visible meter raster emits one kitty transmit carrying its image id, that a second call deduplicates via image residency, and that a disabled meter table is a no-op; the two CLI gallery-column tests now assert the propagated `display.pixel`.

No deviations from the plan — the code confirmed the plan's root-cause and ordering assumptions. `cargo xtask test sidebar_pane` (703 passed) and `cargo xtask gate` (fmt, invariants, docs-links, lint, test — all pass) are green.

## Advisories

- No kitty-capable terminal was available for a visual spot check, and the sandboxed `sidebar gallery` could not complete Crossterm's cursor-position handshake through the execution PTY, so the runtime evidence is the automated test that exercises the emitted kitty transmit command and image id directly rather than a rendered frame.