### PR TITLE
feat(docker): multi-arch try-it/deploy images on Debian 13 and Ubuntu LTS with daily-fresh toolchain

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+target/
+plan.md
+result.md
+review.md

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,211 @@
+name: Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: release tag to rebuild (defaults to the latest release)
+        required: false
+  schedule:
+    # Refresh the latest release's mutable tags with current upstream tools.
+    - cron: "0 5 * * *"
+  push:
+    tags: ["v*"]
+  pull_request:
+    paths:
+      - docker/**
+      - .dockerignore
+      - .github/workflows/docker-image.yml
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  # Publishes serialize on one non-cancelling lane; PR validation builds key
+  # per-ref and cancel stale runs.
+  group: docker-image-${{ github.event_name == 'pull_request' && format('pr-{0}', github.ref) || 'publish' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  resolve:
+    name: resolve release
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.release.outputs.image }}
+      matrix: ${{ steps.release.outputs.matrix }}
+      ref: ${{ steps.release.outputs.ref }}
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - id: release
+        name: Resolve release and build matrix
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          image="ghcr.io/${owner}/rimz"
+
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            tag="pr"
+            version="pr"
+            ref="$GITHUB_SHA"
+            matrix='{"include":[{"variant":"debian","base":"debian:13-slim","arch":"amd64","platform":"linux/amd64","runner":"ubuntu-latest"}]}'
+          else
+            if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+              tag="$GITHUB_REF_NAME"
+            else
+              tag="${REQUESTED_TAG:-$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)}"
+            fi
+            if ! printf '%s' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9][A-Za-z0-9.-]*)?$'; then
+              echo "::error::invalid RimZ release tag: ${tag}"
+              exit 1
+            fi
+            version="${tag#v}"
+            if ! printf '%s' "$version" | grep -Eq '^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$'; then
+              echo "::error::invalid Docker tag derived from ${tag}: ${version}"
+              exit 1
+            fi
+            ref="$tag"
+            matrix='{"include":[{"variant":"debian","base":"debian:13-slim","arch":"amd64","platform":"linux/amd64","runner":"ubuntu-latest"},{"variant":"debian","base":"debian:13-slim","arch":"arm64","platform":"linux/arm64","runner":"ubuntu-24.04-arm"},{"variant":"ubuntu","base":"ubuntu:26.04","arch":"amd64","platform":"linux/amd64","runner":"ubuntu-latest"},{"variant":"ubuntu","base":"ubuntu:26.04","arch":"arm64","platform":"linux/arm64","runner":"ubuntu-24.04-arm"}]}'
+          fi
+
+          {
+            echo "image=$image"
+            echo "matrix=$matrix"
+            echo "ref=$ref"
+            echo "tag=$tag"
+            echo "version=$version"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: build ${{ matrix.variant }}/${{ matrix.arch }}
+    needs: resolve
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.resolve.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.resolve.outputs.ref }}
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        env:
+          TOKEN: ${{ github.token }}
+        run: echo "$TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+      - name: Build image
+        env:
+          BASE_IMAGE: ${{ matrix.base }}
+          IMAGE: ${{ needs.resolve.outputs.image }}
+          PLATFORM: ${{ matrix.platform }}
+          VARIANT: ${{ matrix.variant }}
+        run: |
+          set -euo pipefail
+          common=(
+            --platform "$PLATFORM"
+            --pull
+            --no-cache
+            --build-arg "BASE_IMAGE=$BASE_IMAGE"
+            -f docker/Dockerfile
+          )
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            docker buildx build "${common[@]}" --load -t rimz-docker-pr .
+            exit 0
+          fi
+
+          metadata="${RUNNER_TEMP}/build-metadata.json"
+          docker buildx build "${common[@]}" \
+            --metadata-file "$metadata" \
+            --output "type=image,name=${IMAGE},push-by-digest=true,name-canonical=true,push=true" \
+            .
+          digest="$(jq -er '."containerimage.digest"' "$metadata")"
+          mkdir -p "${RUNNER_TEMP}/digests"
+          touch "${RUNNER_TEMP}/digests/${VARIANT}-${digest#sha256:}"
+          echo "pushed ${IMAGE}@${digest}"
+
+      - name: Upload image digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rimz-digest-${{ matrix.variant }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Publish validation summary
+        if: github.event_name == 'pull_request'
+        run: |
+          {
+            echo "### Validated Docker image build (not pushed)"
+            echo
+            echo "- \`debian:13-slim\` on \`linux/amd64\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  manifest:
+    name: publish manifests
+    if: github.event_name != 'pull_request'
+    needs: [resolve, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: rimz-digest-*
+          path: ${{ runner.temp }}/digests
+          merge-multiple: true
+
+      - name: Log in to GHCR
+        env:
+          TOKEN: ${{ github.token }}
+        run: echo "$TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+      - name: Publish multi-arch tags
+        env:
+          DIGESTS_DIR: ${{ runner.temp }}/digests
+          IMAGE: ${{ needs.resolve.outputs.image }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          publish_variant() {
+            variant="$1"
+            shift
+            files=("${DIGESTS_DIR}/${variant}-"*)
+            if [ ! -e "${files[0]}" ]; then
+              echo "::error::no ${variant} image digests were downloaded"
+              exit 1
+            fi
+
+            command=(docker buildx imagetools create)
+            for tag in "$@"; do
+              command+=(-t "${IMAGE}:${tag}")
+            done
+            for file in "${files[@]}"; do
+              command+=("${IMAGE}@sha256:${file##*-}")
+            done
+            "${command[@]}"
+          }
+
+          publish_variant debian "$VERSION" latest "${VERSION}-debian" debian
+          publish_variant ubuntu "${VERSION}-ubuntu" ubuntu
+
+          {
+            echo "### Published multi-arch RimZ images"
+            echo
+            echo "- \`${IMAGE}:${VERSION}\`"
+            echo "- \`${IMAGE}:latest\`"
+            echo "- \`${IMAGE}:${VERSION}-debian\`"
+            echo "- \`${IMAGE}:debian\`"
+            echo "- \`${IMAGE}:${VERSION}-ubuntu\`"
+            echo "- \`${IMAGE}:ubuntu\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -158,7 +158,7 @@ jobs:
     steps:
       - uses: docker/setup-buildx-action@v4
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@v7
         with:
           pattern: rimz-digest-*
           path: ${{ runner.temp }}/digests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ RimZ is beta software on the 0.x line. Commands, flags, config keys, and output 
 
 ### Added
 
+- Multi-architecture Debian 13 and Ubuntu 26.04 Docker images provide a ready RimZ room, web deployment, and uid-1000 devcontainer base with current multiplexers and the priority agent CLIs. → [installation](./docs/guide/installation.md#run-in-docker)
 - `rimz sessions` promotes the browser's themed live-room manager to a terminal command, and `n` opens a dormant-workspace plus directory selector that births and attaches a new room. → [Getting started](./docs/reference/cli/getting-started.md#pick-a-session)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ cargo install --locked rimz
 
 Prebuilt binaries and building from source are in the [installation guide](./docs/guide/installation.md).
 
+For a self-contained room with RimZ, both multiplexers, ttyd, and the priority agent CLIs preinstalled, [run the Docker image](./docs/guide/installation.md#run-in-docker).
+
 Hooks are how agents report to the room. The first `rimz` run offers to install them with a diff preview, and `rimz hooks install` does the same on demand:
 
 ```sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,132 @@
+ARG BASE_IMAGE=debian:13-slim
+
+FROM ${BASE_IMAGE} AS rimz-build
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      curl \
+      git \
+      libssl-dev \
+      pkg-config \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -fsSL \
+      --retry 5 --retry-delay 2 --retry-all-errors \
+      https://sh.rustup.rs \
+      | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable \
+ && rustc --version \
+ && cargo --version
+
+WORKDIR /src
+COPY . .
+RUN cargo build --locked --release -p rimz \
+ && target/release/rimz --version
+
+FROM ${BASE_IMAGE} AS tmux-build
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      bison \
+      build-essential \
+      ca-certificates \
+      curl \
+      libevent-dev \
+      libncurses-dev \
+      pkg-config \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --chmod=0755 docker/install-tmux.sh /usr/local/bin/install-tmux
+RUN /usr/local/bin/install-tmux
+
+FROM ${BASE_IMAGE}
+
+ARG BASE_IMAGE
+ARG DEBIAN_FRONTEND=noninteractive
+LABEL org.opencontainers.image.source="https://github.com/rimio-ai/rimz" \
+      org.opencontainers.image.description="Ready-to-run RimZ room with current multiplexers and priority agent CLIs" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.base.name="${BASE_IMAGE}"
+
+ENV LANG=C.UTF-8 \
+    PATH=/home/rimz/.local/bin:/home/rimz/.opencode/bin:$PATH
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      git \
+      jq \
+      libevent-core-2.1-7t64 \
+      libncursesw6 \
+      libstdc++6 \
+      libutempter0 \
+      openssh-client \
+      procps \
+      sudo \
+      unzip \
+      wget \
+      xz-utils \
+ && install -m 0755 -d /etc/apt/keyrings \
+ && curl --proto '=https' --tlsv1.2 -fL \
+      --retry 5 --retry-delay 2 --retry-all-errors \
+      https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && printf 'deb [arch=%s signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main\n' "$(dpkg --print-architecture)" \
+      > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends gh \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=tmux-build /opt/stage/usr/local/ /usr/local/
+COPY --from=rimz-build /src/target/release/rimz /usr/local/bin/rimz
+COPY --chmod=0755 docker/install-tools.sh /usr/local/bin/install-tools
+RUN /usr/local/bin/install-tools \
+ && npm install -g @earendil-works/pi-coding-agent \
+ && npm cache clean --force \
+ && pi --version
+
+RUN userdel -r ubuntu 2>/dev/null || true \
+ && useradd -m -u 1000 -s /bin/bash rimz \
+ && printf 'rimz ALL=(ALL) NOPASSWD:ALL\n' > /etc/sudoers.d/rimz \
+ && chmod 0440 /etc/sudoers.d/rimz \
+ && printf 'export PATH="$HOME/.local/bin:$HOME/.opencode/bin:$PATH"\n' > /etc/profile.d/rimz-path.sh \
+ && install -d -o rimz -g rimz /workspace
+
+COPY --chmod=0755 docker/install-agents.sh /usr/local/bin/install-agents
+COPY --chmod=0755 docker/entrypoint.sh /usr/local/bin/rimz-entrypoint
+
+USER rimz
+ENV HOME=/home/rimz
+WORKDIR /workspace
+RUN /usr/local/bin/install-agents \
+ && rimz hooks install claude \
+ && rimz hooks install codex \
+ && rimz hooks install pi \
+ && rimz hooks install opencode \
+ && rimz --version \
+ && tmux -V \
+ && zellij --version \
+ && ttyd --version \
+ && node --version \
+ && git --version \
+ && gh --version \
+ && claude --version \
+ && codex --version \
+ && pi --version \
+ && opencode --version \
+ && test "$(id -u)" -eq 1000 \
+ && sudo -n true
+
+EXPOSE 8200
+ENTRYPOINT ["/usr/local/bin/rimz-entrypoint"]
+CMD ["shell"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -12,7 +12,10 @@ case "${1:-shell}" in
     web)
         rimz config set web.interface 0.0.0.0
         rimz web open /workspace --print --no-resume
-        exec sleep infinity
+        sleep infinity &
+        sleeper=$!
+        trap 'kill "$sleeper" 2>/dev/null || true; wait "$sleeper" 2>/dev/null || true; exit 0' TERM INT
+        wait "$sleeper"
         ;;
     *)
         exec "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+case "${1:-shell}" in
+    shell)
+        printf '%s\n' \
+            'RimZ is ready: run `rimz` to open the room.' \
+            'Launch an agent with `claude`, `codex`, `pi`, or `opencode`.' \
+            'Browser mode: publish port 8200 and run this image with `web`.'
+        exec bash -l
+        ;;
+    web)
+        rimz config set web.interface 0.0.0.0
+        rimz web open /workspace --print --no-resume
+        exec sleep infinity
+        ;;
+    *)
+        exec "$@"
+        ;;
+esac

--- a/docker/install-agents.sh
+++ b/docker/install-agents.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu
+
+case "$(uname -m)" in
+    x86_64) codex_arch=x86_64 ;;
+    aarch64) codex_arch=aarch64 ;;
+    *)
+        echo "unsupported architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+mkdir -p "$HOME/.local/bin"
+
+echo "installing latest Claude Code"
+claude_installer="$(mktemp)"
+curl --proto '=https' --tlsv1.2 -fsSL \
+    --retry 5 --retry-delay 2 --retry-all-errors \
+    https://claude.ai/install.sh \
+    -o "$claude_installer"
+bash "$claude_installer"
+rm -f "$claude_installer"
+
+echo "installing latest Codex for ${codex_arch}"
+codex_tmp="$(mktemp -d)"
+curl --proto '=https' --tlsv1.2 -fL \
+    --retry 5 --retry-delay 2 --retry-all-errors \
+    "https://github.com/openai/codex/releases/latest/download/codex-${codex_arch}-unknown-linux-musl.tar.gz" \
+    | tar -xz -C "$codex_tmp"
+install -m 0755 "$codex_tmp"/codex-* "$HOME/.local/bin/codex"
+rm -rf "$codex_tmp"
+
+echo "installing latest OpenCode"
+opencode_installer="$(mktemp)"
+curl --proto '=https' --tlsv1.2 -fsSL \
+    --retry 5 --retry-delay 2 --retry-all-errors \
+    https://opencode.ai/install \
+    -o "$opencode_installer"
+bash "$opencode_installer" --no-modify-path
+rm -f "$opencode_installer"
+
+claude --version
+codex --version
+opencode --version

--- a/docker/install-tmux.sh
+++ b/docker/install-tmux.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+release_url="$(
+    curl --proto '=https' --tlsv1.2 -fsSI \
+        --retry 5 --retry-delay 2 --retry-all-errors \
+        https://github.com/tmux/tmux/releases/latest \
+        | tr -d '\r' \
+        | sed -n 's|^[Ll]ocation: .*/tag/||p'
+)"
+version="${release_url##*/}"
+if [ -z "$version" ]; then
+    echo "could not resolve the latest tmux release" >&2
+    exit 1
+fi
+
+echo "installing tmux ${version}"
+curl --proto '=https' --tlsv1.2 -fL \
+    --retry 5 --retry-delay 2 --retry-all-errors \
+    "https://github.com/tmux/tmux/releases/download/${version}/tmux-${version}.tar.gz" \
+    -o /tmp/tmux.tar.gz
+mkdir -p /tmp/tmux-src
+tar -xzf /tmp/tmux.tar.gz -C /tmp/tmux-src --strip-components=1
+(
+    cd /tmp/tmux-src
+    ./configure --prefix=/usr/local
+    make -j"$(nproc)"
+    make install DESTDIR=/opt/stage
+)
+/opt/stage/usr/local/bin/tmux -V

