### PR TITLE
docs(contract): delegate judgment to the agent, keep the rules that bind

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,25 +4,40 @@ Working contract for humans and coding agents contributing to RimZ. Read on entr
 
 > **Invariant.** RimZ routes attention: it surfaces which agent needs you and takes you straight to its pane, where you answer in the agent's own UI.
 
-A child `AGENTS.md` under a subtree extends this file with local constraints; it never restates parent rules.
+A child `AGENTS.md` extends this file with what holds only inside its subtree.
+
+## How to read this contract
+
+Two kinds of statement live here, and they earn different deference.
+
+**Invariants** are load-bearing: a product promise, an architectural boundary a `cargo xtask invariants` grep enforces, or a durability rule. Breaking one breaks the build or the product. The sections below say which statements are invariants. Change one deliberately, in its own commit, with the doc and the gate moving together.
+
+**Everything else is a default** — the choice that has been right most of the time here. Follow it absent better information; depart when the work in front of you argues otherwise, and say why in the PR or hand-off. A default that keeps losing is a bug in this file, so fix the file.
+
+Exercise judgment without asking on how to decompose a change, which tests earn their cost, and when a rule's rationale does not reach the case at hand. Push back when a request looks wrong, rests on a false premise, or has a simpler shape — an early correction beats a faithful implementation of the wrong thing. Ask when a wrong guess is expensive and a question is cheap.
+
+Match the size of the change to the size of the ask, and leave the refactor you noticed on the way as a note unless it blocks you. When this map and the territory disagree, the code is what ships: follow the code, then fix the map in the same change.
 
 ## Tone
 
-Declarative, present tense. State the contract; don't narrate history. Prefer imperatives (`Use Result.`) over prohibitions.
+Declarative, present tense. State the contract; don't narrate history.
 
