### PR TITLE
fix(cli): default first-run consent prompts to no

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ RimZ is beta software on the 0.x line. Commands, flags, config keys, and output 
 - Codex 0.145+ cache writes are parsed from rollouts, priced at the model's cache-create rate, and rendered in agent cards and `rimz stats`.
 - `harness.idle_compact` compacts a large idle agent context before the provider cache expires, either for every eligible agent or only while a teammate still works or the pull request remains open. → [loops](./docs/guide/loops.md#idle-compaction)
 
+### Changed
+
+- First-run consent prompts default to no: the project-trust grant for an untrusted clone and the hands-off automation opt-in both need an explicit yes, so pressing Enter never activates a cloned repo's command surface or unattended runs. Re-running setup still defaults the automation prompt to your current setting. → [security](./docs/guide/security.md#project-trust)
+
 ### Fixed
 
 - Healthy builds and large-file copies stay in the sidebar's working state while Linux completes blocking disk I/O; `!` now requires a sustained non-progressing process stall, and a new foreground command starts with a fresh stall baseline.

--- a/crates/rimz/src/cli/first_run.rs
+++ b/crates/rimz/src/cli/first_run.rs
@@ -166,7 +166,13 @@ pub(crate) fn ask(
     }
     writeln!(out)?;
 
-    let Some(automation) = prompt_bool("  Enable hands-off automation?", true, input, out)? else {
+    let Some(automation) = prompt_bool(
+        "  Enable hands-off automation?",
+        defaults.automation,
+        input,
+        out,
+    )?
+    else {
         return Ok(Answers {
             defaults,
             truecolor,
@@ -411,13 +417,13 @@ mod tests {
         assert!(answers.truecolor);
         assert!(answers.nerd_font);
         assert!(!answers.pet_enabled);
-        assert!(answers.automation);
+        assert!(!answers.automation);
         assert!(rendered.contains("Use truecolor?"));
         assert!(rendered.contains("Use Nerd Font icons?"));
         assert!(rendered.contains("Want a pet?"));
         assert!(rendered.contains("Enable hands-off automation?"));
-        assert_eq!(rendered.matches("[y/N]").count(), 3);
-        assert_eq!(rendered.matches("[Y/n]").count(), 1);
+        assert_eq!(rendered.matches("[y/N]").count(), 4);
+        assert_eq!(rendered.matches("[Y/n]").count(), 0);
     }
 
     #[test]

--- a/crates/rimz/src/cli/room/mod.rs
+++ b/crates/rimz/src/cli/room/mod.rs
@@ -748,7 +748,7 @@ fn prompt_project_trust(project_root: &Path) {
         tracing::warn!(error = %err, "trust birth prompt render failed");
         return;
     }
-    match confirm_with_default("Trust this project's config on this machine?", true) {
+    match confirm_with_default("Trust this project's config on this machine?", false) {
         Ok(true) => match rimz::trust::grant(project_root) {
             Ok(_) => {
                 if let Err(err) = write_project_trust_notice(&[


### PR DESCRIPTION
## Default first-run consent prompts to no

Two first-run consent prompts that gate command execution and unattended behavior defaulted to yes, so an absent-minded Enter opted in (#70).

### What changed

- **Project trust.** The birth-prompt grant for an untrusted clone (`prompt_project_trust`) now defaults to no. Activating a freshly cloned repo's command-running surface — agents, profiles, hooks, and `[tasks]` shell commands run via `sh -c` — takes an explicit yes. The trust model itself (hashing, staleness, inert-until-granted) is unchanged; only the default answer on the grant prompt moves.
- **Hands-off automation.** The first-run opt-in for `auto_continue` + `auto_redeem` now follows the current config default instead of a hardcoded yes. On a fresh machine that resolves to no. Re-running `rimz setup` keeps the user's existing setting, matching how `apply` diffs the answer against the default — the same pattern every other first-run prompt already uses.

### Why

Default-no is the safer posture for a security-relevant grant (arbitrary `sh -c` from a cloned repo) and for unattended execution, and it matches the "asks before it changes anything" framing in `docs/guide/security.md`.

### Tests

Updated `prompt_accepts_declines_and_defaults` for the new default and suffix counts; the existing re-run and EOF-cascade tests already cover the config-driven default in both directions. The unrelated pre-existing `workspace::tests` failures (Marker vs Directory root classification) reproduce on a clean tree and are environmental.

Closes #70