--- a/docker/install-tools.sh
+++ b/docker/install-tools.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -eu
+
+case "$(uname -m)" in
+    x86_64)
+        release_arch=x86_64
+        node_arch=x64
+        ;;
+    aarch64)
+        release_arch=aarch64
+        node_arch=arm64
+        ;;
+    *)
+        echo "unsupported architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+echo "installing latest ttyd for ${release_arch}"
+curl --proto '=https' --tlsv1.2 -fL \
+    --retry 5 --retry-delay 2 --retry-all-errors \
+    "https://github.com/tsl0922/ttyd/releases/latest/download/ttyd.${release_arch}" \
+    -o /usr/local/bin/ttyd
+chmod 0755 /usr/local/bin/ttyd
+
+echo "installing latest zellij for ${release_arch}"
+curl --proto '=https' --tlsv1.2 -fL \
+    --retry 5 --retry-delay 2 --retry-all-errors \
+    "https://github.com/zellij-org/zellij/releases/latest/download/zellij-${release_arch}-unknown-linux-musl.tar.gz" \
+    | tar -xz -C /usr/local/bin zellij
+
+node_version="$(
+    curl --proto '=https' --tlsv1.2 -fL \
+        --retry 5 --retry-delay 2 --retry-all-errors \
+        https://nodejs.org/dist/index.json \
+        | jq -er 'map(select(.lts != false))[0].version'
+)"
+echo "installing Node.js ${node_version} LTS for ${node_arch}"
+curl --proto '=https' --tlsv1.2 -fL \
+    --retry 5 --retry-delay 2 --retry-all-errors \
+    "https://nodejs.org/dist/${node_version}/node-${node_version}-linux-${node_arch}.tar.xz" \
+    | tar -xJ -C /usr/local --strip-components=1
+
+ttyd --version
+zellij --version
+node --version
+npm --version

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,17 +1,61 @@
 # Installation
 