-Lead with the capability, and introduce a concept by what it does before leaning on it — say what queuing *does* (hold text for the agent's next open turn) rather than "a queued message never interrupts a turn". State a safety boundary as a positive commitment (`Hook stdout is the decision channel.`); avoid "X is a Y, not a Z" and defensive "we don't…" / "it never…" framing. Reserve negation for genuine disambiguation.
+Lead with the capability, and introduce a concept by what it does before leaning on it — say what queuing *does* (hold text for the agent's next open turn) before saying what it avoids. State a safety boundary as a positive commitment (`Hook stdout is the decision channel.`), and reserve negation for genuine disambiguation.
 
 Markdown prose uses one logical line per paragraph, list item, and blockquote paragraph. Do not hard-wrap.
 
 ## Engineering principles
 
-- **Explicit Rust.** Typed IDs, state machines, structured parsers, explicit errors. Domain errors return `Result`; `unwrap`/`expect`/panic belong in tests, build scripts, and provably-impossible states (with a comment).
-- **Strong types** for workspace, request, pane, agent-kind, and agent-session IDs, and for surfaces, statuses, and protocol versions.
-- **Structured parsers** for TOML, JSON, KDL, and agent payloads.
+The house style is explicit Rust: typed IDs for identifiers that cross a module boundary (workspace, request, pane, agent-kind, agent-session) and for surfaces, statuses, and protocol versions; structured parsers for TOML, JSON, KDL, and agent payloads; state machines where a bool would drift. Domain errors return `Result`. `unwrap`/`expect`/panic belong in tests, build scripts, and provably-impossible states — leave a comment naming why the state is impossible.
+
+Two invariants sit underneath that style:
+
 - **Store durability.** File-state writes use temp-file plus rename; event-log writes follow the [store durability contract](./docs/internals/store.md).
 - **Fail-fast on preconditions.** A configured capability that cannot work fails at the entry point with the fix — `rimz start` refuses rather than launching a degraded surface. Best-effort is for latency and enrichment (sidebar wakeups, app-server context), never for a precondition the user switched on.
 
 ## Product invariants
+
+These are the promises the product is built on. Treat a change to one as a product decision, not an implementation detail.
 
 - **Durability first.** Correctness lives in durable records, CAS rules, nonces, and per-request sockets. Wakeups and pane reads are latency, never truth.
 - **Automation is accountable.** User-benefiting automation appends durable assist records and surfaces in `rimz stats`; internal repairs keep durable diagnostic records ([loops.md](./docs/internals/harness/loops.md#the-assist-log), [diagnostics.md](./docs/internals/diagnostics.md)).
@@ -65,31 +80,28 @@ rimz loop logs <task>                # full forensics for recent runs
 
 ## Implementation rules
 
-- `AGENTS.md` and `CLAUDE.md` are one file via symlink; edits to either land in both.
-- Rust unless the task targets docs, tests, scripts, examples, or build glue.
-- Root docs stay short and authoritative; detail lives in `docs/` and is linked.
-- Update the [code map](#code-map) when modules move, [ARCHITECTURE.md](./ARCHITECTURE.md) when the runtime shape changes, and [DESIGN.md](./DESIGN.md) only when a product or runtime invariant changes.
-- Write [CHANGELOG.md](./CHANGELOG.md) as a standalone change once the work it describes is merged and before the version release. Pull requests leave the file untouched, so concurrent branches never contend over the same lines.
+- `AGENTS.md` and `CLAUDE.md` are one file per directory, joined by symlink; an edit to either lands in both.
+- Rust unless the task targets docs, tests, scripts, examples, or build glue. Use `uv` for Python helpers.
+- Root docs stay short and authoritative; detail lives in `docs/` and is linked. Update the [code map](#code-map) when modules move, [ARCHITECTURE.md](./ARCHITECTURE.md) when the runtime shape changes, and [DESIGN.md](./DESIGN.md) only when a product or runtime invariant changes.
+- Leave [CHANGELOG.md](./CHANGELOG.md) untouched in a pull request. It is written as a standalone change once the work merges and before the version release, so concurrent branches never contend over the same lines.
 - Contributor automation lives in `xtask/`; command surface and gate stack in [rust-conventions.md](./docs/contributing/rust-conventions.md).
-- Use `uv` for Python helpers.
 
-## Testing requirements
+## Testing
 
 - Run `cargo xtask gate` before a PR or hand-off: it auto-formats, then runs invariants, docs-links, lint, and the fast nextest subset. That subset excludes the live-backend and journey tiers; `cargo xtask test -P live` and `cargo xtask test -P journey` are the exact excluded complement.
-- Use `cargo xtask test <filter>` for focused iteration; nextest is the only suite runner, so never run bare `cargo test`.
+- Use `cargo xtask test <filter>` for focused iteration. nextest is the only suite runner, so bare `cargo test` does not work here.
 - Run a built `target/.../rimz` against a real multiplexer through `cargo xtask sandbox -- <command>`; the sandbox gives HOME, XDG, tmux, and Zellij disposable roots and tears its mux servers down on exit.
-- Escalate to journey, live-backend, performance, dependency gates, or full CI (`cargo xtask ci`) when the change touches those surfaces, their fixtures, or shared infrastructure; instrumented coverage runs through `cargo xtask coverage`.
-- CI's `tests` job is the branch-protection check; the pipeline shape (single compile, profile steps, branch protection) lives in [rust-conventions.md](./docs/contributing/rust-conventions.md).
+- Judge the reach of your own change and escalate to journey, live-backend, performance, dependency gates, or full CI (`cargo xtask ci`) when it touches those surfaces, their fixtures, or shared infrastructure. CI's `tests` job is the branch-protection floor rather than the ceiling; the pipeline shape lives in [rust-conventions.md](./docs/contributing/rust-conventions.md). Instrumented coverage runs through `cargo xtask coverage`.
 - Keep test tiers separate: unit tests stay in-module and pure, integration tests own subprocess/filesystem behaviour, journey tests own rendered user flows, live-backend tests own real tmux/Zellij, and performance tests assert bounded resource use.
 - A module's unit tests have one home: inline `#[cfg(test)] mod tests`, or a sibling `tests.rs` past the size gate (enforced by `cargo xtask invariants`). Minimal usage examples live as unit tests. Shape and threshold in [rust-conventions.md](./docs/contributing/rust-conventions.md).
-- Do not land ignored tests for future product targets. Capture planned behaviour in the owning doc, then add the executable test when the implementation can make it pass under nextest.
-- Grep-style invariants (`cargo xtask invariants`) guard the architectural boundaries — decision-channel integrity, sidebar/store separation, the trust hash, pane-primitive use, and more.
+- Capture planned behaviour in the owning doc and add the executable test when the implementation can make it pass; an ignored test standing in for a future product target does not land.
+- **Invariant.** `cargo xtask invariants` greps tracked text — Rust and Markdown alike — to guard the architectural boundaries: decision-channel integrity, sidebar/store separation, the trust hash, pane-primitive use, and more. Because it matches text rather than parsed code, an `AGENTS.md` inside a guarded subtree is scanned along with it: describe a boundary in prose and leave the path the rule bans unwritten.
 
 ## Code map
 
 RimZ ships as one Rust binary: the `rimz` crate is CLI, domain library, and native sidebar renderer, with `rimz-presence-zellij` a standalone Zellij wasm plugin beside it. This indexes what lives where; runtime shape and the single-binary rationale live in [ARCHITECTURE.md](./ARCHITECTURE.md), and each module's `//!` header is the per-file authority.
 
-**Repository** — `crates/rimz/` (the binary plus the runtime/domain library; `benches/`, and `presence/`/`pricing/`/`themes/` data `build.rs` embeds), `crates/rimz-presence-zellij/` (headless Zellij presence plugin, wasm32-wasip1, no rimz-crate deps), `docs/` (product and engineering docs; `docs/externals/` mirrors upstream), `xtask/` (task runner and every gate), `examples/`, `ci/`, `scripts/`, `supply-chain/`.
+**Repository** — `crates/rimz/` (the binary plus the runtime/domain library; `benches/`, and `presence/`/`pricing/`/`themes/` data `build.rs` embeds), `crates/rimz-presence-zellij/` (headless Zellij presence plugin, wasm32-wasip1, no rimz-crate deps), `docs/` (product and engineering docs; `docs/externals/` mirrors upstream), `xtask/` (task runner and every gate), `examples/`, `ci/`, `docker/`, `scripts/`, `supply-chain/`.
 
 **Subsystems — `crates/rimz/src/`**, each carrying its own `AGENTS.md` contract:
 - `cli/` — command parsing, one `run(...)` per subcommand, shared `cli/render/` output.
@@ -104,7 +116,7 @@ RimZ ships as one Rust binary: the `rimz` crate is CLI, domain library, and nati
 - `remote/` — SSH grammar, reconnect policy, link health, `remote.toml`.
 - `diag/` — diagnostic-only JSONL append surfaces.
 
-**Top-level modules** — identity and reach (`workspace`, `web`, `channel`, `worktree`, `disk_usage`, `forge`); transcript/panes/seams (`transcript`, `pane`, `sock`, `ids`, `trust`); shared presentation (`theme` semantic palette, provider identity, glyph resolution and setup probes, and value formats); daemon view (`daemon_view` spec and reconciliation, `daemon_content` supervisors, `remote_control` provider-neutral readiness/toggle coordination); process and config (`config`, `observability`, `agent_activity`, `lane`, `proc`, `reload`, `osc`, `build_id`, `child_process`, `tui`, `testkit`).
+**Top-level modules** — identity and reach (`workspace`, `web`, `channel`, `worktree`, `disk_usage`, `forge`); transcript/panes/seams (`transcript`, `pane`, `sock`, `ids`, `trust`); shared presentation (`theme` semantic palette, provider identity, glyph resolution and setup probes, and value formats); daemon view (`daemon_view` spec and reconciliation, `daemon_content` supervisors, `remote_control` provider-neutral readiness/toggle coordination); process and config (`config`, `observability`, `agent_activity`, `lane`, `proc`, `reload`, `osc`, `build_id`, `child_process`, `tui`, `testkit`); install lifecycle (`update` install-origin detection, release verification, and atomic binary replacement; `uninstall` machine-wide removal mechanics).
 
 ## Documentation map
 

--- a/crates/rimz/AGENTS.md
+++ b/crates/rimz/AGENTS.md
@@ -1,6 +1,6 @@
 # RimZ core
 
-Local contract for `crates/rimz/` — the CLI binary, hook entrypoints, and the runtime/domain library. Extends the root [AGENTS.md](../../AGENTS.md); it never restates parent rules. The module map lives in [ARCHITECTURE.md](../../ARCHITECTURE.md); deeper subtree contracts live in [src/agents/](./src/agents/AGENTS.md), [src/harness/](./src/harness/AGENTS.md), [src/room/](./src/room/AGENTS.md), [src/store/](./src/store/AGENTS.md), [src/mux/](./src/mux/AGENTS.md), and [tests/integration/](./tests/integration/AGENTS.md).
+Local contract for `crates/rimz/` — the CLI binary, hook entrypoints, and the runtime/domain library. Extends the root [AGENTS.md](../../AGENTS.md). The module map lives in [ARCHITECTURE.md](../../ARCHITECTURE.md); deeper subtree contracts live in [src/cli/](./src/cli/AGENTS.md), [src/agents/](./src/agents/AGENTS.md), [src/room/](./src/room/AGENTS.md), [src/harness/](./src/harness/AGENTS.md), [src/message/](./src/message/AGENTS.md), [src/store/](./src/store/AGENTS.md), [src/mux/](./src/mux/AGENTS.md), [src/sidebar/](./src/sidebar/AGENTS.md), [src/sidebar_pane/](./src/sidebar_pane/AGENTS.md), [src/remote/](./src/remote/AGENTS.md), [src/diag/](./src/diag/AGENTS.md), and [tests/integration/](./tests/integration/AGENTS.md).
 
 ## Crate-wide seams
 

--- a/crates/rimz/src/agents/AGENTS.md
+++ b/crates/rimz/src/agents/AGENTS.md
@@ -1,8 +1,8 @@
 # Agent adapters
 
-Local contract for `crates/rimz/src/agents/` — the integration layer. Extends [crates/rimz/AGENTS.md](../../AGENTS.md); it never restates parent rules.
+Local contract for `crates/rimz/src/agents/` — the integration layer. Extends [crates/rimz/AGENTS.md](../../AGENTS.md).
 
-Topic detail lives in the internals leaves the root map describes — [adapter.md](../../../../docs/internals/agents/adapter.md) (this layer: the registry, the capability traits, the hook path, install, context sources, and declared coverage), [model.md](../../../../docs/internals/agents/model.md) (the agent model the adapters feed: the rollup, the state machine, and the displayed-status ladder), the per-kind internal mappings ([claude.md](../../../../docs/internals/agents/claude.md) and its Codex, Copilot, Kimi, Pi, OpenCode, Antigravity, Cursor, Droid, Kiro, Qwen, and Grok siblings), [providers.md](../../../../docs/internals/agents/providers.md) (accounts, balances, spend, and pricing), and the per-agent upstream references in [agent-adapter/](../../../../docs/externals/agent-adapter/claude-reference.md). The sequenced integration playbook for a new built-in is [agent-adapters.md](../../../../docs/contributing/agent-adapters.md).
+Topic detail lives in the internals leaves the root map describes — [adapter.md](../../../../docs/internals/agents/adapter.md) (this layer: the registry, the capability traits, the hook path, install, context sources, and declared coverage), [model.md](../../../../docs/internals/agents/model.md) (the agent model the adapters feed: the rollup, the state machine, and the displayed-status ladder), the per-kind internal mappings ([claude.md](../../../../docs/internals/agents/claude.md) and its Codex, Amp, Copilot, Kimi, Pi, OpenCode, Antigravity, Cursor, Droid, Kiro, Qwen, and Grok siblings), [providers.md](../../../../docs/internals/agents/providers.md) (accounts, balances, spend, and pricing), and the per-agent upstream references in [agent-adapter/](../../../../docs/externals/agent-adapter/claude-reference.md). The sequenced integration playbook for a new built-in is [agent-adapters.md](../../../../docs/contributing/agent-adapters.md).
 
 ## Layout
 
@@ -31,7 +31,7 @@ Provider modules own native protocol and process interpretation. Code outside `a
 ## Hook discipline
 
 - **Blocking ask hooks are sync.** Installing one as async is a hard install error — the source of truth for "must block" is the adapter's hook catalog or equivalent typed installer declaration, never the on-disk config.
-- **Neutral follows the agent's decision contract.** Claude, Codex, Pi, OpenCode, and Grok use empty stdout; Cursor returns `{}` on every wired event because its hook contract requires JSON. Diagnostics stay off stdout. The fresh-stdio rule for helper children (a wrapped statusline, a notifier) is enforced by the no-`Stdio::inherit` CI grep.
+- **Neutral follows the agent's decision contract.** Claude, Codex, Pi, OpenCode, and Grok use empty stdout; Cursor and Antigravity answer every wired event with JSON because their hook contracts require it. Diagnostics stay off stdout. The fresh-stdio rule for helper children (a wrapped statusline, a notifier) is enforced by the no-`Stdio::inherit` CI grep.
 - **Set installed hook timeouts from upstream deadlines**, leaving margin for RimZ to finish store writes before the agent kills the hook.
 - **Install is idempotent.** Reclaim every rimz-owned entry by the stable command substring before rewriting the canonical set; leave user-authored entries untouched.
 

--- a/crates/rimz/src/cli/AGENTS.md
+++ b/crates/rimz/src/cli/AGENTS.md
@@ -1,6 +1,6 @@
 # CLI layer
 
-Local contract for `crates/rimz/src/cli/` — command parsing, presentation, and cross-command orchestration. Extends [crates/rimz/AGENTS.md](../../AGENTS.md); it never restates parent rules.
+Local contract for `crates/rimz/src/cli/` — command parsing, presentation, and cross-command orchestration. Extends [crates/rimz/AGENTS.md](../../AGENTS.md).
 
 ## What lives here
 
@@ -28,5 +28,5 @@ A handler parses, calls the domain, and presents; the knowledge lives in its own
 - Human colors come from `render::palette` accessors, state tones come from typed `render::status` helpers, and provider names and handles come from `palette::identity`. JSON, hook stdout, pane capture, scripting values, and streaming protocols stay raw.
 - A command module's internals are private: one command never imports another command's functions or types. Shared logic moves to the domain module that owns the knowledge, or to a shared CLI-layer module when it is pure presentation.
 - A command may publish an orchestration entry that other commands call as its owning surface: `room` publishes attach execution (used by `remote`), `hooks` publishes the install UX (used by `room` start and `setup`), `supervised` publishes the run driver and run rendering (used by `agents_cmd` and `loop_cmd`), and `agents_cmd` publishes resolved agent lifecycle operations (used by `teams`).
-- Concrete typed structs and functions suffice; generic service traits and ports stay out.
+- Concrete typed structs and functions are the default shape here. A generic service trait earns its place once a second real caller needs the seam, never in anticipation of one.
 - Domain code reports warnings as returned values and the handler prints them; the CLI owns every write to stdout and stderr.

--- a/crates/rimz/src/diag/AGENTS.md
+++ b/crates/rimz/src/diag/AGENTS.md
@@ -1,0 +1,27 @@
+# Diagnostics
+
+Local contract for `crates/rimz/src/diag/` — append-only JSONL evidence. Extends [crates/rimz/AGENTS.md](../../AGENTS.md). Subsystem behaviour — the schema table, the envelope, rate limiting, frame captures, off-box reporting — lives in [docs/internals/diagnostics.md](../../../../docs/internals/diagnostics.md).
+
+## Evidence, not input
+
+- **Diagnostics are for a human.** Correctness reads the store, the CAS rules, and the caches. No correctness path reads a diagnostic record back, and nothing here gates product behaviour.
+- **Records are anomaly-only.** A steady-state tick writes nothing, which is what keeps the log readable when something does go wrong.
+- **Writes are best-effort.** A failed append logs at debug and returns; the calling path continues unchanged.
+- **Only the sink touches disk.** Pure projection layers return diagnostics as data and hand them to `DiagSink`, so a fold stays testable and quiet.
+- Rate limiting lives with the sink: an identity window plus a per-kind ceiling bounds a loop that would otherwise flood the log.
+
+## Accountability
+
+An internal repair keeps a durable record of what it did — [`focus_repair.rs`](./focus_repair.rs) is the worked example, pairing automatic sidebar focus repair with its own rotating log. User-benefiting automation instead appends an assist record and surfaces in `rimz stats`; the split lives in [loops.md](../../../../docs/internals/harness/loops.md#the-assist-log).
+
+## Layout and boundaries
+
+- [`diag.rs`](../diag.rs) owns the sink, the rate limiter, and the frame-capture ring. It also owns the main diagnostics log name and the frame-capture directory name; `cargo xtask invariants` rejects those two literals anywhere else, so the primary surface stays enumerable from one file.
+- [`record.rs`](./record.rs) owns the schema and its version; [`rotating.rs`](./rotating.rs) is the shared rotating JSONL helper, with schema and path left to the caller.
+- Per-surface logs stay in their own file: [`notify.rs`](./notify.rs), [`binding.rs`](./binding.rs), [`focus_repair.rs`](./focus_repair.rs), [`plugin_presence.rs`](./plugin_presence.rs). Each is documented by the subsystem that writes it.
+- [`store/`](../store/AGENTS.md) owns durable truth and never consumes a record from here. `observability.rs` is the separate opt-in off-box channel behind the `sentry` build feature; keep local-only episodes local.
+- Snapshot projection stays quiet: the invariant rejects `warn!` and `error!` under `store/snapshot/`, so a per-fold diagnostic never floods the off-box channel.
+
+## Tests
+
+Severity mapping, rotation, and rate-limit windows stay in-module beside the file they cover. Fixtures pin time, so a record's envelope is asserted rather than approximated.

--- a/crates/rimz/src/diag/CLAUDE.md
+++ b/crates/rimz/src/diag/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/rimz/src/harness/AGENTS.md
+++ b/crates/rimz/src/harness/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent harness
 
-Local contract for `crates/rimz/src/harness/` — the spawn, address, drive, and reclaim machinery for agent sessions. Extends [crates/rimz/AGENTS.md](../../AGENTS.md); it never restates parent rules.
+Local contract for `crates/rimz/src/harness/` — the spawn, address, drive, and reclaim machinery for agent sessions. Extends [crates/rimz/AGENTS.md](../../AGENTS.md).
 
 Topic detail lives in [harness.md](../../../../docs/internals/harness/harness.md) (spawn, address, resume, reclaim), [scripting.md](../../../../docs/internals/harness/scripting.md) (supervised runs), [loops.md](../../../../docs/internals/harness/loops.md) (loop scheduling and the assist log), and [budget.md](../../../../docs/internals/harness/budget.md) (dollar caps and the park), with the shared delivery substrate in [messaging.md](../../../../docs/internals/harness/messaging.md).
 

--- a/crates/rimz/src/message/AGENTS.md
+++ b/crates/rimz/src/message/AGENTS.md
@@ -1,6 +1,6 @@
 # Message system
 
-Local contract for `crates/rimz/src/message/`: the durable queue that routes text into a running agent's pane. Extends [crates/rimz/AGENTS.md](../../AGENTS.md); it never restates parent rules.
+Local contract for `crates/rimz/src/message/`: the durable queue that routes text into a running agent's pane. Extends [crates/rimz/AGENTS.md](../../AGENTS.md).
 
 Topic detail lives in [messaging.md](../../../../docs/internals/harness/messaging.md), which owns the record, the ordered delivery check, the pipeline, reply waits, channels, and the transcript.
 
@@ -9,7 +9,7 @@ Topic detail lives in [messaging.md](../../../../docs/internals/harness/messagin
 - **The record is the message.** Every send persists a `MessageRecord` before a byte reaches a pane. A pane write is an attempt against that record, never the message itself.
 - **`Sent` precedes the submit.** `write_batch` records the batch as `Sent` after the paste lands and before it presses Enter, so a submitted message always has a durable record and audit event behind it.
 - **One card, one FIFO queue.** Records key on `(kind, agent_id)` with `agent_name` folding a provisional `launch_*` id into the session it registers as. `msg_` id string order is FIFO order.
-- **Two counters, two caps.** `attempts` guards pre-send claim failures (`MAX_DELIVERY_ATTEMPTS`); `unconfirmed_sends` guards writes a lifecycle hook never confirmed (`RIMZ_MESSAGE_MAX_DELIVERY_ATTEMPTS`). Keep them separate.
+- **Two counters, two caps.** `attempts` guards pre-send claim failures (`MAX_DELIVERY_ATTEMPTS`); `unconfirmed_sends` guards writes a lifecycle hook never confirmed (`DEFAULT_MAX_DELIVERY_ATTEMPTS`, overridable per run through the `RIMZ_MESSAGE_MAX_DELIVERY_ATTEMPTS` environment variable). Keep them separate.
 - **Delivery reads store state.** Gates evaluate the rollup and the message queue. Focused-pane state and captured composer contents never decide a delivery.
 - **`retry_after` is a wake hint.** It schedules the elder's next look and never affects `is_ready`, FIFO position, claim leases, or hook-driven delivery.
 
@@ -19,6 +19,6 @@ Topic detail lives in [messaging.md](../../../../docs/internals/harness/messagin
 - `message.rs` stays pure: types, card matching, FIFO and batch selection, threshold and schedule parsing, environment knobs. I/O belongs in the submodules.
 - Status transitions belong to the store boundary (`store/writer/queue.rs`), under the workspace lock, each with its audit event. The status enum carries vocabulary, not rules.
 - Message content never enters the event log. Terminal text lives in `messages/history.jsonl`.
-- `fire.rs` is in the sidebar import graph. It reads the wake stamp and spawns `message sweep`; store reads and writes stay in that helper.
+- `fire.rs` runs on the renderer's cache-refresh tick, so keep it as light as that path demands. It reads the wake stamp and spawns `message sweep`; store reads and writes stay in that helper.
 - Address grammar, handle rendering, and channel resolution live in `harness/target.rs`. This module resolves targets through it and never parses addresses itself.
 - CLI handlers own flag parsing, rendering, and exit codes. Dispatch conditions, delivery causality, and reply-wait state live here.

--- a/crates/rimz/src/mux/AGENTS.md
+++ b/crates/rimz/src/mux/AGENTS.md
@@ -1,6 +1,6 @@
 # Multiplexer backends
 
-Local contract for `crates/rimz/src/mux/` — the Zellij/tmux seam. Extends [crates/rimz/AGENTS.md](../../AGENTS.md); it never restates parent rules. Backend behaviour — selection, session birth, layouts, focus, recovery — lives in [docs/internals/multiplexers.md](../../../../docs/internals/multiplexers.md).
+Local contract for `crates/rimz/src/mux/` — the Zellij/tmux seam. Extends [crates/rimz/AGENTS.md](../../AGENTS.md). Backend behaviour — selection, session birth, layouts, focus, recovery — lives in [docs/internals/multiplexers.md](../../../../docs/internals/multiplexers.md).
 
 ## The seam
 

--- a/crates/rimz/src/remote/AGENTS.md
+++ b/crates/rimz/src/remote/AGENTS.md
@@ -1,0 +1,27 @@
+# Remote attach
+
+Local contract for `crates/rimz/src/remote/` — the SSH attach library. Extends [crates/rimz/AGENTS.md](../../AGENTS.md). Subsystem behaviour — attach and aliases, the reconnect supervisor, link health, port forwarding, bandwidth — lives in [docs/internals/remote.md](../../../../docs/internals/remote.md).
+
+## Pure library, process-free
+
+- This module parses targets, builds argv, classifies exits, and advances state machines from caller-supplied durations. It spawns no child, reads no clock, and writes no terminal.
+- `cli/remote/` owns every process, timer, thread, and terminal write: the supervisor, the outage panel, link stats, tty restore, setup, and list. A new behaviour lands as a pure transition here plus its driver there.
+- Every SSH invocation compiles to a [`mux::command::CommandSpec`](../mux/command.rs), so a remote command carries the same deadline and kill discipline as a local one.
+- State machines take durations as arguments and return the next state. That is what makes reconnect backoff, recovery timing, and link health testable without sleeping.
+
+## The two sides
+
+- Local owns the SSH child, reconnect policy, terminal hygiene, the recovery panel, link measurement, and port forwards.
+- Remote owns the room: workspace, session, sidebar, store, and the health gate.
+- Neither side reaches across, and they share no environment beyond the launch-snippet variables. Keep a new signal on the side that can observe it.
+
+## Layout
+
+- [`mod.rs`](./mod.rs) — the `[user@]host:<session-or-path>` grammar, the guarded ssh command, and the autossh-style reconnect policy.
+- [`aliases.rs`](./aliases.rs) — per-machine aliases in `remote.toml`; [`version.rs`](./version.rs) — client/host skew classification.
+- [`link.rs`](./link.rs) — the health JSONL protocol and terminal-session transitions; [`reachability.rs`](./reachability.rs) — endpoint discovery and reconnect-wait state; [`recovery.rs`](./recovery.rs) — panel timing and checkpoints.
+- [`forward.rs`](./forward.rs) — listener discovery and live ControlMaster forwards; [`web.rs`](./web.rs) and [`setup.rs`](./setup.rs) — argv builders whose I/O belongs to the CLI; [`tty.rs`](./tty.rs) — terminal-state hygiene.
+
+## Tests
+
+Grammar, classification, and every state transition stay in-module and pure. Attach behaviour that needs a subprocess lives in [`tests/integration/`](../../tests/integration/AGENTS.md), and rendered outage and reconnect flows belong to the journey tier.

--- a/crates/rimz/src/remote/CLAUDE.md
+++ b/crates/rimz/src/remote/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/rimz/src/room/AGENTS.md
+++ b/crates/rimz/src/room/AGENTS.md
@@ -1,6 +1,6 @@
 # Room runtime
 
-Local contract for `crates/rimz/src/room/` — managed room identity and lifecycle. Extends [crates/rimz/AGENTS.md](../../AGENTS.md); it never restates parent rules.
+Local contract for `crates/rimz/src/room/` — managed room identity and lifecycle. Extends [crates/rimz/AGENTS.md](../../AGENTS.md).
 
 ## Boundaries
 

--- a/crates/rimz/src/room/CLAUDE.md
+++ b/crates/rimz/src/room/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/rimz/src/sidebar/AGENTS.md
+++ b/crates/rimz/src/sidebar/AGENTS.md
@@ -1,0 +1,35 @@
+# Sidebar data plane
+
+Local contract for `crates/rimz/src/sidebar/` — the view-model the renderer draws. Extends [crates/rimz/AGENTS.md](../../AGENTS.md). Subsystem behaviour — presence, ranking, reload — lives in [docs/internals/sidebar/sidebar.md](../../../../docs/internals/sidebar/sidebar.md), and the data plane itself — election, fetch cycle, caches, events, fusion, cadences — lives in [state.md](../../../../docs/internals/sidebar/state.md).
+
+## Read-only on the store
+
+- This subsystem reads durable state and computes a `SidebarSnapshot`; [`store/`](../store/AGENTS.md) owns every write. `cargo xtask invariants` rejects a store-writer, run-wake, or broker import anywhere under this tree, tests included. The rule greps text, so state it in prose here rather than pasting the banned paths.
+- Event-log history enters through a `RollupCursor` fold. A direct whole-log or offset read is rejected here and in [`sidebar_pane/`](../sidebar_pane/AGENTS.md), which is what keeps snapshot cost bounded by the log tail rather than its length.
+- [`enrich.rs`](./enrich.rs) is the shared ordered projection spine both producer and consumer run: it forks no subprocess and writes no cache. The invariant rejects every subprocess-spawning path inside it; subprocess lanes live in [`refresh/`](./refresh/mod.rs).
+- The fold order is enforced: live panes land before project roots and worktree roots, so pane-derived identity is present when path enrichment reads it.
+
+## Truth and latency
+
+- **Pulled truth is authoritative.** The store rollup plus the producer's pane frame decide what is true.
+- **Events are latency.** [`events.rs`](./events.rs) wakeups and [`presence.rs`](./presence.rs) plugin pushes overlay pulled truth in [`fuse.rs`](./fuse.rs) until the next pull supersedes them. A missed event costs a tick, never correctness.
+- **Pending focus intent outranks both** until the mux confirms the jump or the anchor in [`focus_anchor.rs`](./focus_anchor.rs) expires, so a click never appears to bounce back.
+- **One producer per workspace.** The eldest live instance by UUIDv7 wins the election in [`mod.rs`](./mod.rs); younger renderers read the cache. The heartbeat is a latency hint and never blocks a fresh launch.
+- Cadence constants live in [`timing.rs`](./timing.rs) alone. Tune a TTL there so poll mode, push mode, and the heavy lanes stay legible against each other.
+
+## Lanes
+
+- [`produce/`](./produce/mod.rs) is the per-tick pipeline the elected producer runs: group roots, sidecars, pane overlay, refresh-lane projection.
+- [`refresh/`](./refresh/mod.rs) owns the heavy lanes — git, provider accounts, credits, pull requests, rate limits, sessions, live spend. Each lane gates on its own TTL and publishes through the cache temp-then-rename helper.
+- [`consumer.rs`](./consumer.rs) reads a fresh rollup over the producer's pane cache and calls no mux, git, or provider.
+- Projections published for consumers — [`agent_projection.rs`](./agent_projection.rs), [`workspace_projection.rs`](./workspace_projection.rs) — are disposable and re-validated before use.
+
+## Boundaries
+
+- [`mux/`](../mux/AGENTS.md) supplies the pane roster behind the `PaneRef` seam in [`frame.rs`](./frame.rs); backend knowledge stops there.
+- [`sidebar_pane/`](../sidebar_pane/AGENTS.md) renders the snapshot and holds no data-plane policy.
+- [`agents/`](../agents/AGENTS.md) never imports `crate::sidebar`; the invariant enforces the direction, and workspace inputs flow outward through `agents::spending`.
+
+## Tests
+
+Fold, fusion, election, and cadence logic stay in-module beside the file they cover. Supervisor, snapshot, launch, and unread behaviour lives in [`tests/integration/`](../../tests/integration/AGENTS.md); rendered flows belong to the journey tier and diff-stat cost to the performance tier.

--- a/crates/rimz/src/sidebar/CLAUDE.md
+++ b/crates/rimz/src/sidebar/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/rimz/src/sidebar_pane/AGENTS.md
+++ b/crates/rimz/src/sidebar_pane/AGENTS.md
@@ -1,0 +1,29 @@
+# Sidebar renderer
+
+Local contract for `crates/rimz/src/sidebar_pane/` — the pane-resident renderer process. Extends [crates/rimz/AGENTS.md](../../AGENTS.md). The renderer split lives in [docs/internals/sidebar/sidebar.md](../../../../docs/internals/sidebar/sidebar.md), the on-screen spec in [docs/interface/sidebar.md](../../../../docs/interface/sidebar.md), the color pipeline in [theme.md](../../../../docs/internals/theme.md), and the pet in [pets.md](../../../../docs/internals/sidebar/pets.md).
+
+## The process
+
+- [`app.rs`](./app.rs) owns the serve loop; [`render/`](./render/mod.rs) turns a `SidebarSnapshot` into cells. Reducers in [`app/state.rs`](./app/state.rs) stay pure, and [`supervise.rs`](./supervise.rs) owns convergence.
+- Snapshots arrive in process on the fetch worker in [`app/fetch.rs`](./app/fetch.rs), which reads through [`sidebar::consumer`](../sidebar/consumer.rs). `rimz sidebar snapshot` is the inspection and scripting delegate over the same library, never this process's data path.
+- Rendering reads the snapshot clock. `cargo xtask invariants` rejects `Timestamp::now()` in non-test render code, which is what keeps a frame reproducible from its snapshot alone.
+- Renderer-local state — row and group order holds, selection, width control — stays renderer-local and never travels back into the data plane.
+
+## Read-only on the store
+
+- The renderer draws; [`store/`](../store/AGENTS.md) writes. The invariant rejects a store-atomic or store-writer import anywhere under this tree, and it greps text, so state the rule in prose rather than pasting the banned paths.
+- Event-log history enters through a `RollupCursor` fold, the same rule that binds [`sidebar/`](../sidebar/AGENTS.md).
+
+## The theme edge
+
+- Resolve every color through a component token, `theme.component(Component::…)` in [`render/theme.rs`](./render/theme.rs), or a semantic accessor. The invariant rejects every named ratatui `Color` variant in render code — including the indexed and true-color constructors — leaving `Color::Reset` as the single literal a render file may name, so only the theme pipeline mints a color.
+- Resolve every glyph through `theme.glyph(GlyphRole::…)`, which the shared core in [`theme/`](../theme/mod.rs) owns. The invariant carries the banned-literal list, which is what keeps the legend and the frame in step.
+- The carrier layer is exempt: [`render/theme.rs`](./render/theme.rs) and its component tokens turn a tone into a ratatui color, and [`render/ansi.rs`](./render/ansi.rs) quantizes that carrier down for a limited terminal. Add a color or glyph there and name it by role everywhere else.
+
+## Pets
+
+[`pets/`](./pets/mod.rs) owns asset loading, sprite slicing, cell-art conversion, track selection, and captions. The renderer receives a `PetView` and nothing more, so decode, cache, and I/O stay inside the module.
+
+## Tests
+
+Render tests golden a full screen through the `assert_snapshot` helper in [`render/tests/`](./render/tests/mod.rs), which pins `insta` settings and scrubs live durations and ages before comparing — reach for it rather than calling `insta` directly, so a frame never fails on elapsed time. Reducer, selection, and ordering tests stay pure and in-module.

--- a/crates/rimz/src/sidebar_pane/CLAUDE.md
+++ b/crates/rimz/src/sidebar_pane/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/rimz/src/store/AGENTS.md
+++ b/crates/rimz/src/store/AGENTS.md
@@ -1,10 +1,10 @@
 # Store
 
-Local contract for `crates/rimz/src/store/` — durable workspace state. Extends [crates/rimz/AGENTS.md](../../AGENTS.md); it never restates parent rules. Subsystem behaviour — on-disk shape, event log, write and read paths, write classes, maintenance — lives in [docs/internals/store.md](../../../../docs/internals/store.md).
+Local contract for `crates/rimz/src/store/` — durable workspace state. Extends [crates/rimz/AGENTS.md](../../AGENTS.md). Subsystem behaviour — on-disk shape, event log, write and read paths, write classes, maintenance — lives in [docs/internals/store.md](../../../../docs/internals/store.md).
 
 ## Writes and durability
 
-- Every mutator lands under [`writer.rs`](./writer.rs): the façade owns the `commit` primitive, and `writer/` owns the debounce, lifecycle, publish, reset, and queue branches. Reads on the `Store` handle stay lock-free.
+- Every mutator lands under [`writer.rs`](./writer.rs): the façade owns the `commit` primitive, and `writer/` owns the debounce, lifecycle, publish, reset, queue, and reap branches. Reads on the `Store` handle stay lock-free.
 - `workspace.lock` is the only cross-process serialization. Every writer is a short-lived CLI process, so a change that needs ordering takes the lock rather than introducing an in-process actor.
 - Every durable write routes through [`atomic.rs`](./atomic.rs), and every fsync syscall lives inside it; `cargo xtask invariants` rejects a `sync_all`/`sync_data` call anywhere else. No module hand-rolls its own atomic dance, and the event-log frame encoding stays beside its decoder in [`event_log/frame.rs`](./event_log/frame.rs).
 - [`writer/queue.rs`](./writer/queue.rs) owns all three message surfaces together: the live `messages.jsonl`, terminal text in the sibling `history.jsonl`, and terminal outcomes in the event log. Shared age pruning stays in [`atomic.rs`](./atomic.rs).

--- a/crates/rimz/tests/integration/AGENTS.md
+++ b/crates/rimz/tests/integration/AGENTS.md
@@ -1,17 +1,17 @@
 # Integration suite
 
-Local contract for `crates/rimz/tests/integration/` — the crate's single integration-test binary. Extends [crates/rimz/AGENTS.md](../../AGENTS.md); it never restates parent rules. Test tiers and runner rules live in [rust-conventions.md](../../../../docs/contributing/rust-conventions.md#tests).
+Local contract for `crates/rimz/tests/integration/` — the crate's single integration-test binary. Extends [crates/rimz/AGENTS.md](../../AGENTS.md). Test tiers and runner rules live in [rust-conventions.md](../../../../docs/contributing/rust-conventions.md#tests).
 
 ## Harness
 
 - One binary: every suite is a module of [`main.rs`](./main.rs), and [`common/`](./common/mod.rs) is declared once — no per-file harness duplication.
-- Pick the tier by what the test drives: `common::Env` runs the `rimz` binary out of process with HOME, XDG, `TMUX_TMPDIR`, and `ZELLIJ_CONFIG_DIR` scoped to tempdirs; `common::Harness` opens a real in-process `rimz::Store` for direct API tests; `common::payloads` holds the golden agent hook payloads and environment probes both tiers share.
+- Pick the tier by what the test drives: `common::Env` runs the `rimz` binary out of process with HOME, XDG, `TMUX_TMPDIR`, and `ZELLIJ_CONFIG_DIR` scoped to tempdirs; `common::Harness` opens a real in-process `rimz::Store` for direct API tests; `common::payloads` holds the golden agent hook payloads and `common::shim` the environment probes and fake executables, both shared across tiers.
 - Real tempdir, real store files — no in-memory stubs.
 - Every builder that runs `rimz` or creates a mux server scrubs the ambient session env at construction (`common::ScrubSessionEnvExt` — the `RIMZ_*` identity pin and the `ZELLIJ*`/`TMUX*` detection vars), so a suite run from inside a live RimZ room behaves like a clean shell; a test that needs one of these sets it explicitly afterwards.
 
 ## Placement
 
-- Subdirectory matches tier: `store/` durability and CAS, `backend/` live-mux parity plus the real-browser web suite (`backend/web/`: real ttyd + headless Chromium, self-skipping without them), `examples/` the embedded and shipped script surfaces (the Pi extension, mux config samples), `journey/` rendered user flows, `performance/` bounded resource use. A new suite lands where its tier says, not beside a similar-looking file.
-- Host dependencies self-skip: a test that needs `zellij`, `tmux`, or `python3` probes for the binary and skips when absent — CI never requires an installed mux.
+- Subdirectory matches tier: `store/` durability and CAS, `backend/` live-mux parity plus the real-browser web suite (`backend/web/`: real ttyd + headless Chromium, self-skipping without them), `examples/` the RimZ-authored in-process scripts running under their real interpreter (the Pi extension, the OpenCode plugin), `journey/` rendered user flows, `performance/` bounded resource use. A new suite lands where its tier says, not beside a similar-looking file.
+- Host dependencies self-skip: a test that needs `zellij`, `tmux`, or `node` probes for the capability and skips when absent — CI never requires an installed mux, and the OpenCode suite additionally skips a `node` that cannot strip TypeScript syntax.
 - External seams are faked with the [`tests/fixtures/`](../fixtures/) shims (`zellij-trace`, `git-trace`, `ssh-trace`, `codex-appserver-stub`); mux-driving tests route `rimz` invocations at an isolated tmux server env and a private Zellij runtime so a developer's live sessions stay untouched.
 - Time is deterministic: fixed-epoch fixtures, boundary-exact.

--- a/docs/contributing/agent-adapters.md
+++ b/docs/contributing/agent-adapters.md
@@ -105,7 +105,7 @@ Conformance, definition validation, and registry uniqueness tests enroll the ada
 
 ## Step 11 — Gate it
 
-Done means: `cargo xtask gate` is green (format, invariants, docs-links, lint, fast tests); `rimz coverage` shows the kind's six capability marks reading true and `rimz coverage --wiring` its concern and lifecycle-hook rows; `rimz doctor` reports the hook install state; and `rimz agents <kind>` launches the stock CLI into a pane whose row registers, runs, asks, and settles in the sidebar. Escalate to the journey and live-backend tiers when the change touches their surfaces ([AGENTS.md → Testing requirements](../../AGENTS.md#testing-requirements)).
+Done means: `cargo xtask gate` is green (format, invariants, docs-links, lint, fast tests); `rimz coverage` shows the kind's six capability marks reading true and `rimz coverage --wiring` its concern and lifecycle-hook rows; `rimz doctor` reports the hook install state; and `rimz agents <kind>` launches the stock CLI into a pane whose row registers, runs, asks, and settles in the sidebar. Escalate to the journey and live-backend tiers when the change touches their surfaces ([AGENTS.md → Testing](../../AGENTS.md#testing)).
 
 ## The deliverables checklist
 

--- a/docs/guide/AGENTS.md
+++ b/docs/guide/AGENTS.md
@@ -1,6 +1,6 @@
 # Guide writing contract
 
-Local contract for `docs/guide/`, the user guides. Extends the root [AGENTS.md](../../AGENTS.md); it never restates parent rules. It governs new guides and every edit to an existing one.
+Local contract for `docs/guide/`, the user guides. Extends the root [AGENTS.md](../../AGENTS.md). It governs new guides and every edit to an existing one.
 
 ## The reader
 
@@ -32,6 +32,6 @@ Each topic has one owning guide; every other page links there with a half-line o
 
 - Guide filenames are lowercase topic words. Never name a guide `agents.md`: it collides with the `AGENTS.md` contract files on case-insensitive filesystems and with the reference and internals files of that name.
 - `sh` blocks are copy-runnable; `console` blocks carry output as the command actually printed it, captured, never invented.
-- Every guide ends with a "See also" list, each link carrying the reason to follow it.
+- A guide that leaves the reader with an obvious next step ends in a `## See also` list, each link carrying the reason to follow it. Most do; a terminal page like `installation.md` or `security.md` reasonably stops instead.
 - A moved or reworded heading breaks inbound anchors silently. After changing one, grep for the old anchor across the repo and run `cargo xtask docs-links`, which validates file targets and `#anchors` together.
 - A new guide is not done until [docs/README.md](../README.md) and the root documentation map list it; an unlinked page is invisible.

--- a/docs/guide/CLAUDE.md
+++ b/docs/guide/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

Recalibrates the working contract for a more capable agent.

The contract was written to leave the agent little discretion: nearly every statement was an absolute rule, whether it guarded a product invariant or merely expressed a wording preference. An agent that judges well does not need most of them, and spending the contract's authority on preferences dilutes the few rules that genuinely bind. This hands that judgment back.

**Fewer absolute rules.** The tone section enumerated specific phrasings to avoid; it now states the principle and leaves the application to the writer. Engineering principles spent three bullets instructing the reader to use typed identifiers and structured parsers — ordinary practice a capable agent already follows — and is now one paragraph. The clause `it never restates parent rules` is gone from all thirteen child contracts, being itself a restatement of a parent rule.

**Judgment is delegated in writing.** Decide change decomposition and test cost without asking. Push back when a request rests on a false premise or has a simpler shape. Match the size of the change to the size of the ask. When the documentation and the code disagree, follow the code and fix the documentation in the same change.

**Two grades, so the surviving rules keep their force.** Loosening everything uniformly would cost as much as the old blanket strictness. Invariants — enforced by the build or promised by the product — stay absolute and are marked as such in each section. Everything else is a default: followed absent better information, departed from with a stated reason. A default that keeps losing is a bug in the contract.

**Four subsystem contracts land** — `diag`, `remote`, `sidebar`, `sidebar_pane` — along with the `CLAUDE.md` symlinks still missing beside `room` and `docs/guide`.

### Corrections

Reviewing for judgment latitude surfaced claims that no longer matched the code. Each was verified against the source before changing.

| Claim | Reality |
| --- | --- |
| A doc should name the path a rule bans | The checker scans markdown too, so a contract inside a guarded subtree must describe the boundary instead |
| `diag.rs` owns every diagnostic log path literal | It owns two guarded names; four others live in their per-surface files |
| The store writer has five branches | Six — `reap` was missing |
| The render color rule rejects two constructors | It rejects every named `Color` variant, `Color::Reset` excepted |
| `theme.component` lives in `src/theme/` | It lives under `sidebar_pane/render/theme` |
| `render/theme.rs` is the only exempt carrier | `render/ansi.rs` is exempt too |
| `message/fire.rs` is in the sidebar import graph | It runs on the renderer's cache-refresh tick |
| The second delivery cap is a Rust constant | It is a default plus an environment override |
| The integration suite probes `python3` | It probes `node`, and skips one that cannot strip TypeScript |
| The examples tier holds mux config samples | It holds the Pi extension and the OpenCode plugin |
| `common::payloads` holds the environment probes | `common::shim` does |
| The adapter contract lists every per-agent doc | Amp was missing |
| Only Cursor replies to hooks in JSON | Antigravity does too |
| The repository layout is complete | `docker/` was missing |

The guide rule requiring a `See also` section on every page is relaxed to match the two thirds that follow it, so a terminal page like `installation.md` or `security.md` may reasonably stop instead.

## Verification

Markdown-only change; no Rust file is touched, and no test asserts on contract content (the two Rust references are a doc comment and a fixture prompt string).

- [x] `cargo xtask invariants` — the gate that greps tracked markdown
- [x] `cargo xtask docs-links` — file targets and `#anchors`
- [x] `cargo xtask test` — not run; `fmt`, `lint`, and nextest cannot be reached by this diff
- [x] `cargo xtask ci`

Renaming the root heading `Testing requirements` to `Testing` broke one inbound anchor from `docs/contributing/agent-adapters.md`, repointed in this change. All sixteen `CLAUDE.md` symlinks remain symlinks (committed as mode 120000).

## Checklist

- [x] Docs updated or not needed
- [x] Security, trust, and pane-I/O boundaries preserved — invariant text is clarified, never loosened
- [x] New or changed behavior covered by tests — no behavior change; both markdown gates pass
- [x] `CHANGELOG.md` untouched, per the contract
