### PR TITLE
feat(harness): compact idle agents before the provider cache expires (`harness.idle_compact`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ RimZ is beta software on the 0.x line. Commands, flags, config keys, and output 
 - Finished team receipts show the aggregate session cache-hit percentage, and `rimz stats` leads Agents rows with dollars and separates the heatmap legend from the grid. → [Token Insight](./docs/guide/insight.md#the-full-picture-rimz-stats)
 - `rimz agents show` and sidebar snapshots expose live per-session tool-call counts, while `rimz stats --json` adds backfilled tool totals and per-name maps for Claude, Codex, Pi, and OpenCode history. → [Token Insight](./docs/guide/insight.md#how-the-numbers-are-calculated)
 - Codex 0.145+ cache writes are parsed from rollouts, priced at the model's cache-create rate, and rendered in agent cards and `rimz stats`.
+- `harness.idle_compact` compacts a large idle agent context before the provider cache expires, either for every eligible agent or only while a teammate still works or the pull request remains open. → [loops](./docs/guide/loops.md#idle-compaction)
 
 ### Fixed
 

--- a/crates/rimz/src/cli/agents_cmd/idle_compact.rs
+++ b/crates/rimz/src/cli/agents_cmd/idle_compact.rs
@@ -1,0 +1,307 @@
+//! `rimz agents idle-compact` — the hidden helper the sidebar producer spawns
+//! to compact an eligible idle agent through the durable message path.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use clap::Args;
+use jiff::Timestamp;
+
+use rimz::agents::AgentStatus;
+use rimz::config::{IdleCompactMode, MachineConfig};
+use rimz::harness::assist_log::{Assist, AssistRecord};
+use rimz::ids::{AgentKind, AgentSessionId, PaneId, WorkspaceId};
+use rimz::message::{
+    DeliveryGate, MessageBody, MessageRecord, MessageSender, deliver, send::already_compacted_at,
+};
+use rimz::store::workspace_record;
+use rimz::workspace::ResolvedWorkspace;
+use rimz::{RuntimePaths, StatePaths, Store};
+
+#[derive(Debug, Args)]
+pub struct IdleCompactArgs {
+    #[arg(long)]
+    workspace_id: String,
+    #[arg(long)]
+    kind: String,
+    #[arg(long)]
+    agent_id: String,
+    /// Normalized pane id (`tmux:%3`, `zellij:terminal_3`).
+    #[arg(long)]
+    pane: String,
+    #[arg(long)]
+    command: String,
+    #[arg(long)]
+    occupied_tokens: u64,
+    #[arg(long)]
+    label: Option<String>,
+}
+
+pub fn run_idle_compact(args: IdleCompactArgs) -> Result<()> {
+    let workspace_id: WorkspaceId = args.workspace_id.parse().context("parsing workspace id")?;
+    let pane_id = PaneId::parse(&args.pane).context("parsing pane id")?;
+    let kind = AgentKind::new_unchecked(args.kind.clone());
+    let agent_id = AgentSessionId::from(args.agent_id.as_str());
+    let expected_command = rimz::agents::spec_by_kind(kind.as_str())
+        .and_then(|spec| spec.launch.compact_command())
+        .context("idle-compaction target adapter has no compact command")?;
+    if args.command != expected_command {
+        bail!(
+            "idle-compaction command `{}` does not match {} adapter command `{expected_command}`",
+            args.command,
+            kind
+        );
+    }
+
+    let config = MachineConfig::load_lenient();
+    if config.harness.idle_compact == IdleCompactMode::Off {
+        return Ok(());
+    }
+
+    let paths = StatePaths::for_workspace(workspace_id.clone()).context("preparing store paths")?;
+    let runtime =
+        RuntimePaths::for_workspace(workspace_id.clone()).context("preparing runtime paths")?;
+    let record = workspace_record::read(&paths.workspace_record).with_context(|| {
+        format!(
+            "reading workspace record `{}`",
+            paths.workspace_record.display()
+        )
+    })?;
+    let store = Store::open(paths, runtime).context("opening store")?;
+    let workspace = ResolvedWorkspace {
+        workspace_id: workspace_id.clone(),
+        project_root: record.project_root.clone(),
+        root_class: record.root_class,
+        worktree_root: record.project_root.clone(),
+        worktree_branch: None,
+        session_name: record.session_name,
+        mux_hint: Some(pane_id.mux()),
+    };
+    let mut snapshot =
+        rimz::sidebar::produce::resolution_snapshot(&workspace, &store, Some(pane_id.mux()))
+            .context("reading idle-compaction delivery snapshot")?;
+    snapshot =
+        snapshot.with_agent_context(rimz::store::agent_context::read_all(store.runtime_paths()));
+    let agent = snapshot
+        .agents
+        .iter()
+        .find(|agent| agent.kind == kind && agent.agent_id == agent_id)
+        .context("idle-compaction target agent is no longer in the rollup")?;
+    snapshot
+        .agent_panes
+        .iter()
+        .find(|pane| {
+            pane.kind == kind
+                && pane.agent_id.as_ref() == Some(&agent_id)
+                && pane.pane_id == pane_id
+        })
+        .context("idle-compaction target pane is no longer bound to the agent")?;
+
+    let idle_after = config.harness.idle_compact_after();
+    let idle_secs = Timestamp::now().as_second() - agent.last_activity.as_second();
+    if agent.parent_agent_id.is_some()
+        || agent.agent_id.is_empty()
+        || agent.compacting_since.is_some()
+        || agent.budget_park.is_some()
+        || agent.is_awaiting_input()
+        || !matches!(
+            agent.effective_status(),
+            AgentStatus::Idle | AgentStatus::Success
+        )
+        || idle_secs < idle_after.as_secs().min(i64::MAX as u64) as i64
+    {
+        return Ok(());
+    }
+    let Some(occupied_tokens) = agent
+        .occupied_context_tokens()
+        .filter(|tokens| *tokens >= rimz::harness::idle_compact::IDLE_COMPACT_MIN_TOKENS)
+    else {
+        return Ok(());
+    };
+    if args.occupied_tokens != occupied_tokens {
+        tracing::debug!(
+            producer_occupied = args.occupied_tokens,
+            current_occupied = occupied_tokens,
+            "idle-compaction context reading changed before helper validation",
+        );
+    }
+    if already_compacted_at(&store, agent, expected_command, occupied_tokens)
+        || latest_delivered_was_compaction(
+            &store
+                .list_message_history()
+                .context("reading idle-compaction message history")?,
+            agent,
+            expected_command,
+        )
+    {
+        return Ok(());
+    }
+
+    let mut message = MessageRecord::new(
+        workspace_id,
+        agent,
+        expected_command.to_owned(),
+        true,
+        DeliveryGate::Done,
+    )
+    .with_channel(rimz::harness::target::agent_channel(agent))
+    .with_sender(MessageSender::System)
+    .with_automated(true)
+    .with_body(MessageBody::Command)
+    .with_pane_id(pane_id.clone());
+    message.compacted_context_tokens = Some(occupied_tokens);
+    let message_id = message.message_id.clone();
+    if let Err(err) = store.queue_message(&message, &workspace.session_name) {
+        append_assist(
+            &args,
+            kind,
+            agent_id,
+            idle_secs,
+            occupied_tokens,
+            &message_id,
+            false,
+            Some(err.to_string()),
+        );
+        return Err(err).context("queueing idle-compaction command");
+    }
+
+    let delivered = match deliver::deliver_one(
+        &workspace,
+        &store,
+        &message_id,
+        Duration::ZERO,
+        Some(pane_id.mux()),
+        deliver::DeliveryPolicy::Boundary,
+    ) {
+        Ok(delivered) => delivered,
+        Err(err) => {
+            append_assist(
+                &args,
+                kind,
+                agent_id,
+                idle_secs,
+                occupied_tokens,
+                &message_id,
+                false,
+                Some(err.to_string()),
+            );
+            return Err(err).context("delivering idle-compaction command");
+        }
+    };
+    let delivery_error = if delivered {
+        None
+    } else {
+        let reason = "idle-compaction delivery gate closed".to_owned();
+        match store.record_message_delivery_failures(
+            std::slice::from_ref(&message_id),
+            None,
+            rimz::store::DeliveryFailureDisposition::Retry,
+            &reason,
+            &workspace.session_name,
+        ) {
+            Ok(_) => Some(reason),
+            Err(err) => Some(format!("{reason}; recording retry failed: {err}")),
+        }
+    };
+    append_assist(
+        &args,
+        kind,
+        agent_id,
+        idle_secs,
+        occupied_tokens,
+        &message_id,
+        delivered,
+        delivery_error.clone(),
+    );
+    if let Some(error) = delivery_error.filter(|error| error.contains("recording retry failed")) {
+        bail!("{error}");
+    }
+    Ok(())
+}
+
+fn latest_delivered_was_compaction(
+    history: &[MessageRecord],
+    agent: &rimz::agents::AgentState,
+    command: &str,
+) -> bool {
+    history
+        .iter()
+        .filter(|message| {
+            message.status == rimz::message::MessageStatus::Delivered
+                && message.same_agent_card(agent)
+        })
+        .max_by(|left, right| left.message_id.as_str().cmp(right.message_id.as_str()))
+        .is_some_and(|message| {
+            message.body == MessageBody::Command
+                && message.text == command
+                && message.compacted_context_tokens.is_some()
+        })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn append_assist(
+    args: &IdleCompactArgs,
+    kind: AgentKind,
+    agent_id: AgentSessionId,
+    idle_secs: i64,
+    occupied_tokens: u64,
+    message_id: &rimz::ids::MessageId,
+    delivered: bool,
+    error: Option<String>,
+) {
+    rimz::harness::assist_log::append(&AssistRecord {
+        at: Timestamp::now(),
+        assist: Assist::IdleCompact {
+            kind,
+            agent_id,
+            label: args.label.clone(),
+            idle_secs: idle_secs.max(0) as u64,
+            occupied_tokens,
+            message_id: message_id.to_string(),
+            delivered,
+            error,
+        },
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn delivered(
+        agent: &rimz::agents::AgentState,
+        text: &str,
+        body: MessageBody,
+        tokens: Option<u64>,
+    ) -> MessageRecord {
+        let mut message = MessageRecord::new(
+            WorkspaceId::from_project_root(std::path::Path::new("/repo")),
+            agent,
+            text.to_owned(),
+            true,
+            DeliveryGate::Done,
+        )
+        .with_body(body);
+        message.status = rimz::message::MessageStatus::Delivered;
+        message.compacted_context_tokens = tokens;
+        message
+    }
+
+    #[test]
+    fn only_a_latest_delivered_compaction_suppresses_the_idle_reflex() {
+        let agent = rimz::agents::AgentState::stub("claude", "session-1", AgentStatus::Idle);
+        let compact = delivered(&agent, "/compact", MessageBody::Command, Some(80_000));
+        assert!(latest_delivered_was_compaction(
+            std::slice::from_ref(&compact),
+            &agent,
+            "/compact"
+        ));
+
+        let prompt = delivered(&agent, "continue", MessageBody::Prompt, None);
+        assert!(!latest_delivered_was_compaction(
+            &[compact, prompt],
+            &agent,
+            "/compact"
+        ));
+    }
+}

--- a/crates/rimz/src/cli/agents_cmd/mod.rs
+++ b/crates/rimz/src/cli/agents_cmd/mod.rs
@@ -8,6 +8,7 @@ mod check;
 mod exec;
 mod fork;
 mod history;
+mod idle_compact;
 pub(in crate::cli) mod launch;
 mod list;
 mod logs;
@@ -65,6 +66,7 @@ use check::{CheckArgs, run_check};
 use exec::run_exec;
 use fork::{ForkArgs, run_fork};
 use history::history_agent;
+use idle_compact::{IdleCompactArgs, run_idle_compact};
 use launch::*;
 use list::list_agents;
 pub(crate) use list::render_agents_table;
@@ -423,6 +425,10 @@ enum AgentsSubcmd {
     /// condition is due (`sidebar::enrich` auto-continue).
     #[command(hide = true)]
     AutoContinue(AutoContinueArgs),
+    /// Hidden helper the producer spawns to compact an eligible idle agent
+    /// before its provider prompt cache expires.
+    #[command(hide = true)]
+    IdleCompact(IdleCompactArgs),
     /// Hidden helper the producer spawns to redeem an account-wide Codex reset
     /// credit after rechecking current provider state.
     #[command(hide = true)]
@@ -455,6 +461,7 @@ pub fn run(args: AgentsArgs, globals: &GlobalFlags) -> Result<()> {
         Some(AgentsSubcmd::Register(args)) => return run_register(args),
         Some(AgentsSubcmd::Exec(exec)) => return run_exec(*exec, globals),
         Some(AgentsSubcmd::AutoContinue(args)) => return run_auto_continue(args),
+        Some(AgentsSubcmd::IdleCompact(args)) => return run_idle_compact(args),
         Some(AgentsSubcmd::AutoRedeem(args)) => return run_auto_redeem(args),
         Some(AgentsSubcmd::BudgetPark(args)) => return run_budget_park(args),
         Some(AgentsSubcmd::RefreshUsage(args)) => return run_refresh_usage(args, globals),

--- a/crates/rimz/src/cli/snapshots/rimz__cli__surface_tests__cli_surface.snap
+++ b/crates/rimz/src/cli/snapshots/rimz__cli__surface_tests__cli_surface.snap
@@ -174,6 +174,8 @@ rimz agents help help
 
 rimz agents help history
 
+rimz agents help idle-compact [hidden]
+
 rimz agents help list
 
 rimz agents help logs
@@ -207,6 +209,21 @@ rimz agents history
     --root <ROOT>  [action=set takes=1..=1 global]
     -n, --tail <TAIL>  [action=set takes=1..=1]
     --tmux  [action=set-true takes=0..=0 global]
+    --zellij  [action=set-true takes=0..=0 global]
+
+rimz agents idle-compact [hidden]
+    --agent-id <AGENT_ID>  [action=set takes=1..=1 required]
+    --color <COLOR>  [action=set takes=1..=1 global default=auto values=auto|always|never]
+    --command <COMMAND>  [action=set takes=1..=1 required]
+    -h, --help  [action=help takes=0..=0]
+    --kind <KIND>  [action=set takes=1..=1 required]
+    --label <LABEL>  [action=set takes=1..=1]
+    --mux <MUX>  [action=set takes=1..=1 global]
+    --occupied-tokens <OCCUPIED_TOKENS>  [action=set takes=1..=1 required]
+    --pane <PANE>  [action=set takes=1..=1 required]
+    --root <ROOT>  [action=set takes=1..=1 global]
+    --tmux  [action=set-true takes=0..=0 global]
+    --workspace-id <WORKSPACE_ID>  [action=set takes=1..=1 required]
     --zellij  [action=set-true takes=0..=0 global]
 
 rimz agents list (aliases: ls, ps)
@@ -669,6 +686,8 @@ rimz help agents focus
 rimz help agents fork
 
 rimz help agents history
+
+rimz help agents idle-compact [hidden]
 
 rimz help agents list
 

--- a/crates/rimz/src/cli/stats/assists.rs
+++ b/crates/rimz/src/cli/stats/assists.rs
@@ -71,6 +71,20 @@ pub(super) enum AssistEvent {
         occupied_tokens: Option<u64>,
         message_id: String,
     },
+    #[serde(rename = "idle_compact")]
+    IdleCompact {
+        at: Timestamp,
+        kind: AgentKind,
+        agent_id: AgentSessionId,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
+        idle_secs: u64,
+        occupied_tokens: u64,
+        message_id: String,
+        delivered: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
     #[serde(rename = "auto_resume")]
     Resume {
         at: Timestamp,
@@ -116,6 +130,9 @@ impl AssistStats {
                     }
                 }
                 AssistEvent::Compact { .. } => rollup.compacts += 1,
+                AssistEvent::IdleCompact { delivered, .. } => {
+                    rollup.compacts += usize::from(*delivered);
+                }
                 AssistEvent::Resume { recovered, .. } => {
                     rollup.restores += 1;
                     rollup.restored_sessions += recovered;
@@ -195,6 +212,26 @@ impl AssistEvent {
                 occupied_tokens,
                 message_id,
             },
+            Assist::IdleCompact {
+                kind,
+                agent_id,
+                label,
+                idle_secs,
+                occupied_tokens,
+                message_id,
+                delivered,
+                error,
+            } => Self::IdleCompact {
+                at: record.at,
+                kind,
+                agent_id,
+                label,
+                idle_secs,
+                occupied_tokens,
+                message_id,
+                delivered,
+                error,
+            },
             Assist::AutoResume {
                 workspace_id,
                 session_name,
@@ -217,6 +254,7 @@ impl AssistEvent {
             Self::Redeem { at, .. }
             | Self::Continue { at, .. }
             | Self::Compact { at, .. }
+            | Self::IdleCompact { at, .. }
             | Self::Resume { at, .. } => *at,
         }
     }
@@ -385,6 +423,31 @@ pub(super) fn benefit_line(event: &AssistEvent, zone: &jiff::tz::TimeZone) -> St
                 .unwrap_or_default();
             format!("{time} ⌁ {agent} auto-compact{detail}")
         }
+        AssistEvent::IdleCompact {
+            kind,
+            label,
+            idle_secs,
+            occupied_tokens,
+            delivered,
+            error,
+            ..
+        } => {
+            let agent = label.as_deref().unwrap_or(kind.as_str());
+            let outcome = if *delivered {
+                "compacted"
+            } else {
+                "compact held"
+            };
+            let error = error
+                .as_deref()
+                .map(|error| format!(" ({})", first_line(error)))
+                .unwrap_or_default();
+            format!(
+                "{time} ⌁ {agent} idle {outcome} after {} — {} ctx{error}",
+                format_hours(*idle_secs),
+                compact_token_count(*occupied_tokens),
+            )
+        }
         AssistEvent::Resume {
             cause,
             recovered,
@@ -441,6 +504,14 @@ pub(super) fn forensic_line(event: &AssistEvent, zone: &jiff::tz::TimeZone) -> S
         } => format!(
             "{at} {benefit} · agent {agent_id} · message {message_id} · threshold {}",
             compact_threshold(*threshold),
+        ),
+        AssistEvent::IdleCompact {
+            agent_id,
+            message_id,
+            delivered,
+            ..
+        } => format!(
+            "{at} {benefit} · agent {agent_id} · message {message_id} · delivered {delivered}"
         ),
         AssistEvent::Resume {
             workspace_id,

--- a/crates/rimz/src/cli/stats/tests.rs
+++ b/crates/rimz/src/cli/stats/tests.rs
@@ -1529,6 +1529,19 @@ fn assists_fold_rolls_up_benefit_and_keeps_failed_attempts_forensics() {
             },
         },
         AssistRecord {
+            at: ts(4_150),
+            assist: Assist::IdleCompact {
+                kind: AgentKind::new_unchecked("claude"),
+                agent_id: AgentSessionId::from("session-2"),
+                label: Some("@planner".to_owned()),
+                idle_secs: 3_540,
+                occupied_tokens: 180_000,
+                message_id: "msg_4".to_owned(),
+                delivered: true,
+                error: None,
+            },
+        },
+        AssistRecord {
             at: ts(4_200),
             assist: Assist::AutoResume {
                 workspace_id: rimz::ids::WorkspaceId::parse("ws_0123456789abcdef01234567").unwrap(),
@@ -1548,12 +1561,12 @@ fn assists_fold_rolls_up_benefit_and_keeps_failed_attempts_forensics() {
             resets: 1,
             resumes: 1,
             recovered_secs: 3_600,
-            compacts: 1,
+            compacts: 2,
             restores: 1,
             restored_sessions: 2,
         }
     );
-    assert_eq!(stats.events.len(), 5, "every assist outcome stays forensic");
+    assert_eq!(stats.events.len(), 6, "every assist outcome stays forensic");
     let categories = category_rows(&stats.rollup)
         .into_iter()
         .map(|row| strip_ansi(&row))
@@ -1585,6 +1598,11 @@ fn assists_fold_rolls_up_benefit_and_keeps_failed_attempts_forensics() {
             .iter()
             .any(|line| line.contains("@coder auto-compact — 210k ctx cleared before delivery"))
     );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.contains("@planner idle compacted after 1.0h — 180k ctx"))
+    );
     assert!(lines.iter().any(|line| {
         line.contains("rebirth recovery — 2 agents restored after crash (@coder, @reviewer)")
     }));
@@ -1597,6 +1615,11 @@ fn assists_fold_rolls_up_benefit_and_keeps_failed_attempts_forensics() {
         forensics
             .iter()
             .any(|line| line.contains("agent session-1 · message msg_3 · threshold 200k"))
+    );
+    assert!(
+        forensics
+            .iter()
+            .any(|line| line.contains("agent session-2 · message msg_4 · delivered true"))
     );
     assert!(forensics.iter().any(|line| {
         line.contains("workspace ws_0123456789abcdef01234567 · session rimz-test")

--- a/crates/rimz/src/config.rs
+++ b/crates/rimz/src/config.rs
@@ -79,7 +79,10 @@ pub use glyphs::{
     GlyphOverrides, GlyphRole, ThemeGlyphsConfig, glyph_lookup_hint, is_named_glyph_set,
     validate_glyph_source,
 };
-pub use harness::{DayCap, DayCapParseError, HarnessConfig, RtkMode, TurnCap, TurnCapParseError};
+pub use harness::{
+    DEFAULT_IDLE_COMPACT_AFTER, DayCap, DayCapParseError, HarnessConfig, IdleCompactMode, RtkMode,
+    TurnCap, TurnCapParseError,
+};
 pub use loop_::{CheckOn, LoopConfig, TaskBudgetError, TaskEntry, TaskTarget, Tasks};
 pub use mux::{
     MultiplexerConfig, MuxConfig, TmuxConfig, TmuxExtendedKeysFormat, TmuxPaneBorderLines,

--- a/crates/rimz/src/config/edit.rs
+++ b/crates/rimz/src/config/edit.rs
@@ -806,6 +806,8 @@ fn parse_edit_value(raw: &str) -> Value {
 
 fn parse_set_value(path: &[String], raw: &str) -> Value {
     if is_harness_smart_compact_edit(path)
+        || is_harness_idle_compact_edit(path)
+        || is_harness_idle_compact_after_edit(path)
         || is_harness_rtk_edit(path)
         || is_daily_budget_edit(path)
         || is_turn_budget_edit(path)
@@ -854,6 +856,22 @@ fn validate_set_value(path: &[String], value: &Value) -> Result<()> {
         };
         if let Err(err) = crate::message::AutoCompact::parse(threshold) {
             invalid_value!("{err}");
+        }
+    }
+    if is_harness_idle_compact_edit(path) {
+        let Some(mode) = value.as_str() else {
+            invalid_value!("harness.idle_compact must be a string");
+        };
+        if !matches!(mode, "off" | "auto" | "always") {
+            invalid_value!("harness.idle_compact must be one of off, auto, or always");
+        }
+    }
+    if is_harness_idle_compact_after_edit(path) {
+        let Some(duration) = value.as_str() else {
+            invalid_value!("harness.idle_compact_after must be a duration string");
+        };
+        if let Err(err) = super::harness::parse_idle_compact_after(duration) {
+            invalid_value!("harness.idle_compact_after {err}; use a duration such as 59m or 2h");
         }
     }
     if is_harness_rtk_edit(path) {
@@ -909,6 +927,14 @@ fn is_sidebar_theme_scheme_edit(path: &[String]) -> bool {
 
 fn is_harness_smart_compact_edit(path: &[String]) -> bool {
     matches!(path, [root, child] if root == "harness" && child == "smart_compact")
+}
+
+fn is_harness_idle_compact_edit(path: &[String]) -> bool {
+    matches!(path, [root, child] if root == "harness" && child == "idle_compact")
+}
+
+fn is_harness_idle_compact_after_edit(path: &[String]) -> bool {
+    matches!(path, [root, child] if root == "harness" && child == "idle_compact_after")
 }
 
 fn is_harness_rtk_edit(path: &[String]) -> bool {

--- a/crates/rimz/src/config/edit/tests.rs
+++ b/crates/rimz/src/config/edit/tests.rs
@@ -66,6 +66,8 @@ const LEGACY_SET_KEYS: &[&str] = &[
     "agents.worktree.base",
     "agents.placement",
     "harness.smart_compact",
+    "harness.idle_compact",
+    "harness.idle_compact_after",
     "harness.budget",
     "harness.rtk",
     "timezone",
@@ -253,6 +255,8 @@ fn validates_config_key_read_and_write_surfaces() {
         "notifications.title",
         "notifications.body",
         "harness.smart_compact",
+        "harness.idle_compact",
+        "harness.idle_compact_after",
         "harness.budget",
         "harness.turn_budget",
         "harness.rtk",
@@ -945,6 +949,15 @@ fn harness_smart_compact_values_are_parsed_as_strings() {
 }
 
 #[test]
+fn harness_idle_compact_values_are_parsed_as_strings() {
+    let mode = parse_key("harness.idle_compact").expect("mode key");
+    let after = parse_key("harness.idle_compact_after").expect("duration key");
+
+    assert_eq!(parse_set_value(&mode, "auto").as_str(), Some("auto"));
+    assert_eq!(parse_set_value(&after, "59m").as_str(), Some("59m"));
+}
+
+#[test]
 fn harness_turn_budget_values_are_validated_as_plain_amount_strings() {
     let key = parse_key("harness.turn_budget").expect("key");
 
@@ -985,6 +998,28 @@ fn harness_smart_compact_validation_rejects_bad_values() {
         err.contains("invalid auto-compact threshold `abc`"),
         "unexpected error: {err}"
     );
+}
+
+#[test]
+fn harness_idle_compact_validation_accepts_modes_and_duration() {
+    let mode = parse_key("harness.idle_compact").expect("mode key");
+    for value in ["off", "auto", "always"] {
+        validate_set_value(&mode, &Value::from(value)).expect("idle compact mode");
+    }
+    let err = validate_set_value(&mode, &Value::from("sometimes"))
+        .expect_err("invalid idle compact mode")
+        .to_string();
+    assert_eq!(
+        err,
+        "harness.idle_compact must be one of off, auto, or always"
+    );
+
+    let after = parse_key("harness.idle_compact_after").expect("duration key");
+    validate_set_value(&after, &Value::from("59m")).expect("idle compact duration");
+    let err = validate_set_value(&after, &Value::from("soon"))
+        .expect_err("invalid idle compact duration")
+        .to_string();
+    assert!(err.contains("use a duration such as 59m or 2h"), "{err}");
 }
 
 #[test]

--- a/crates/rimz/src/config/harness.rs
+++ b/crates/rimz/src/config/harness.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::str::FromStr;
+use std::time::Duration;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -168,6 +169,39 @@ pub enum TurnCapParseError {
 
 use crate::message::AutoCompact;
 
+/// Default idle span before RimZ compacts a warm provider cache.
+pub const DEFAULT_IDLE_COMPACT_AFTER: Duration = Duration::from_secs(59 * 60);
+
+const IDLE_COMPACT_DURATION_UNITS: &[(&str, u64)] =
+    &[("s", 1), ("m", 60), ("h", 60 * 60), ("d", 24 * 60 * 60)];
+
+/// Automatic idle-compaction policy.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum IdleCompactMode {
+    /// Leave idle agents untouched.
+    #[default]
+    Off,
+    /// Compact while a teammate still works or the worktree PR remains open.
+    Auto,
+    /// Compact every eligible idle agent.
+    Always,
+}
+
+impl IdleCompactMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Auto => "auto",
+            Self::Always => "always",
+        }
+    }
+
+    fn is_off(&self) -> bool {
+        *self == Self::Off
+    }
+}
+
 /// rtk output compression mode for agent-run cargo commands in `cargo xtask`.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -209,9 +243,66 @@ pub struct HarnessConfig {
         with = "smart_compact_serde"
     )]
     pub smart_compact: Option<AutoCompact>,
+    /// Compact an idle agent before its provider prompt cache expires.
+    #[serde(default, skip_serializing_if = "IdleCompactMode::is_off")]
+    pub idle_compact: IdleCompactMode,
+    /// Idle span that triggers [`idle_compact`](Self::idle_compact).
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "idle_compact_after_serde"
+    )]
+    pub idle_compact_after: Option<Duration>,
     /// rtk output compression for agent-run cargo commands in `cargo xtask`.
     #[serde(default)]
     pub rtk: RtkMode,
+}
+
+impl HarnessConfig {
+    pub fn idle_compact_after(&self) -> Duration {
+        self.idle_compact_after
+            .unwrap_or(DEFAULT_IDLE_COMPACT_AFTER)
+    }
+}
+
+pub(crate) fn parse_idle_compact_after(raw: &str) -> Result<Duration, String> {
+    crate::harness::schedule::parse_duration_units(raw, IDLE_COMPACT_DURATION_UNITS)
+}
+
+fn format_idle_compact_after(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    for (unit, factor) in [("d", 86_400), ("h", 3_600), ("m", 60)] {
+        if seconds >= factor && seconds.is_multiple_of(factor) {
+            return format!("{}{unit}", seconds / factor);
+        }
+    }
+    format!("{seconds}s")
+}
+
+mod idle_compact_after_serde {
+    use super::*;
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<String>::deserialize(deserializer)?
+            .map(|raw| parse_idle_compact_after(&raw).map_err(serde::de::Error::custom))
+            .transpose()
+    }
+
+    pub fn serialize<S>(
+        idle_compact_after: &Option<Duration>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match idle_compact_after {
+            Some(duration) => serializer.serialize_str(&format_idle_compact_after(*duration)),
+            None => serializer.serialize_none(),
+        }
+    }
 }
 
 mod smart_compact_serde {
@@ -310,6 +401,53 @@ mod tests {
         let back: HarnessConfig = toml::from_str(&toml).expect("parse harness config");
 
         assert_eq!(back, config);
+    }
+
+    #[test]
+    fn idle_compact_defaults_off_after_fifty_nine_minutes() {
+        let config: HarnessConfig = toml::from_str("").expect("parse harness config");
+
+        assert_eq!(config.idle_compact, IdleCompactMode::Off);
+        assert_eq!(config.idle_compact_after(), DEFAULT_IDLE_COMPACT_AFTER);
+    }
+
+    #[test]
+    fn idle_compact_modes_and_duration_round_trip() {
+        for mode in [
+            IdleCompactMode::Off,
+            IdleCompactMode::Auto,
+            IdleCompactMode::Always,
+        ] {
+            let config = HarnessConfig {
+                idle_compact: mode,
+                idle_compact_after: Some(Duration::from_secs(59 * 60)),
+                ..Default::default()
+            };
+
+            let toml = toml::to_string(&config).expect("serialize harness config");
+            if mode == IdleCompactMode::Off {
+                assert!(!toml.contains("idle_compact ="));
+            } else {
+                assert!(toml.contains(&format!("idle_compact = \"{}\"", mode.as_str())));
+            }
+            assert!(toml.contains("idle_compact_after = \"59m\""));
+            let back: HarnessConfig = toml::from_str(&toml).expect("parse harness config");
+            assert_eq!(back, config);
+        }
+    }
+
+    #[test]
+    fn idle_compact_after_parses_supported_units() {
+        for (raw, expected) in [
+            ("30s", Duration::from_secs(30)),
+            ("59m", Duration::from_secs(59 * 60)),
+            ("2h", Duration::from_secs(2 * 60 * 60)),
+            ("1d", Duration::from_secs(24 * 60 * 60)),
+        ] {
+            let config: HarnessConfig = toml::from_str(&format!("idle_compact_after = \"{raw}\""))
+                .expect("parse idle compact duration");
+            assert_eq!(config.idle_compact_after, Some(expected));
+        }
     }
 
     #[test]

--- a/crates/rimz/src/config/templates/config.template.toml
+++ b/crates/rimz/src/config/templates/config.template.toml
@@ -148,4 +148,6 @@ aggressive_resize = true
 ## budget = "50/day"             # turn on the whole-room local-day cap; adjust the live cap with `rimz budget`
 ## turn_budget = "3"              # cap every agent turn at this dollar amount
 ## smart_compact = "70%"          # default for messages/wakes ("70%", "120000", or "180k"); unset = off
+## idle_compact = "auto"           # compact idle agents before the provider cache expires; auto = while teammates work or the PR is open
+## idle_compact_after = "59m"      # idle span before compaction
 # rtk = "auto"                    # wrap agent cargo runs (build/check/test/nextest/clippy) through `rtk`; auto = when rtk is on PATH, on = force, off = never

--- a/crates/rimz/src/harness/AGENTS.md
+++ b/crates/rimz/src/harness/AGENTS.md
@@ -6,9 +6,9 @@ Topic detail lives in [harness.md](../../../../docs/internals/harness/harness.md
 
 ## Boundaries
 
-- The harness owns layout specs, effective launch resolution, profile prompt-file validation, launch finalization, provider-process compilation and argv, stable handles, supervised run records, the durable blocking-wait policy and run-wake socket (`run_wake.rs`), rebirth inspection and materialization, cohort and lane qualification/resume planning, relaunch posture resolution (`resume::resolve_posture`, shared by restart, fork, and every resume path), lane restore materialization, loop scheduling, hidden runner domain, and auto-continue policy.
+- The harness owns layout specs, effective launch resolution, profile prompt-file validation, launch finalization, provider-process compilation and argv, stable handles, supervised run records, the durable blocking-wait policy and run-wake socket (`run_wake.rs`), rebirth inspection and materialization, cohort and lane qualification/resume planning, relaunch posture resolution (`resume::resolve_posture`, shared by restart, fork, and every resume path), lane restore materialization, loop scheduling, hidden runner domain, auto-continue policy, and idle-compaction policy.
 - Harness delivery rides `message`; it never reimplements queues, gates, retries, or transcript audit.
 - CLI handlers keep argument parsing, presentation, and cross-command orchestration. Harness modules own pure domain rules, durable records, helper argv shape, and side-effect boundaries.
-- Elder-fired helpers in `schedule/fire.rs`, `auto_continue.rs`, and `auto_redeem.rs` spawn hidden CLI subprocesses with fresh null stdio.
-- `auto_continue.rs` and `auto_redeem.rs` are in the sidebar import graph. Keep them free of store-writer, run-wake, and broker imports; runtime-cache writes through `store::atomic::write_temp_then_rename_cache` are the allowed durability path.
+- Elder-fired helpers in `schedule/fire.rs`, `auto_continue.rs`, `auto_redeem.rs`, and `idle_compact.rs` spawn hidden CLI subprocesses with fresh null stdio.
+- `auto_continue.rs`, `auto_redeem.rs`, and `idle_compact.rs` are in the sidebar import graph. Keep them free of store-writer, run-wake, and broker imports; runtime-cache writes through `store::atomic::write_temp_then_rename_cache` are the allowed durability path.
 - Assist records append from detached helper CLI handlers and the loop runner; sidebar-graph modules only pass the evidence those writers need.

--- a/crates/rimz/src/harness/assist_log.rs
+++ b/crates/rimz/src/harness/assist_log.rs
@@ -64,6 +64,18 @@ pub enum Assist {
         occupied_tokens: Option<u64>,
         message_id: String,
     },
+    IdleCompact {
+        kind: AgentKind,
+        agent_id: AgentSessionId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
+        idle_secs: u64,
+        occupied_tokens: u64,
+        message_id: String,
+        delivered: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
     AutoResume {
         workspace_id: crate::ids::WorkspaceId,
         session_name: String,
@@ -181,12 +193,29 @@ mod tests {
         }
     }
 
+    fn idle_compacted(at: i64) -> AssistRecord {
+        AssistRecord {
+            at: ts(at),
+            assist: Assist::IdleCompact {
+                kind: AgentKind::new_unchecked("claude"),
+                agent_id: AgentSessionId::from("session-2"),
+                label: Some("@planner".to_owned()),
+                idle_secs: 3_540,
+                occupied_tokens: 180_000,
+                message_id: "msg_3".to_owned(),
+                delivered: true,
+                error: None,
+            },
+        }
+    }
+
     #[test]
     fn variants_round_trip_through_the_wire_shape() {
         for record in [
             redeem(20, "request-1"),
             resumed(20),
             compacted(20),
+            idle_compacted(20),
             restored(20),
         ] {
             let json = serde_json::to_string(&record).expect("serialize");

--- a/crates/rimz/src/harness/idle_compact.rs
+++ b/crates/rimz/src/harness/idle_compact.rs
@@ -1,0 +1,532 @@
+//! Producer-side idle compaction: condense a warm, inactive agent context before
+//! its provider prompt cache expires.
+//!
+//! The elected producer makes the pure eligibility decision and spawns the
+//! detached `rimz agents idle-compact` helper. The helper owns the durable
+//! message write; this module writes only a disposable pacing record.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+
+use crate::agents::{AgentState, AgentStatus};
+#[cfg(not(test))]
+use crate::child_process::detached_rimz_command;
+use crate::config::{HarnessConfig, IdleCompactMode};
+use crate::ids::{AgentKind, AgentSessionId, PaneId};
+use crate::store::atomic::write_temp_then_rename_cache;
+use crate::{RuntimePaths, SidebarSnapshot, WorktreePrState};
+
+/// Below this fill, re-caching costs less than an extra compaction turn.
+pub const IDLE_COMPACT_MIN_TOKENS: u64 = 50_000;
+
+/// Bounds duplicate helper spawns while a frame or context reading catches up.
+const IDLE_COMPACT_RESPAWN_THROTTLE: Duration = Duration::from_secs(10 * 60);
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct FireRecord {
+    fired_at: Timestamp,
+    fired_for_activity: Timestamp,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct AutoSignals {
+    teammate_working: bool,
+    pr_open: bool,
+}
+
+/// Compact every eligible root agent whose idle threshold is due.
+pub(crate) fn compact_idle_agents(
+    snapshot: &SidebarSnapshot,
+    runtime: &RuntimePaths,
+    config: &HarnessConfig,
+) {
+    if config.idle_compact == IdleCompactMode::Off {
+        return;
+    }
+    let pr_cache = (config.idle_compact == IdleCompactMode::Auto)
+        .then(|| crate::sidebar::refresh::pr::read_pr_state_cache(&runtime.pr_state_path()));
+    for agent in &snapshot.agents {
+        let command = crate::agents::spec_by_kind(agent.kind.as_str())
+            .and_then(|spec| spec.launch.compact_command());
+        let occupied = agent.occupied_context_tokens();
+        let record_path = fire_record_path(runtime, &agent.kind, &agent.agent_id);
+        let signals = if config.idle_compact == IdleCompactMode::Auto {
+            AutoSignals {
+                teammate_working: teammate_working(snapshot, agent),
+                pr_open: pr_cache
+                    .as_ref()
+                    .is_some_and(|cache| worktree_pr_open(agent, cache)),
+            }
+        } else {
+            AutoSignals::default()
+        };
+        if !should_compact(
+            agent,
+            command,
+            occupied,
+            config.idle_compact,
+            config.idle_compact_after(),
+            snapshot.now,
+            signals,
+            read_fire_record(&record_path).as_ref(),
+        ) {
+            continue;
+        }
+        let Some(pane_id) = live_pane(snapshot, agent) else {
+            continue;
+        };
+        let (Some(command), Some(occupied)) = (command, occupied) else {
+            continue;
+        };
+        let peers = snapshot.root_agents().collect::<Vec<_>>();
+        let label = crate::harness::target::agent_handle(agent, &peers, false);
+        if spawn_idle_compact(
+            runtime,
+            &agent.kind,
+            &agent.agent_id,
+            &pane_id,
+            command,
+            occupied,
+            &label,
+        ) {
+            write_fire_record(
+                &record_path,
+                &FireRecord {
+                    fired_at: snapshot.now,
+                    fired_for_activity: agent.last_activity,
+                },
+            );
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn should_compact(
+    agent: &AgentState,
+    compact_command: Option<&str>,
+    occupied: Option<u64>,
+    mode: IdleCompactMode,
+    idle_after: Duration,
+    now: Timestamp,
+    signals: AutoSignals,
+    record: Option<&FireRecord>,
+) -> bool {
+    if mode == IdleCompactMode::Off
+        || agent.parent_agent_id.is_some()
+        || agent.agent_id.is_empty()
+        || compact_command.is_none()
+        || agent.compacting_since.is_some()
+        || agent.budget_park.is_some()
+        || agent.is_awaiting_input()
+        || !matches!(
+            agent.effective_status(),
+            AgentStatus::Idle | AgentStatus::Success
+        )
+    {
+        return false;
+    }
+    if mode == IdleCompactMode::Auto && !(signals.teammate_working || signals.pr_open) {
+        return false;
+    }
+    let idle_secs = now.as_second() - agent.last_activity.as_second();
+    if idle_secs < idle_after.as_secs().min(i64::MAX as u64) as i64 {
+        return false;
+    }
+    let Some(occupied) = occupied.filter(|tokens| *tokens >= IDLE_COMPACT_MIN_TOKENS) else {
+        return false;
+    };
+    if agent.last_compact_command_tokens == Some(occupied) {
+        return false;
+    }
+    record.is_none_or(|record| {
+        record.fired_for_activity != agent.last_activity
+            && now.as_second() - record.fired_at.as_second()
+                >= IDLE_COMPACT_RESPAWN_THROTTLE.as_secs() as i64
+    })
+}
+
+fn teammate_working(snapshot: &SidebarSnapshot, candidate: &AgentState) -> bool {
+    let Some(channel) = crate::harness::target::agent_channel(candidate) else {
+        return false;
+    };
+    snapshot.root_agents().any(|agent| {
+        !(agent.kind == candidate.kind && agent.agent_id == candidate.agent_id)
+            && crate::harness::target::agent_channel(agent).as_deref() == Some(channel.as_str())
+            && agent.effective_status() == AgentStatus::Running
+    })
+}
+
+fn worktree_pr_open(agent: &AgentState, cache: &crate::sidebar::refresh::pr::PrStateCache) -> bool {
+    let (Some(path), Some(branch)) = (
+        agent.worktree_path.as_deref(),
+        agent.worktree_branch.as_deref(),
+    ) else {
+        return false;
+    };
+    cache.states.get(path).is_some_and(|link| {
+        link.branch.as_deref() == Some(branch) && link.state == WorktreePrState::Open
+    })
+}
+
+fn live_pane(snapshot: &SidebarSnapshot, agent: &AgentState) -> Option<PaneId> {
+    snapshot
+        .agent_panes
+        .iter()
+        .find(|pane| pane.kind == agent.kind && pane.agent_id.as_ref() == Some(&agent.agent_id))
+        .map(|pane| pane.pane_id.clone())
+}
+
+fn fire_record_path(
+    runtime: &RuntimePaths,
+    kind: &AgentKind,
+    agent_id: &AgentSessionId,
+) -> PathBuf {
+    runtime.root.join("idle-compact").join(format!(
+        "{}.json",
+        crate::harness::budget::agent_digest(kind, agent_id)
+    ))
+}
+
+fn read_fire_record(path: &Path) -> Option<FireRecord> {
+    std::fs::read(path)
+        .ok()
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+}
+
+fn write_fire_record(path: &Path, record: &FireRecord) {
+    if let Err(err) = write_temp_then_rename_cache(path, record) {
+        tracing::warn!(
+            tags.operation = "idle_compact.write_fire_record",
+            error = &err as &dyn std::error::Error,
+            "sidebar: failed to record idle-compaction pacing",
+        );
+    }
+}
+
+#[cfg(not(test))]
+fn spawn_idle_compact(
+    runtime: &RuntimePaths,
+    kind: &AgentKind,
+    agent_id: &AgentSessionId,
+    pane_id: &PaneId,
+    command: &str,
+    occupied: u64,
+    label: &str,
+) -> bool {
+    let exe = crate::proc::rimz_exe();
+    let mut cmd = detached_rimz_command(exe, runtime);
+    cmd.args([
+        "agents",
+        "idle-compact",
+        "--workspace-id",
+        runtime.workspace_id.as_str(),
+        "--kind",
+        kind.as_str(),
+        "--agent-id",
+        agent_id.as_str(),
+        "--pane",
+        &pane_id.to_string(),
+        "--command",
+        command,
+        "--occupied-tokens",
+        &occupied.to_string(),
+        "--label",
+        label,
+    ]);
+    tracing::info!(
+        target: crate::observability::BREADCRUMB_TARGET,
+        workspace = %runtime.workspace_id,
+        kind = %kind,
+        occupied,
+        "sidebar: compacting idle agent",
+    );
+    if let Err(err) = crate::child_process::spawn_detached_reaped(&mut cmd, "agent-idle-compact") {
+        tracing::debug!(
+            workspace = %runtime.workspace_id,
+            tags.operation = "idle_compact.spawn",
+            error = &err as &dyn std::error::Error,
+            "sidebar: failed to spawn agent idle-compaction",
+        );
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+fn spawn_idle_compact(
+    runtime: &RuntimePaths,
+    kind: &AgentKind,
+    agent_id: &AgentSessionId,
+    pane_id: &PaneId,
+    command: &str,
+    occupied: u64,
+    label: &str,
+) -> bool {
+    let _ = (runtime, kind, agent_id, pane_id, command, occupied, label);
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::AgentStatus;
+    use crate::ids::{MuxName, WorkspaceId};
+    use crate::sidebar::refresh::pr::{PrLink, PrStateCache};
+    use crate::store::snapshot::PaneAgent;
+
+    fn ts(seconds: i64) -> Timestamp {
+        Timestamp::from_second(seconds).expect("timestamp")
+    }
+
+    fn agent(status: AgentStatus, activity: i64, tokens: u64) -> AgentState {
+        let mut agent = AgentState::seed(
+            AgentKind::new_unchecked("claude"),
+            AgentSessionId::from("session-1"),
+            status,
+            ts(activity),
+        );
+        agent.usage.total_tokens = Some(tokens);
+        agent.worktree_path = Some("/repo/worktree".to_owned());
+        agent.worktree_branch = Some("feat/cache".to_owned());
+        agent
+    }
+
+    fn due(agent: &AgentState) -> bool {
+        should_compact(
+            agent,
+            Some("/compact"),
+            agent.occupied_context_tokens(),
+            IdleCompactMode::Always,
+            Duration::from_secs(59 * 60),
+            ts(10_000),
+            AutoSignals::default(),
+            None,
+        )
+    }
+
+    #[test]
+    fn predicate_requires_idle_threshold_and_context_floor() {
+        let candidate = agent(AgentStatus::Idle, 6_000, 50_000);
+        assert!(due(&candidate));
+        assert!(!due(&agent(AgentStatus::Idle, 6_461, 50_000)));
+        assert!(!due(&agent(AgentStatus::Idle, 6_000, 49_999)));
+        assert!(!should_compact(
+            &candidate,
+            None,
+            Some(50_000),
+            IdleCompactMode::Always,
+            Duration::from_secs(59 * 60),
+            ts(10_000),
+            AutoSignals::default(),
+            None,
+        ));
+        assert!(!should_compact(
+            &candidate,
+            Some("/compact"),
+            Some(50_000),
+            IdleCompactMode::Off,
+            Duration::from_secs(59 * 60),
+            ts(10_000),
+            AutoSignals::default(),
+            None,
+        ));
+    }
+
+    #[test]
+    fn predicate_skips_busy_parked_compacting_and_child_agents() {
+        for status in [
+            AgentStatus::Running,
+            AgentStatus::Waiting,
+            AgentStatus::Failed,
+            AgentStatus::Paused,
+        ] {
+            assert!(!due(&agent(status, 6_000, 50_000)), "{status:?}");
+        }
+
+        let mut parked = agent(AgentStatus::Idle, 6_000, 50_000);
+        parked.budget_park = Some(crate::harness::budget::BudgetPark {
+            cap_usd: 1.0,
+            spend_usd: 1.0,
+            window: crate::harness::budget::BudgetWindow::Session,
+            at: ts(6_000),
+            scope: crate::harness::budget::BudgetScope::Agent,
+            account_kind: None,
+            resets_at: None,
+        });
+        assert!(!due(&parked));
+
+        let mut compacting = agent(AgentStatus::Idle, 6_000, 50_000);
+        compacting.compacting_since = Some(ts(9_000));
+        assert!(!due(&compacting));
+
+        let mut child = agent(AgentStatus::Idle, 6_000, 50_000);
+        child.parent_agent_id = Some(AgentSessionId::from("parent"));
+        assert!(!due(&child));
+    }
+
+    #[test]
+    fn predicate_deduplicates_context_and_paces_spawns() {
+        let mut candidate = agent(AgentStatus::Idle, 6_000, 80_000);
+        candidate.last_compact_command_tokens = Some(80_000);
+        assert!(!due(&candidate));
+        candidate.last_compact_command_tokens = None;
+
+        let same_activity = FireRecord {
+            fired_at: ts(8_000),
+            fired_for_activity: candidate.last_activity,
+        };
+        assert!(!should_compact(
+            &candidate,
+            Some("/compact"),
+            Some(80_000),
+            IdleCompactMode::Always,
+            Duration::from_secs(59 * 60),
+            ts(10_000),
+            AutoSignals::default(),
+            Some(&same_activity),
+        ));
+
+        let recent = FireRecord {
+            fired_at: ts(9_500),
+            fired_for_activity: ts(5_000),
+        };
+        assert!(!should_compact(
+            &candidate,
+            Some("/compact"),
+            Some(80_000),
+            IdleCompactMode::Always,
+            Duration::from_secs(59 * 60),
+            ts(10_000),
+            AutoSignals::default(),
+            Some(&recent),
+        ));
+    }
+
+    #[test]
+    fn auto_requires_a_working_teammate_or_open_pr() {
+        let candidate = agent(AgentStatus::Idle, 6_000, 80_000);
+        for (signals, expected) in [
+            (AutoSignals::default(), false),
+            (
+                AutoSignals {
+                    teammate_working: true,
+                    pr_open: false,
+                },
+                true,
+            ),
+            (
+                AutoSignals {
+                    teammate_working: false,
+                    pr_open: true,
+                },
+                true,
+            ),
+        ] {
+            assert_eq!(
+                should_compact(
+                    &candidate,
+                    Some("/compact"),
+                    Some(80_000),
+                    IdleCompactMode::Auto,
+                    Duration::from_secs(59 * 60),
+                    ts(10_000),
+                    signals,
+                    None,
+                ),
+                expected
+            );
+        }
+        assert!(due(&candidate), "always ignores auto signals");
+    }
+
+    #[test]
+    fn auto_signal_resolution_uses_channel_and_matching_open_pr_branch() {
+        let candidate = agent(AgentStatus::Idle, 6_000, 80_000);
+        let mut teammate = agent(AgentStatus::Running, 9_900, 1);
+        teammate.agent_id = AgentSessionId::from("session-2");
+        let snapshot = SidebarSnapshot::build_with_agents(
+            WorkspaceId::from_project_root(Path::new("/repo")),
+            vec![candidate.clone(), teammate],
+            ts(10_000),
+        );
+        assert!(teammate_working(&snapshot, &candidate));
+
+        let open = PrLink {
+            branch: Some("feat/cache".to_owned()),
+            state: WorktreePrState::Open,
+            number: None,
+            url: None,
+            ci: None,
+            merge_sha: None,
+        };
+        let mut cache = PrStateCache::default();
+        cache
+            .states
+            .insert("/repo/worktree".to_owned(), open.clone());
+        assert!(worktree_pr_open(&candidate, &cache));
+        for state in [WorktreePrState::Closed, WorktreePrState::Merged] {
+            cache.states.get_mut("/repo/worktree").expect("link").state = state;
+            assert!(!worktree_pr_open(&candidate, &cache));
+        }
+        cache.states.insert(
+            "/repo/worktree".to_owned(),
+            PrLink {
+                branch: Some("other".to_owned()),
+                ..open
+            },
+        );
+        assert!(!worktree_pr_open(&candidate, &cache));
+    }
+
+    #[test]
+    fn producer_records_one_spawn_for_an_idle_stretch() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let workspace_id = WorkspaceId::from_project_root(dir.path());
+        let runtime = RuntimePaths::under(workspace_id.clone(), dir.path()).expect("runtime");
+        runtime.ensure_dirs().expect("runtime dirs");
+        let candidate = agent(AgentStatus::Idle, 6_000, 80_000);
+        let mut snapshot =
+            SidebarSnapshot::build_with_agents(workspace_id, vec![candidate.clone()], ts(10_000));
+        snapshot.agent_panes.push(PaneAgent {
+            kind: candidate.kind.clone(),
+            kind_ordinal: None,
+            name: None,
+            name_explicit: false,
+            profile: None,
+            role: None,
+            channel: None,
+            agent_id: Some(candidate.agent_id.clone()),
+            pane_id: PaneId::from_parts(MuxName::Tmux, "%1"),
+            pane_pid: None,
+            worktree_path: candidate.worktree_path.clone(),
+            worktree_branch: candidate.worktree_branch.clone(),
+        });
+        let config = HarnessConfig {
+            idle_compact: IdleCompactMode::Always,
+            idle_compact_after: Some(Duration::from_secs(59 * 60)),
+            ..Default::default()
+        };
+
+        compact_idle_agents(&snapshot, &runtime, &config);
+        let record = read_fire_record(&fire_record_path(
+            &runtime,
+            &candidate.kind,
+            &candidate.agent_id,
+        ))
+        .expect("fire record");
+        assert_eq!(record.fired_for_activity, candidate.last_activity);
+        assert!(!should_compact(
+            &candidate,
+            Some("/compact"),
+            Some(80_000),
+            IdleCompactMode::Always,
+            Duration::from_secs(59 * 60),
+            ts(11_000),
+            AutoSignals::default(),
+            Some(&record),
+        ));
+    }
+}

--- a/crates/rimz/src/harness/mod.rs
+++ b/crates/rimz/src/harness/mod.rs
@@ -4,6 +4,7 @@ pub mod assist_log;
 pub(crate) mod auto_continue;
 pub mod auto_redeem;
 pub mod budget;
+pub mod idle_compact;
 pub mod launch;
 pub mod petname;
 pub mod plan;

--- a/crates/rimz/src/sidebar/refresh/mod.rs
+++ b/crates/rimz/src/sidebar/refresh/mod.rs
@@ -247,6 +247,7 @@ pub fn refresh_heavy_lanes(
         base.resume_outcomes.as_deref().unwrap_or_default(),
     );
     crate::harness::auto_continue::resume_parked(base, runtime, &config.resume, &resume_messages);
+    crate::harness::idle_compact::compact_idle_agents(base, runtime, &config.harness);
     crate::harness::auto_redeem::redeem_credits(
         &panels.providers,
         runtime,

--- a/crates/rimz/src/store/gc/collect.rs
+++ b/crates/rimz/src/store/gc/collect.rs
@@ -74,6 +74,7 @@ fn collect_workspace_runtime(
     let context_dir = workspace_root.join("agent_context");
     let subagent_context_dir = workspace_root.join("subagent_context");
     let telemetry_dir = workspace_root.join("agent-telemetry");
+    let idle_compact_dir = workspace_root.join("idle-compact");
     for dir in [
         &heartbeat_dir,
         &sock_dir,
@@ -83,6 +84,7 @@ fn collect_workspace_runtime(
         &context_dir,
         &subagent_context_dir,
         &telemetry_dir,
+        &idle_compact_dir,
         workspace_root,
     ] {
         sweep.remember_dir_size(dir);
@@ -98,6 +100,7 @@ fn collect_workspace_runtime(
     collect_stale_sidecars(&active_time_dir, older_than, sweep, report)?;
     collect_stale_sidecars(&context_dir, older_than, sweep, report)?;
     collect_stale_sidecars(&subagent_context_dir, older_than, sweep, report)?;
+    collect_stale_sidecars(&idle_compact_dir, older_than, sweep, report)?;
     if !room_is_live {
         collect_stale_sidecars(&telemetry_dir, older_than, sweep, report)?;
     }
@@ -108,6 +111,7 @@ fn collect_workspace_runtime(
     sweep.remove_dir_if_empty(&active_time_dir, report)?;
     sweep.remove_dir_if_empty(&context_dir, report)?;
     sweep.remove_dir_if_empty(&subagent_context_dir, report)?;
+    sweep.remove_dir_if_empty(&idle_compact_dir, report)?;
     if !room_is_live {
         sweep.remove_dir_if_empty(&telemetry_dir, report)?;
     }
@@ -567,6 +571,9 @@ mod tests {
         fs::write(&stale_subagent, b"{}").unwrap();
         let stale_telemetry = rt.copilot_otel_path();
         fs::write(&stale_telemetry, b"{}\n").unwrap();
+        let stale_idle_compact = rt.root.join("idle-compact").join("deadbeef.json");
+        fs::create_dir_all(stale_idle_compact.parent().unwrap()).unwrap();
+        fs::write(&stale_idle_compact, b"{}").unwrap();
         let old = SystemTime::now() - Duration::from_secs(7200);
         for path in [
             &stale_read_marks,
@@ -575,6 +582,7 @@ mod tests {
             &stale_context,
             &stale_subagent,
             &stale_telemetry,
+            &stale_idle_compact,
         ] {
             fs::File::open(path).unwrap().set_modified(old).unwrap();
         }
@@ -583,7 +591,7 @@ mod tests {
             collect_runtime_under(&temp.path().join("rimz"), Duration::from_secs(3600), false)
                 .unwrap();
 
-        assert_eq!(report.sidecar_files_removed, 6);
+        assert_eq!(report.sidecar_files_removed, 7);
         assert!(
             !rt.read_marks_dir.exists(),
             "the emptied read-marks dir is removed"
@@ -607,6 +615,10 @@ mod tests {
         assert!(
             !rt.agent_telemetry_dir.exists(),
             "the emptied telemetry dir is removed"
+        );
+        assert!(
+            !rt.root.join("idle-compact").exists(),
+            "the emptied idle-compact dir is removed"
         );
         assert!(
             !rt.agent_activity_dir.parent().unwrap().exists(),

--- a/crates/rimz/src/store/writer/queue/tests/deliver.rs
+++ b/crates/rimz/src/store/writer/queue/tests/deliver.rs
@@ -141,6 +141,50 @@ fn record_sent_then_turn_start_confirms_delivery() {
 }
 
 #[test]
+fn idle_compact_command_delivers_at_boundary_and_stamps_the_rollup() {
+    let q = Queue::new();
+    let observation = AgentLifecycleObservation::new(
+        Some(AgentSessionId::from("sess-1")),
+        LifecycleSignal::Registered,
+    );
+    q.append_event(&EventEnvelope::agent_lifecycle(
+        q.workspace_id.clone(),
+        "session",
+        "claude",
+        "SessionStart",
+        &observation,
+    ))
+    .unwrap();
+    let command = q.queue_with(1, |message| {
+        message.text = "/compact".to_owned();
+        message.body = MessageBody::Command;
+        message.compacted_context_tokens = Some(80_000);
+    });
+    let claimed = q
+        .claim_message_for_delivery(&command.message_id, Timestamp::now())
+        .unwrap()
+        .expect("idle boundary claims command");
+    let sent = q
+        .record_sent_message(&claimed, "session")
+        .unwrap()
+        .expect("command sent");
+    let delivered = q
+        .confirm_delivered_for_card(
+            &sent.kind,
+            &sent.agent_id,
+            sent.agent_name.as_deref(),
+            MessageBody::Command,
+            "session",
+        )
+        .unwrap();
+    assert_eq!(delivered.len(), 1);
+
+    let (_, agents, _) = crate::store::snapshot::catch_up_rollup(&q.inner.paths).unwrap();
+    assert_eq!(agents.len(), 1);
+    assert_eq!(agents[0].last_compact_command_tokens, Some(80_000));
+}
+
+#[test]
 fn confirm_delivered_for_card_selects_oldest_matching_batch() {
     struct Case {
         name: &'static str,

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -16,6 +16,7 @@ rimz config set theme.style modern             # truecolor plus Nerd Font glyphs
 rimz config set theme.pets.enabled true        # an animated companion on the provider dashboard
 rimz config set resume.auto_continue true      # resume rate-limit and API-error parks on their own
 rimz config set harness.smart_compact 200k     # compact before a message once context passes 200k tokens
+rimz config set harness.idle_compact auto      # compact warm idle contexts while work may return
 rimz config set notifications.triggers '["waiting", "failed"]'   # which rows raise a banner
 rimz config set sidebar.focus_key "Alt+p"      # the chord that jumps to the sidebar from any pane
 rimz config set timezone "America/New_York"    # transcript times, scheduling, and the "today" cutoff
@@ -177,6 +178,16 @@ smart_compact = "200k"
 ```
 
 `smart_compact` sets the default threshold for compact-first `rimz message` sends and scheduled loop wakes, as an occupied-token count (`"200k"` or `"120000"`) or a percentage of the window (`"70%"`). When an agent's context window has reached the threshold, RimZ submits its `/compact` ahead of the text so the prompt lands against a fresh window. Leave it unset to keep compaction opt-in through the per-command `--smart-compact` flag for messages, which overrides this value. The mechanics are in [messaging.md](../internals/harness/messaging.md#smart-compaction).
+
+### Idle compaction
+
+```toml
+[harness]
+idle_compact = "auto"
+idle_compact_after = "59m"
+```
+
+`idle_compact` is `off` by default. `auto` compacts an eligible idle agent while a same-channel teammate is working or its worktree pull request is open; `always` ignores those re-engagement signals. `idle_compact_after` accepts `s`, `m`, `h`, or `d` and defaults to `59m`. The reflex requires at least 50,000 occupied context tokens, uses each adapter's native compact command, and fires at most once in one idle stretch. The behavior model is in [loops.md](./loops.md#idle-compaction), and the durable delivery mechanics are in [messaging.md](../internals/harness/messaging.md#idle-compaction).
 
 ### rtk output compression
 

--- a/docs/guide/loops.md
+++ b/docs/guide/loops.md
@@ -104,6 +104,7 @@ RimZ ships those reflexes built in. Switched on, the room recognizes each stop f
 ```sh
 rimz config set resume.auto_continue true     # resume rate-limit and API-error parks
 rimz config set resume.auto_redeem true       # spend Codex reset credits when they buy real time
+rimz config set harness.idle_compact auto     # compact warm idle contexts while work may return
 rimz config set harness.smart_compact 200k    # compact before a message once context passes 200k tokens (or "70%")
 ```
 
@@ -132,6 +133,12 @@ A Codex plan grants reset credits: redeem one and a spent usage window refills o
 - Scheduled redeem. Several credits approach expiry together. RimZ measures from your own recent usage how long a fresh window takes to fill and spaces the redemptions that far apart, working back from each credit's expiry, so each credit lands on a window with room to absorb it. A redemption or a natural reset moves the next attempt later, keeping the chain paced to real capacity.
 
 The reflex fails closed and paces itself. Every rule starts from a credit in hand, blocked gain and doomed credit additionally require a readable reset time, and attempts are throttled account-wide across every room on the machine: ten minutes between attempts, thirty after a success. A successful redemption immediately refreshes the account reading, and because a refilled window is certified recovered capacity, [auto-continue](#auto-continue) wakes the parked turns on it. The verdict and pacing model in full are [providers.md → Auto-redeem](../internals/agents/providers.md#auto-redeem).
+
+### Idle compaction
+
+An idle agent can outlive its provider's warm prompt cache, making the next message pay to cache the whole accumulated conversation again. `harness.idle_compact = "auto"` submits the agent's own compact command after 59 minutes of inactivity while a same-channel teammate is still working or the worktree pull request remains open; `"always"` applies the reflex to every eligible idle agent. `harness.idle_compact_after` overrides the threshold with a duration such as `"45m"` or `"2h"`.
+
+The reflex applies only to top-level agents whose adapter exposes a compact command and whose occupied context is at least 50,000 tokens. Working, waiting, parked, and already-compacting agents stay untouched, and durable delivery waits for an idle turn boundary. Each idle stretch compacts at most once: the pacing record suppresses repeated helper launches, the message record suppresses the same context fill, and a delivered compact remains the last-action guard until real work reaches the agent.
 
 ### Smart compaction
 

--- a/docs/internals/harness/messaging.md
+++ b/docs/internals/harness/messaging.md
@@ -261,6 +261,14 @@ Two paths, because the modes have different promises:
 
 A failed compaction fails the delivery through the same retry path as a failed send, which is the point of routing the command through a real record rather than typing it inline.
 
+## Idle compaction
+
+Idle compaction reuses the command-record half of smart compaction without attaching a following prompt. The elected sidebar producer checks top-level rollup agents against `[harness] idle_compact`, the idle threshold, the 50,000-token floor, adapter support, and the `auto` re-engagement signals, then spawns a detached `rimz agents idle-compact` helper so the sidebar import graph remains read-only on the store.
+
+The helper re-resolves the workspace, session, and pane, verifies that the agent is still idle and the configured threshold is still due, and validates the command against the adapter. It queues one automated system `MessageBody::Command` with `DeliveryGate::Done`, pins the pane, stamps `compacted_context_tokens` from the fresh context reading, and attempts `DeliveryPolicy::Boundary`. A closed boundary stays queued through the ordinary retry disposition rather than typing into a working, waiting, parked, or compacting pane.
+
+Three layers make the action once-per-idle-stretch. The producer's cache-class `(kind, agent_id)` record suppresses the same `last_activity` and throttles helper respawns; the live queue and `last_compact_command_tokens` suppress the same occupied reading; and the helper stops when the session's latest delivered record is already a compact command. A later delivered prompt breaks that final guard and begins a new eligible stretch once its own activity and context thresholds are reached.
+
 ## Reply waits
 
 `--wait[=DURATION]` turns a send into a synchronous scatter-gather. It stamps `reply_wait` on each durable record, then polls until every leg settles.


### PR DESCRIPTION
## Context

A provider's prompt cache expires after a TTL of inactivity (Claude Code's extended cache is 1h; every API request refreshes it). An agent left idle past the TTL pays to re-cache its entire accumulated context on the next message. Submitting the agent's own compact command *just before* expiry — while the cache is still warm, so the compact turn is a cheap cached read — lands the next message on a small summarized context instead of re-caching everything.

This adds an opt-in reflex, `harness.idle_compact`, that compacts a top-level agent once it has been idle for a threshold (default 59m, targeting Claude's 1h TTL). It applies to every agent kind whose adapter defines a compact command; Amp and Antigravity have none and are skipped. A given idle stretch is compacted at most once.

## Design choices

- **Config: two sibling keys under `[harness]`**, following the `resume.auto_continue*` precedent. `idle_compact = "off" | "auto" | "always"` (strict snake_case enum, default `off`) and `idle_compact_after = "59m"` (duration string, default 59m). Setting the duration without a mode does nothing.
- **Three modes.** `off` (default), `always` (every eligible idle agent), and `auto` (only while re-engagement is likely: a same-channel teammate is still Working, or the worktree's PR resolves to `Open` in the producer's `pr-state.json` cache). A solo agent on a trunk checkout with no PR therefore never auto-compacts — `always` is the mode for that shape. The PR cache is long-TTL, so a just-merged PR may still read `Open` briefly; the failure mode is one extra compact, which is self-limiting and accepted rather than adding a new forge probe.
- **Producer reflex + detached helper**, the same split as auto-continue. A pure fire predicate in `harness/idle_compact.rs` decides which agent and when from producer-side snapshot data; a hidden `rimz agents idle-compact` helper owns the durable store write, keeping the sidebar import graph read-only on the store.
- **Delivery through the durable message path.** The helper queues a `MessageBody::Command` carrying the adapter's compact command with `DeliveryGate::Done` and delivers it with `DeliveryPolicy::Boundary`. `Done` is ready only when the agent is Idle/Success, so a compact never types into a working, waiting, parked, or compacting pane; the snapshot stamp of `last_compact_command_tokens` gives dedup.
- **At most one compact per idle stretch, in three layers.** The producer's cache-class `(kind, agent_id)` fire record suppresses the same `last_activity` and throttles respawns (10m); the live queue plus `last_compact_command_tokens` suppress the same occupied-token reading; and the helper — the authoritative check — stops when the session's latest delivered record is already a compact command, so a summary is never re-compacted. A later delivered prompt clears that final guard and begins a new eligible stretch.
- **Worth-it floor.** The reflex requires at least 50,000 occupied context tokens; below that, re-caching costs less than a compact turn, and the floor doubles as the first line of re-fire suppression.
- **Accountability.** The helper appends an `Assist::IdleCompact` record (kind, agent, idle duration, occupied tokens, message id, delivery outcome) rendered in `rimz stats --assists`.

## Implementation

- `config/harness.rs` — `IdleCompactMode` enum and `idle_compact_after` duration serde (parsed via `parse_duration_units`), `DEFAULT_IDLE_COMPACT_AFTER` constant, round-trip and parse tests. `config/edit.rs` routes both keys for `rimz config set` with strict validation.
- `harness/idle_compact.rs` — the producer reflex: the pure `should_compact` predicate, `auto`-signal resolution (channel cohort from the snapshot, PR state from the producer's cache), the atomic fire record, and the detached helper spawn. In-module unit tests cover the threshold and floor boundaries, skipped states (working/waiting/parked/compacting/child), the context dedup and respawn throttle, and the `auto` gate.
- `cli/agents_cmd/idle_compact.rs` — the hidden helper: re-resolves the live card and pane, revalidates eligibility and the adapter command, enforces the latest-delivered guard, queues and boundary-delivers the command, records a retry disposition on a closed gate, and appends the assist.
- `harness/assist_log.rs` + `cli/stats/assists.rs` — the `IdleCompact` assist variant and its stats rendering; successful compactions join the existing compact count, held or failed attempts remain visible as forensic records.
- `store/gc/collect.rs` — the `idle-compact` runtime dir joins the sidecar reap set. Docs updated in `docs/guide/loops.md`, `docs/guide/configuration.md`, `docs/internals/harness/messaging.md`, and the changelog.

### Deviations from the plan

- The latest-delivered guard treats any delivered tracked compact command as satisfying, whether it came from idle or smart compaction, because `MessageRecord` carries no automation-source discriminator and re-compacting a fresh summary would be the wrong fallback.
- The requested double-invocation integration test is split into a pure `latest_delivered_was_compaction` unit test plus the store-lifecycle delivery test, covering the guard's decision without a live multiplexer.
- The template examples use `##` rather than `#`: `template_defaults_deserialize_to_machine_defaults` uncomments single-`#` leaves and asserts them against machine defaults, so a single `#` on `idle_compact = "auto"` would fail against the locked `off` default.

## Advisories

- **Minor, non-blocking (efficiency).** `compact_idle_agents` computes the `auto` signals (`teammate_working` scans root agents, O(n²) across the fleet in `auto` mode) and reads the per-agent fire record from disk for every agent before the cheap eligibility filter runs, whereas the sibling `auto_continue::resume_parked` filters child/empty-id agents ahead of its record read. Negligible for small fleets on the slow heavy-lane cadence and gated on opt-in, but it diverges from the idiom; reordering the cheap producer-side rejects ahead of the signal and disk work would match `resume_parked`.
- **Not manually smoke-tested end to end.** No real provider session over 50k tokens was left idle to exercise the live `/compact` pane action and its provider confirmation; the predicate, store-delivery, config, and assist seams are covered by automated tests, and the isolated binary smoke covers the config writes and hidden command surface.