-RimZ is a single binary for macOS and Linux. Pick one install path: the [install script](#install-with-the-script), [Homebrew](#install-with-homebrew-macos) on macOS, a [prebuilt binary](#install-a-prebuilt-binary) from the releases page, or [Cargo](#install-with-cargo). [Building from source](#build-from-source) is for working on RimZ itself or for platforms the prebuilt paths miss.
+RimZ is a single binary for macOS and Linux. Pick one host install path: the [install script](#install-with-the-script), [Homebrew](#install-with-homebrew-macos) on macOS, a [prebuilt binary](#install-a-prebuilt-binary) from the releases page, or [Cargo](#install-with-cargo). [Run in Docker](#run-in-docker) for a self-contained room with the supported tools already installed. [Building from source](#build-from-source) is for working on RimZ itself or for platforms the prebuilt paths miss.
 
 ## Prerequisites
 
 - **macOS or Linux.**
 - **A terminal multiplexer** — Zellij 0.44 or newer, or tmux 3.5 or newer. One is enough; both are first-class. Distribution packages are often too old; [get a current Zellij or tmux](#get-a-current-zellij-or-tmux) has install recipes for current builds.
-- **The agent CLIs you plan to run** — Claude Code, Codex, Pi, OpenCode, Droid, Kiro CLI, or Grok Build, installed per their own docs. RimZ drives the stock CLIs and bundles none of them.
+- **The agent CLIs you plan to run on a host install** — Claude Code, Codex, Pi, OpenCode, Droid, Kiro CLI, or Grok Build, installed per their own docs. RimZ drives the stock CLIs; the Docker image preinstalls Claude Code, Codex, Pi, and OpenCode.
 - **Git** — agent worktrees and the sidebar's git status use it.
 
 RimZ refuses to start against a multiplexer below the minimum supported version, and `rimz doctor` reports the installed version and whether it clears that floor. On tmux, 3.6 or newer gives the best experience ([why](#rimz-doctor-flags-the-multiplexer-as-unsupported)).
 
 The multiplexer needs no configuration for RimZ: every room sets its own options on session start and reattach, and your existing Zellij or tmux config keeps owning your theme, shell, and keybinds. The room's essential settings are in [set up your machine](./setup.md#configure-your-multiplexer), and a full baseline for your own sessions is [Zellij and tmux baselines](./multiplexer.md).
+
+## Run in Docker
+
+A normal container gives a clean shell but leaves you to assemble its developer tools. The RimZ image starts as uid 1000 with RimZ, current Zellij, tmux, ttyd, GitHub CLI, Node.js, Claude Code, Codex, Pi, and OpenCode ready on `PATH`:
+
+```sh
+docker run --rm -it -v "$PWD":/workspace ghcr.io/rimio-ai/rimz
+```
+
+The bind mount makes the current checkout the room at `/workspace`. Agent authentication otherwise disappears with the container; add a named home volume to keep logins, agent state, RimZ configuration, and the hooks baked into the image:
+
+```sh
+docker run --rm -it \
+  -v "$PWD":/workspace \
+  -v rimz-home:/home/rimz \
+  ghcr.io/rimio-ai/rimz
+```
+
+Codex keeps per-hook trust behind its own UI, so the image leaves that consent to you: after the first Codex launch, run `/hooks` inside Codex and trust the RimZ hooks. `rimz doctor` reports the hooks as installed but untrusted until then.
+
+The `web` command births the `/workspace` room, binds RimZ to every container interface, and leaves the authenticated ttyd daemon online:
+
+```sh
+docker run -d --name rimz-web \
+  -p 8200:8200 \
+  -v "$PWD":/workspace \
+  -v rimz-home:/home/rimz \
+  ghcr.io/rimio-ai/rimz web
+docker logs rimz-web              # URL and generated Basic credential
+docker rm -f rimz-web             # stop and remove it
+```
+
+The default and `debian` tags use Debian 13; `ubuntu` uses Ubuntu 26.04 LTS. A release such as `0.4.2` also has `0.4.2-debian` and `0.4.2-ubuntu` tags. The workflow refreshes these tags daily so the bundled toolchain stays current; pin an image digest when the complete filesystem must stay immutable.
+
+The uid-1000 `rimz` user has passwordless sudo, so the same image works as a devcontainer base:
+
+```json
+{
+  "image": "ghcr.io/rimio-ai/rimz",
+  "remoteUser": "rimz"
+}
+```
+
+Docker builds run on both amd64 and arm64. Use the normal host install when you need another agent CLI, direct access to an existing host multiplexer, or native desktop integration.
 
 ## Install with the script
 


### PR DESCRIPTION
## Context

Trying RimZ today means first assembling a working multiplexer, ttyd, and each agent CLI on the host. This ships a set of ready-to-run container images so a single `docker run` lands in a room with RimZ, current Zellij/tmux/ttyd, GitHub CLI, Node, and the four priority agent CLIs (Claude Code, Codex, Pi, OpenCode) already on `PATH`. One image serves three uses: an interactive try-it shell, a deployable web-accessible container (`rimz web` on an exposed port), and a uid-1000 base image for end-user devcontainers. This repo's own dev/CI image (`rimz-ci`) is untouched.

## Design choices

- **Multi-arch on native runners.** `linux/amd64` + `linux/arm64` built on `ubuntu-latest` + `ubuntu-24.04-arm`, no QEMU — avoids emulation failure modes, at the cost of depending on GitHub's arm64 runner availability.
- **Two bases, one Dockerfile.** `ARG BASE_IMAGE` parameterizes `debian:13-slim` (default/bare tags) and `ubuntu:26.04` (LTS, suffixed tags).
- **rimz compiled from the checked-out tag**, in a builder stage sharing the runtime base — rather than `cargo install` from crates.io. This avoids racing `release.yml`'s crates.io publish, works on both arches, and keeps builder glibc equal to runtime glibc. `.git` stays in the build context so `build.rs` stamps a clean version at the tag.
- **Registry and tags.** `ghcr.io/<owner>/rimz`, beside `rimz-ci`. From `vX.Y.Z`: Debian gets `X.Y.Z`, `latest`, `X.Y.Z-debian`, `debian`; Ubuntu gets `X.Y.Z-ubuntu`, `ubuntu`.
- **Mutable tags, daily refresh.** A cron rebuilds the latest release with `--pull --no-cache`, moving the tags onto a freshly-resolved toolchain. Digest pins are documented for deployments that need an immutable filesystem.
- **No checksum pins on upstream tools.** "Latest" is the contract; TLS plus official sources are the integrity boundary, matching `install.sh`'s latest path.

## Implementation

- `docker/Dockerfile` — three stages sharing `ARG BASE_IMAGE`: `rimz-build` (rustup stable, `cargo build --locked --release -p rimz`), `tmux-build` (tmux from source, `make install DESTDIR=/opt/stage` for a clean copy-out), and the runtime stage. Runtime installs the tmux runtime libs, GitHub CLI from its apt repo, ttyd/Zellij/Node via `install-tools.sh`, Pi via npm, then creates the uid-1000 `rimz` user (deleting Ubuntu's stock uid-1000 user first) with passwordless sudo. Agent CLIs install as `rimz`, then `rimz hooks install` bakes hooks for all four. A closing `RUN` verifies every tool resolves and executes, uid is 1000, and sudo is non-interactive.
- `docker/install-{tmux,tools,agents}.sh` — POSIX sh, `set -eu`, curl with retry and `--proto '=https' --tlsv1.2`. Each resolves and prints the versions it installs (the daily build's audit trail); arch mapping lives once per script.
- `docker/entrypoint.sh` — `shell` (default) prints a quick-start hint and execs a login bash; `web` sets `web.interface 0.0.0.0`, births the `/workspace` room, prints the URL and Basic credential to container logs, and holds PID 1 with a signal-trapped sleeper for a clean `docker stop`; anything else is passthrough.
- `.github/workflows/docker-image.yml` — resolve/build/manifest jobs. Triggers: tag push `v*`, daily cron, `workflow_dispatch`, and `pull_request` on `docker/**`. Build legs push per-arch by digest to artifacts; the manifest job assembles the tag sets with `imagetools create`. The PR lane builds debian/amd64 only, no push.
- `.dockerignore` excludes `target/` and the git-ignored scratch files while keeping `.git`. The existing `ci-image.yml` build is unaffected — it copies only `Cargo.*`, `crates/`, and `xtask/`.
- Docs: a "Run in Docker" section in `docs/guide/installation.md` (try-it, persistent home volume, web mode, tag scheme, digest pin, devcontainer snippet), a README pointer, and a CHANGELOG entry.

Deviations from the plan, all verified in the build:

- The `t64` package-name divergence the plan hedged on did not materialize — both bases expose `libevent-core-2.1-7t64`, and both build.
- `jq` and `libstdc++6` are runtime dependencies (Node release-index parsing; Node and agent native binaries).
- Codex hooks are installed but trust stays behind Codex's interactive `/hooks` consent; the guide and `rimz doctor` surface that remaining step.

## Validation

- Both bases build via podman; the final stage reports RimZ 0.4.2, tmux 3.7b, Zellij 0.44.3, ttyd 1.7.7, Node 24.18.0, Claude Code 2.1.218, Codex 0.145.0, Pi 0.81.1, OpenCode 1.18.4.
- `rimz doctor` in each variant: uid 1000, tmux and ttyd floors green, agents reporting, only the expected Codex trust warning. Web mode returns HTTP 401 with the credential in logs and stops cleanly in ~162 ms.
- `cargo xtask gate` is green; Actionlint and `sh -n docker/*.sh` pass.

## Review

Blind review found two issues, both fixed in `fix(docker): preserve artifact publish and clean shutdown` and re-verified:

- **Blocking:** the manifest job's `download-artifact` was `@v8` while the build job uploaded with `@v7` — a major mismatch on the publish path the PR lane never exercises. Aligned to `@v7`.
- **Advisory:** the `web` entrypoint's `exec sleep infinity` left PID 1 ignoring SIGTERM, so `docker stop` blocked for the full grace period. Replaced with a trapped, backgrounded sleeper that exits cleanly.

## Follow-up to watch

The full multi-arch publish — per-arch digest push plus manifest assembly across all four legs — can only prove out on a real tag or cron run. The pull-request lane validates only the debian/amd64 build without pushing, so the first tagged release is where the publish path gets its first live exercise.