### PR TITLE
docs(readme): clarify first-run hook consent shows a summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ rimz remote connect dev-box:~/code/query-engine
 
 On macOS, the default latest-release script install uses Homebrew automatically when `brew` is available.
 
-Hooks install on the first `rimz` run, with your consent and a diff preview. → [set up your machine](./docs/guide/setup.md) · [enable dynamic shell completion](./docs/guide/setup.md#shell-completion)
+Hooks install on the first `rimz` run, with your consent and a summary of every file it touches; run `rimz hooks install --dry-run` first for the exact per-agent diff. → [set up your machine](./docs/guide/setup.md) · [enable dynamic shell completion](./docs/guide/setup.md#shell-completion)
 
 ## Everyday moves
 
@@ -267,7 +267,7 @@ Prebuilt binaries and building from source are in the [installation guide](./doc
 
 For a self-contained room with RimZ, both multiplexers, ttyd, and the priority agent CLIs preinstalled, [run the Docker image](./docs/guide/installation.md#run-in-docker).
 
-Hooks are how agents report to the room. The first `rimz` run offers to install them with a diff preview, and `rimz hooks install` does the same on demand:
+Hooks are how agents report to the room. The first `rimz` run offers to install them with a summary and your consent, and `rimz hooks install` does the same on demand — pass `--dry-run` first for the exact per-agent diff:
 
 ```sh
 rimz hooks install --dry-run    # per-agent summary plus a unified diff; writes nothing


### PR DESCRIPTION
## What

Fix two README lines that read as though the first-run hook-install consent renders a unified diff.

- `README.md` get-started note: now says consent shows a summary of every file touched, and points to `rimz hooks install --dry-run` for the exact per-agent diff.
- `README.md` install section: the intro to the hooks-install commands now says the first run installs after a summary and consent, with `--dry-run` for the exact diff.

## Why

In practice the first-run consent shows per-agent and file summaries plus statusline changes, not a unified diff. The actual per-file unified diff comes from the separate `rimz hooks install --dry-run`. This is verified in code: the consent summary omits diff hunks while `--dry-run` renders unified diffs. The security guide already describes this accurately, so this aligns the README with both the docs and the code.

Closes #69
