### PR TITLE
fix(agents): pin OAuth usage probes to official provider hosts (GHSA-vv3p-wfq9-jc4m)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ RimZ is beta software on the 0.x line. Commands, flags, config keys, and output 
 ### Fixed
 
 - Codex agent cards follow the successor session created by `/compact` in Codex 0.145 and newer instead of staying pinned to the completed predecessor.
+- OAuth usage probes pin Claude and Codex Bearer tokens to their official provider hosts or loopback test servers, closing GHSA-vv3p-wfq9-jc4m. Thanks to @walt-verweij for the report. → [security](./docs/guide/security.md#what-leaves-your-machine)
 - Healthy builds and large-file copies stay in the sidebar's working state while Linux completes blocking disk I/O; `!` now requires a sustained non-progressing process stall, and a new foreground command starts with a fresh stall baseline.
 - Agent cards keep their activity and estimated active-time clocks current during Claude Code and Codex `/btw` side conversations.
 - `rimz agents fork` replays the source profile's launch posture, so its system prompt, tool configuration, model, effort, and permissions carry into the provider-native fork instead of reverting to defaults. → [agents](./docs/reference/cli/agents.md#fork)

--- a/crates/rimz/src/agents/adapters/claude/oauth_usage.rs
+++ b/crates/rimz/src/agents/adapters/claude/oauth_usage.rs
@@ -19,11 +19,12 @@ use sha2::{Digest, Sha256};
 
 use crate::agents::account::file_mtime_ms;
 use crate::agents::context::{AgentRateLimits, RateLimitWindow, WindowSource};
-use crate::agents::credits::oauth_http_get;
+use crate::agents::credits::{oauth_http_get, trusted_usage_url, url_host};
 use crate::agents::payload::non_empty_trimmed;
 use crate::agents::{AccountUsageSnapshot, ExtraCredits, HttpErrKind, transcript_fs::home_dir};
 
 const DEFAULT_USAGE_URL: &str = "https://api.anthropic.com/api/oauth/usage";
+const OFFICIAL_HOST: &str = "api.anthropic.com";
 const URL_ENV: &str = "RIMZ_CLAUDE_OAUTH_USAGE_URL";
 const USER_AGENT_FALLBACK_VERSION: &str = "unknown";
 const ACCOUNT_KEY_DOMAIN: &[u8] = b"rimz/claude-oauth-account-key/v1";
@@ -42,19 +43,24 @@ pub(crate) enum ClaudeOauthUsageErr {
     Io(#[from] std::io::Error),
     #[error("parsing claude OAuth credentials or usage response: {0}")]
     Parse(#[from] serde_json::Error),
+    #[error("claude OAuth usage URL override refused (host {host})")]
+    UntrustedUsageUrl { host: String },
     #[error("claude OAuth usage HTTP {kind} (host {host})")]
     Http { kind: HttpErrKind, host: String },
 }
 
 impl crate::agents::credits::AccountUsageReportable for ClaudeOauthUsageErr {
     /// Whether this failure is worth reporting off-box. Absent credentials, an
-    /// expired token, and a missing usage scope are the normal state for an
-    /// account that does not feed RimZ its usage, not a fault; a provider 401
-    /// is the same settled auth verdict. Parse and other HTTP failures are.
+    /// expired token, a missing usage scope, and a locally refused URL are
+    /// settled states, not faults; a provider 401 is the same settled auth
+    /// verdict. Parse and other HTTP failures are.
     fn should_report(&self) -> bool {
         !matches!(
             self,
-            Self::NoCredentials | Self::TokenExpired | Self::MissingScope
+            Self::NoCredentials
+                | Self::TokenExpired
+                | Self::MissingScope
+                | Self::UntrustedUsageUrl { .. }
         ) && !matches!(
             self,
             Self::Http { kind, .. } if kind.is_auth_rejected()
@@ -110,9 +116,22 @@ struct ExtraUsageWire {
 
 pub(crate) fn probe_usage(cli_version: Option<&str>) -> crate::agents::AccountUsageProbe {
     let credentials_stamp = credentials_stamp();
+    let url = match usage_url() {
+        Ok(url) => url,
+        Err(err) => {
+            return crate::agents::credits::map_account_usage_probe(
+                Err(err),
+                crate::agents::AccountUsageIdentity {
+                    credentials_stamp,
+                    ..Default::default()
+                },
+                "claude",
+            );
+        }
+    };
     match load_credentials() {
         Ok(credentials) => crate::agents::credits::map_account_usage_probe(
-            fetch_usage_with_url(&usage_url(), &credentials, cli_version),
+            fetch_usage_with_url(&url, &credentials, cli_version),
             crate::agents::AccountUsageIdentity {
                 account_key: Some(credentials.account_key.clone()),
                 credentials_stamp,
@@ -136,7 +155,7 @@ pub(crate) fn fetch_usage_with_token(
     cli_version: Option<&str>,
 ) -> Result<AccountUsageSnapshot> {
     fetch_usage_with_url(
-        &usage_url(),
+        &usage_url()?,
         &ClaudeOauthCredentials {
             access_token: access_token.trim().to_owned(),
             account_key: account_key("access-token", access_token.trim()),
@@ -239,11 +258,21 @@ fn account_key(secret_kind: &str, secret: &str) -> String {
     hex::encode(hasher.finalize())
 }
 
-fn usage_url() -> String {
-    std::env::var(URL_ENV)
-        .ok()
-        .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| DEFAULT_USAGE_URL.to_owned())
+fn usage_url() -> Result<String> {
+    resolve_usage_url(std::env::var(URL_ENV).ok().as_deref())
+}
+
+fn resolve_usage_url(override_url: Option<&str>) -> Result<String> {
+    let Some(candidate) = override_url.filter(|value| !value.trim().is_empty()) else {
+        return Ok(DEFAULT_USAGE_URL.to_owned());
+    };
+    if trusted_usage_url(candidate, OFFICIAL_HOST) {
+        Ok(candidate.to_owned())
+    } else {
+        Err(ClaudeOauthUsageErr::UntrustedUsageUrl {
+            host: url_host(candidate).to_owned(),
+        })
+    }
 }
 
 fn http_get(url: &str, token: &str, cli_version: Option<&str>) -> Result<String> {

--- a/crates/rimz/src/agents/adapters/claude/tests/oauth_usage.rs
+++ b/crates/rimz/src/agents/adapters/claude/tests/oauth_usage.rs
@@ -20,6 +20,29 @@ fn reportable_classifier_treats_unauthorized_as_settled_auth() {
 }
 
 #[test]
+fn usage_url_override_accepts_only_official_or_loopback_hosts() {
+    assert_eq!(resolve_usage_url(None).unwrap(), DEFAULT_USAGE_URL);
+    assert_eq!(resolve_usage_url(Some("")).unwrap(), DEFAULT_USAGE_URL);
+    for url in [
+        "https://api.anthropic.com/api/oauth/usage",
+        "http://127.0.0.1:8080/api/oauth/usage",
+    ] {
+        assert_eq!(resolve_usage_url(Some(url)).unwrap(), url);
+    }
+
+    let url = "https://evil.example/private/path";
+    let error = resolve_usage_url(Some(url)).unwrap_err();
+    assert!(matches!(
+        error,
+        ClaudeOauthUsageErr::UntrustedUsageUrl { .. }
+    ));
+    assert!(!error.should_report());
+    let display = error.to_string();
+    assert!(display.contains("evil.example"));
+    assert!(!display.contains("/private/path"));
+}
+
+#[test]
 fn credentials_parse_token_expiry_and_scope() {
     let credentials = parse_credentials(
         br#"{

--- a/crates/rimz/src/agents/adapters/codex/oauth_usage.rs
+++ b/crates/rimz/src/agents/adapters/codex/oauth_usage.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 
 use crate::agents::account::file_mtime_ms;
 use crate::agents::context::WindowSource;
-use crate::agents::credits::oauth_http_get;
+use crate::agents::credits::{oauth_http_get, trusted_usage_url, url_host};
 use crate::agents::payload::non_empty_trimmed;
 use crate::agents::{AccountUsageSnapshot, HttpErrKind, ResetCredits};
 
@@ -22,6 +22,7 @@ use super::account::{UsageCredits, UsageWindow, normalize_usage, parse_balance};
 use super::app_server::codex_home;
 
 const DEFAULT_BASE_URL: &str = "https://chatgpt.com/backend-api";
+const OFFICIAL_HOST: &str = "chatgpt.com";
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum CodexOauthUsageErr {
@@ -33,24 +34,28 @@ pub(crate) enum CodexOauthUsageErr {
     Io(#[from] std::io::Error),
     #[error("parsing codex OAuth credentials, config, or usage response: {0}")]
     Parse(#[from] serde_json::Error),
+    #[error("codex chatgpt_base_url refused (host {host})")]
+    UntrustedBaseUrl { host: String },
     #[error("codex OAuth usage HTTP {kind} (host {host})")]
     Http { kind: HttpErrKind, host: String },
 }
 
 impl crate::agents::credits::AccountUsageReportable for CodexOauthUsageErr {
     /// Whether this failure is worth reporting off-box. Absent or API-key-only
-    /// credentials are the normal state for an app-server or logged-out account,
-    /// not a fault; provider 401 and 403 responses are settled auth verdicts
-    /// rather than RimZ faults. Parse and other HTTP failures are.
+    /// credentials and a locally refused base URL are settled states, not
+    /// faults; provider 401 and 403 responses are settled auth verdicts too.
+    /// Parse and other HTTP failures are.
     fn should_report(&self) -> bool {
-        !matches!(self, Self::NoCredentials | Self::ApiKeyOnly)
-            && !matches!(
-                self,
-                Self::Http {
-                    kind: HttpErrKind::Status(401 | 403),
-                    ..
-                }
-            )
+        !matches!(
+            self,
+            Self::NoCredentials | Self::ApiKeyOnly | Self::UntrustedBaseUrl { .. }
+        ) && !matches!(
+            self,
+            Self::Http {
+                kind: HttpErrKind::Status(401 | 403),
+                ..
+            }
+        )
     }
 }
 
@@ -114,6 +119,19 @@ pub(crate) fn probe_usage() -> crate::agents::AccountUsageProbe {
         return crate::agents::AccountUsageProbe::NoCredentials(Default::default());
     };
     let credentials_stamp = file_mtime_ms(&home.join("auth.json"));
+    let base_url = match configured_base_url(&home) {
+        Ok(base_url) => base_url,
+        Err(err) => {
+            return crate::agents::credits::map_account_usage_probe(
+                Err(err),
+                crate::agents::AccountUsageIdentity {
+                    credentials_stamp,
+                    ..Default::default()
+                },
+                "codex",
+            );
+        }
+    };
     let credentials = match load_credentials_from(&home.join("auth.json")) {
         Ok(credentials) => credentials,
         Err(err) => {
@@ -131,13 +149,11 @@ pub(crate) fn probe_usage() -> crate::agents::AccountUsageProbe {
         credentials_stamp,
         ..credentials.account_usage_identity()
     };
-    let result = configured_base_url(&home)
-        .map_err(CodexOauthUsageErr::Io)
-        .and_then(|base_url| {
-            let mut snapshot = fetch_usage_with_url(&usage_url(base_url.as_deref()), &credentials)?;
+    let result =
+        fetch_usage_with_url(&usage_url(base_url.as_deref()), &credentials).map(|mut snapshot| {
             snapshot.reset_credits =
                 fetch_reset_credits(&reset_credits_url(base_url.as_deref()), &credentials).ok();
-            Ok(snapshot)
+            snapshot
         });
     crate::agents::credits::map_account_usage_probe(result, identity, "codex")
 }
@@ -148,8 +164,8 @@ pub(crate) fn credentials_stamp() -> Option<u64> {
 
 pub(crate) fn load_configured_credentials() -> Result<(CodexOauthCredentials, Option<String>)> {
     let home = codex_home().ok_or(CodexOauthUsageErr::NoCredentials)?;
-    let credentials = load_credentials_from(&home.join("auth.json"))?;
     let base_url = configured_base_url(&home)?;
+    let credentials = load_credentials_from(&home.join("auth.json"))?;
     Ok((credentials, base_url))
 }
 
@@ -199,16 +215,24 @@ pub(crate) fn parse_credentials(bytes: &[u8]) -> Result<CodexOauthCredentials> {
     })
 }
 
-pub(crate) fn configured_base_url(home: &Path) -> std::io::Result<Option<String>> {
+pub(crate) fn configured_base_url(home: &Path) -> Result<Option<String>> {
     let path = home.join("config.toml");
     match std::fs::read_to_string(path) {
         Ok(text) => {
             let config: CodexConfig = toml::from_str(&text)
                 .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-            Ok(config.chatgpt_base_url.filter(|url| !url.trim().is_empty()))
+            let base_url = config.chatgpt_base_url.filter(|url| !url.trim().is_empty());
+            if let Some(base_url) = base_url.as_deref()
+                && !trusted_usage_url(base_url, OFFICIAL_HOST)
+            {
+                return Err(CodexOauthUsageErr::UntrustedBaseUrl {
+                    host: url_host(base_url).to_owned(),
+                });
+            }
+            Ok(base_url)
         }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(err) => Err(err),
+        Err(err) => Err(CodexOauthUsageErr::Io(err)),
     }
 }
 

--- a/crates/rimz/src/agents/adapters/codex/tests/oauth_usage.rs
+++ b/crates/rimz/src/agents/adapters/codex/tests/oauth_usage.rs
@@ -131,6 +131,36 @@ fn credentials_distinguish_api_key_and_oauth_login() {
 }
 
 #[test]
+fn configured_base_url_accepts_only_official_or_loopback_hosts() {
+    let dir = tempfile::tempdir().unwrap();
+    assert_eq!(configured_base_url(dir.path()).unwrap(), None);
+
+    for base_url in [
+        "https://chatgpt.com/backend-api",
+        "http://127.0.0.1:1234/backend-api",
+    ] {
+        std::fs::write(
+            dir.path().join("config.toml"),
+            format!("chatgpt_base_url = \"{base_url}\"\n"),
+        )
+        .unwrap();
+        assert_eq!(
+            configured_base_url(dir.path()).unwrap().as_deref(),
+            Some(base_url)
+        );
+    }
+
+    std::fs::write(
+        dir.path().join("config.toml"),
+        "chatgpt_base_url = \"https://proxy.invalid/backend-api\"\n",
+    )
+    .unwrap();
+    let error = configured_base_url(dir.path()).unwrap_err();
+    assert!(matches!(error, CodexOauthUsageErr::UntrustedBaseUrl { .. }));
+    assert!(!error.should_report());
+}
+
+#[test]
 fn usage_url_respects_backend_api_base_and_codex_api_base() {
     assert_eq!(
         usage_url(None),

--- a/crates/rimz/src/agents/credits.rs
+++ b/crates/rimz/src/agents/credits.rs
@@ -66,6 +66,28 @@ pub(crate) fn url_host(url: &str) -> &str {
         .map_or(authority, |(_, host)| host)
 }
 
+/// True when `url` targets the provider's official endpoint (exact `https`
+/// origin on the default port) or a loopback host. Integration tests drive the
+/// probes against local stubs, and a loopback listener already implies local
+/// execution; every other origin is refused before a secret-bearing request is
+/// built.
+pub(crate) fn trusted_usage_url(url: &str, official_host: &str) -> bool {
+    let Ok(parsed) = url::Url::parse(url) else {
+        return false;
+    };
+    match parsed.host() {
+        Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
+        Some(url::Host::Domain(domain)) if domain.eq_ignore_ascii_case("localhost") => true,
+        Some(url::Host::Domain(domain)) => {
+            parsed.scheme() == "https"
+                && parsed.port().is_none()
+                && domain.eq_ignore_ascii_case(official_host)
+        }
+        None => false,
+    }
+}
+
 pub(crate) const OAUTH_HTTP_TIMEOUT_SECS: u64 = 5;
 pub(crate) const OAUTH_HTTP_MAX_BYTES: u64 = 512 * 1024;
 const OAUTH_HTTP_ATTEMPTS: u32 = 3;
@@ -393,7 +415,8 @@ pub enum AccountUsageProbe {
 /// adapter's account-usage error so [`map_account_usage_probe`] can fold every
 /// adapter's result through one classifier instead of a hand-rolled match per
 /// adapter. The "report" set (HTTP/IO/parse faults) maps to `Failed`; the silent
-/// set (absent/api-key/expired credentials) maps to `NoCredentials`.
+/// set (absent/api-key/expired credentials and locally refused configuration)
+/// maps to `NoCredentials`.
 pub(crate) trait AccountUsageReportable {
     fn should_report(&self) -> bool;
 }
@@ -531,6 +554,28 @@ mod tests {
         assert!(!HttpErrKind::Status(401).is_transient());
         assert!(!HttpErrKind::Status(404).is_transient());
         assert!(!HttpErrKind::Status(429).is_transient());
+    }
+
+    #[test]
+    fn usage_urls_accept_only_the_official_https_origin_or_loopback() {
+        for url in [
+            "https://api.anthropic.com/api/oauth/usage",
+            "http://127.0.0.1:8080/x",
+            "http://[::1]:9/x",
+            "http://localhost:8080/x",
+        ] {
+            assert!(trusted_usage_url(url, "api.anthropic.com"), "{url}");
+        }
+        for url in [
+            "http://api.anthropic.com/api/oauth/usage",
+            "https://api.anthropic.com:8443/api/oauth/usage",
+            "https://api.anthropic.com.evil.example/api/oauth/usage",
+            "https://api.anthropic.com@evil.example/api/oauth/usage",
+            "https://evil.example/api/oauth/usage",
+            "not a URL",
+        ] {
+            assert!(!trusted_usage_url(url, "api.anthropic.com"), "{url}");
+        }
     }
 
     #[test]

--- a/crates/rimz/tests/integration/oauth_usage.rs
+++ b/crates/rimz/tests/integration/oauth_usage.rs
@@ -224,6 +224,60 @@ fn claude_refresh_usage_populates_windows_and_extra_credits_from_oauth_endpoint(
 }
 
 #[test]
+fn claude_refresh_usage_refuses_an_untrusted_override_without_publishing_usage() {
+    let env = Env::new();
+    let claim_id = env.seed_usage_claim("claude");
+    let claude_home = env.home_root.join(".claude");
+    std::fs::create_dir_all(&claude_home).expect("mkdir claude home");
+    std::fs::write(
+        claude_home.join(".credentials.json"),
+        r#"{
+            "claudeAiOauth": {
+                "accessToken": "claude-token",
+                "expiresAt": 4102444800000,
+                "scopes": ["user:profile"]
+            }
+        }"#,
+    )
+    .expect("write claude credentials");
+
+    let output = env
+        .rimz()
+        .args([
+            "agents",
+            "refresh-usage",
+            "--kind",
+            "claude",
+            "--workspace-id",
+            env.workspace_id.as_str(),
+            "--claim-id",
+            &claim_id,
+            "--merge-windows",
+        ])
+        .env(
+            "RIMZ_CLAUDE_OAUTH_USAGE_URL",
+            "https://rimz-advisory.invalid/api/oauth/usage",
+        )
+        .bounded_output()
+        .expect("rimz agents refresh-usage claude");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let runtime = env.runtime_paths();
+    let credits = read_json(runtime.shared_credits_path());
+    assert!(credits["entries"]["claude"]["oauth_read_at_ms"].as_u64() > Some(1));
+    assert_eq!(credits["entries"]["claude"]["auth_settled"], true);
+    assert!(credits["entries"]["claude"]["direct_query_claim"].is_null());
+    assert!(
+        std::fs::read(runtime.shared_rate_limits_path()).is_err(),
+        "an untrusted endpoint must not publish usage windows"
+    );
+}
+
+#[test]
 fn claude_refresh_usage_retries_transient_http_failures() {
     let env = Env::new();
     let claim_id = env.seed_usage_claim("claude");

--- a/docs/externals/agent-adapter/claude-reference.md
+++ b/docs/externals/agent-adapter/claude-reference.md
@@ -337,7 +337,7 @@ RimZ hashes the normalized `refreshToken`, falling back to `accessToken`, with a
 
 On macOS, a missing credentials file falls back to `/usr/bin/security find-generic-password -s "Claude Code-credentials" -w` with null stdin and a 1.5-second subprocess deadline. Timeout and denied/nonzero results are quiet missing credentials; the bound prevents RimZ from waiting indefinitely, while macOS may still briefly present Keychain UI before the process exits.
 
-The helper calls `GET https://api.anthropic.com/api/oauth/usage` with `Authorization: Bearer <accessToken>`, `Accept: application/json`, `anthropic-beta: oauth-2025-04-20`, and a `claude-code/<claude-version>` user agent when the version is known. `RIMZ_CLAUDE_OAUTH_USAGE_URL` overrides the URL for tests. The path is read-only: RimZ does not refresh tokens or write the file or Keychain item. The parsed response shape:
+The helper calls `GET https://api.anthropic.com/api/oauth/usage` with `Authorization: Bearer <accessToken>`, `Accept: application/json`, `anthropic-beta: oauth-2025-04-20`, and a `claude-code/<claude-version>` user agent when the version is known. `RIMZ_CLAUDE_OAUTH_USAGE_URL` overrides the URL for integration tests, and RimZ honors an override only for the official host or a loopback address. The path is read-only: RimZ does not refresh tokens or write the file or Keychain item. The parsed response shape:
 
 ```jsonc
 {

--- a/docs/externals/agent-adapter/codex-reference.md
+++ b/docs/externals/agent-adapter/codex-reference.md
@@ -384,7 +384,7 @@ When no auth file exists, RimZ runs `codex login status` so keyring-backed login
 
 The app-server `account/rateLimits/read` `planType` is persisted with realtime credits even when plan is the only account field returned. A non-empty app-server plan replaces the cached OAuth plan; an absent app-server plan preserves it, so keyring-backed and idle sessions retain their last provider-authoritative label.
 
-The default usage URL is `GET https://chatgpt.com/backend-api/wham/usage`. A `chatgpt_base_url` value in `~/.codex/config.toml` overrides the base: bases ending in `/backend-api` append `/wham/usage`; other bases append `/api/codex/usage`. The parsed usage response shape:
+The default usage URL is `GET https://chatgpt.com/backend-api/wham/usage`. A `chatgpt_base_url` value in `~/.codex/config.toml` overrides the base: bases ending in `/backend-api` append `/wham/usage`; other bases append `/api/codex/usage`. RimZ refuses a base whose host is neither `chatgpt.com` nor loopback before reading credentials, and the probe reports the base as untrusted. The parsed usage response shape:
 
 ```jsonc
 {

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -70,7 +70,7 @@ The [web guide](./web.md#behind-a-reverse-proxy) configures Traefik and Authenti
 
 RimZ keeps your work local. Your prompts, transcripts, pane text, file paths, and credentials stay on the box. The network calls RimZ makes reuse logins you already hold and reach only services you already use:
 
-- **Provider usage.** To fill the cost and budget meters, RimZ reads each provider's usage endpoint with the OAuth login the agent already holds, contacting only the provider you are signed in to.
+- **Provider usage.** To fill the cost and budget meters, RimZ reads each provider's usage endpoint with the OAuth login the agent already holds. Usage endpoints stay pinned to each provider's official host; URL overrides are refused unless they target that host or loopback.
 - **Pull-request status.** The sidebar's PR marker runs your own `gh` (GitHub) or `tea` (Gitea, Forgejo, Codeberg) against your forge, on your existing login. It reads no RimZ secrets and adds no config field, so it stays off the trust hash.
 - **Pets.** Enabling `[theme.pets]` fetches a sprite sheet over HTTPS from the host you name (a built-in pet reaches the public Codex pets CDN; a local-path pet fetches nothing). `RIMZ_PETS_OFFLINE=1` makes the process tree cache-only. The request carries the asset URL and nothing else.
 - **Off-box error reporting.** Off by default and opt-in. See [Off-box error reporting](#off-box-error-reporting).


### PR DESCRIPTION
Closes #71.

## Context

Security advisory **GHSA-vv3p-wfq9-jc4m** (medium) reports that two provider usage-probe paths send a live OAuth Bearer token to a host built from operator-controlled input with no official-host validation, breaking the `docs/guide/security.md` promise that provider-usage calls contact "only the provider you are signed in to". Thanks to **@walt-verweij** for the report.

Two paths were affected:

- **Claude** — `usage_url()` honored the `RIMZ_CLAUDE_OAUTH_USAGE_URL` env var unconditionally, then sent `Authorization: Bearer <token>` plus the `anthropic-beta` header to that URL. The reference doc claimed the var was test-only, but nothing enforced it.
- **Codex** — `chatgpt_base_url` from `~/.codex/config.toml` flowed into three secret-bearing endpoints: usage (GET), reset-credits lookup (GET), and reset-credit consume (POST, which spends a real credit). The Bearer token and `ChatGPT-Account-Id` went along unchecked.

The shared transport already refuses redirects and logs host-only, so a redirection is low-visibility; the gap was the initial destination. Exploitation requires an attacker who can already set a process env var (`.envrc`, shared profile, CI) or write `~/.codex/config.toml`. The env path is the worse one because it exfiltrates a live, auto-refreshed token.

Kimi was already safe (it refuses any non-official base before touching credentials). Copilot's multi-host model is legitimate GitHub Enterprise configuration with host-scoped tokens and is intentionally out of scope.

## Design choices

- **Validate at the system boundary, before any secret-bearing request exists.** One shared predicate, `trusted_usage_url`, lives beside the OAuth transport helpers in `credits.rs` and runs where the override enters — the env-var read (Claude) and the config-file parse (Codex). No token is loaded until the destination is accepted.
- **Structured parsing, not string matching.** The predicate parses with the `url` crate (already a workspace dependency). Exact-origin matching makes userinfo tricks, deceptive host suffixes, alternate ports, and plain HTTP on the official host all fall out for free.
- **Allow-list = exact official HTTPS origin (default port) + loopback.** Loopback (`127.0.0.0/8`, `::1`, `localhost`, any scheme/port) stays allowed so the out-of-process integration tests keep driving the built binary against local HTTP stubs. This adds no attack surface: a loopback listener already implies local code execution, which can read the credentials files directly. `cfg(test)` gating cannot work here because the binary under test is a normal build.
- **Codex official host is `chatgpt.com` only** (the upstream default base). A non-official base — enterprise proxy included — loses only the usage and reset-credit operations, gracefully.
- **Refusals are quiet, locally-settled verdicts.** Each new error's `should_report()` returns `false` (mirroring Kimi's `Unavailable`), and its `Display` carries only the refused host, never the full URL or any credential.

## Implementation

- **`credits.rs`** — new `trusted_usage_url(url, official_host)`: parse with `url::Url`; loopback IPv4/IPv6 and `localhost` accept on any scheme/port; a domain host accepts only when scheme is `https`, port is default, and the host equals the official host; parse failure or no host rejects.
- **Claude (`adapters/claude/oauth_usage.rs`)** — split `usage_url()` into a thin env wrapper over a pure `resolve_usage_url(Option<&str>)`. Absent/empty override → default URL; a non-empty override is accepted only when trusted, else a new `UntrustedUsageUrl { host }`. `probe_usage` resolves the URL before loading credentials so refusal precedes any token read; `fetch_usage_with_token` (used by the delegated-account path) propagates the same result.
- **Codex (`adapters/codex/oauth_usage.rs`)** — `configured_base_url` now returns the module error type and validates the configured base, rejecting with `UntrustedBaseUrl { host }`. Because every production base flows through this one function — `probe_usage`, and `load_configured_credentials` for the reset-credit offer and consume paths in `codex/mod.rs` — all three endpoints inherit the gate with `endpoint_url` itself unchanged. Credential reads now happen after the base is validated.
- **Both providers** — the new refusal variants join the silent set in `should_report()`; the delegated-account wrapper delegates to the inner classifier, so refusals stay quiet on that path too.
- **Tests** — a `trusted_usage_url` matrix (official/loopback accepted; plain-HTTP, alternate-port, suffix, userinfo, foreign-host, and unparseable rejected); Claude `resolve_usage_url` unit tests (including a Display that shows the host but not the path); Codex `configured_base_url` tests against a tempdir config; and an integration test proving a Claude override to an untrusted host publishes no usage windows and surfaces the refusal with no network I/O. The four existing loopback-stub integration tests continue to pass unchanged.
- **Docs** — `claude-reference.md`, `codex-reference.md`, `docs/guide/security.md`, and the unreleased `CHANGELOG.md` section updated to describe the pinning and credit the reporter.

## Advisories

- **Implicit parser-agreement invariant.** The pin's safety rests on the validating parser (`url` crate) and the transport parser (`ureq`'s `http::Uri`) extracting the same host, or the transport failing closed on any string the validator maps to a trusted host. Today they agree: the one WHATWG-special authority delimiter they differ on — backslash — is rejected as an invalid URI char by `http`, so a `https://official\@evil` override fails closed rather than reaching the attacker host. If the OAuth transport is ever swapped for a client with looser authority parsing, this pin could be bypassed without touching `trusted_usage_url`. A short comment recording the invariant near the predicate or the transport would make the coupling explicit.
- **Silent refusal by design.** A refused override exits successfully and records a settled no-usage result with no new user-facing error, matching the existing best-effort refresh contract and Kimi's behavior. This is intentional (documented in the reference and security guides), noted here for reviewers.