### PR TITLE
Bound every xtask task with a wall clock

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -38,6 +38,16 @@
 # the Zellij group already absorbs. The deep journey tmux smoke joins the group
 # too, mirroring its Zellij twin, so an under-load blip retries instead of
 # failing the run outright.
+#
+# Every test also carries a per-test wall clock. The slowest legitimate waits in
+# the suite are the live spawn and lock deadlines (a Zellij presence poll at
+# 150s, the workspace lock at 120s), so a test still running at 6m is wedged,
+# not slow: nextest terminates it and names it in the summary. That bounds one
+# hung test to a named failure inside the run, while `cargo xtask`'s own budget
+# bounds the run as a whole (xtask/src/deadline.rs).
+[profile.default]
+slow-timeout = { period = "120s", terminate-after = 3 }
+
 [test-groups]
 live-zellij = { max-threads = 2 }
 live-tmux = { max-threads = 4 }

--- a/docs/contributing/rust-conventions.md
+++ b/docs/contributing/rust-conventions.md
@@ -248,6 +248,11 @@ Every PR gate runs in CI with warnings treated as errors; each has a local `carg
 
 Escalate past `gate` when the change touches the matching surface: `cargo xtask test -P live` for live-backend and deep-mux-smoke coverage, `cargo xtask test -P journey` for rendered journeys, `cargo xtask externals` when dependencies change, and `cargo xtask ci` for both checks and the full suite.
 
+Two wall clocks bound a run, so a wedged compile, test process, or multiplexer costs a bounded wait instead of the caller's patience:
+
+- **The run** — every task carries a budget armed at startup ([xtask/src/deadline.rs](../../xtask/src/deadline.rs)): 15 minutes for `gate` and the fast tasks, 45 minutes for the tasks that pay a whole build plus every test tier (`ci`, `checks`, `lint`, `test`, `test-archive`, `coverage`, `perf`, and the release builds), and no bound for the operator-driven `sandbox` and `screenshot`. On overrun the running child gets `SIGTERM`, then `SIGKILL` five seconds later, and the task fails naming the command and its elapsed time. `RIMZ_XTASK_TIMEOUT` sets the budget for one run — `45m`, `900s`, a bare `900` for seconds, or `off` to lift it — which is the escape hatch when a cold tree needs a full compile inside the gate.
+- **One test** — `slow-timeout` in [.config/nextest.toml](../../.config/nextest.toml) warns every two minutes and terminates a test at six, so a hung test fails by name in the run summary while the tiers around it keep going. The suite's slowest legitimate waits are the live spawn and lock deadlines at 150s and 120s.
+
 The individual gates:
 
 - Long-running human-facing phases show a TTY-gated stderr status line with the live phase and elapsed time; `xtask/src/spinner.rs` is a deliberate lightweight copy of the RimZ CLI spinner that keeps xtask independent of the runtime crate.

--- a/xtask/src/deadline.rs
+++ b/xtask/src/deadline.rs
@@ -1,0 +1,226 @@
+//! Wall-clock budget for one `cargo xtask` run.
+//!
+//! Every task carries a budget, armed once at startup: [`overrun`] reports when
+//! the run has spent it, and [`crate::runner`] terminates the running child and
+//! fails with the overrun. A hung compile, a wedged test process, or a starved
+//! multiplexer therefore costs a bounded wait instead of the caller's patience.
+//!
+//! `RIMZ_XTASK_TIMEOUT` sets the budget for one run: `15m`, `900s`, a bare
+//! `900` (seconds), or `off` to lift the bound entirely.
+
+use std::env;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use anyhow::{Result, bail};
+
+/// The pre-PR budget: `gate` and every fast task run inside this.
+const DEFAULT_BUDGET: Duration = Duration::from_secs(15 * 60);
+/// Whole-compile and whole-suite passes: `ci`, the unfiltered nextest suite,
+/// instrumented coverage, and release-profile builds all pay a full build plus
+/// every test tier, so they carry a wider bound than the pre-PR gate.
+const LONG_BUDGET: Duration = Duration::from_secs(45 * 60);
+
+const ENV_OVERRIDE: &str = "RIMZ_XTASK_TIMEOUT";
+
+static RUN: OnceLock<Run> = OnceLock::new();
+
+struct Run {
+    task: String,
+    limit: Option<Duration>,
+    start: Instant,
+}
+
+/// A run that has spent its budget, rendered by the terminating caller.
+pub(crate) struct Overrun {
+    task: String,
+    limit: Duration,
+    elapsed: Duration,
+}
+
+impl std::fmt::Display for Overrun {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "xtask `{}` exceeded its {} budget after {}",
+            self.task,
+            format_duration(self.limit),
+            format_duration(self.elapsed),
+        )
+    }
+}
+
+impl Overrun {
+    /// The one line that tells the operator how to get past this.
+    pub(crate) fn next_step(&self) -> String {
+        format!(
+            "NEXT: rerun the slow step on its own, or widen the budget for one run with {ENV_OVERRIDE}={}",
+            format_duration(self.limit.saturating_mul(3)),
+        )
+    }
+}
+
+/// Arm the budget for `task`. Called once, before the task runs.
+pub(crate) fn arm(task: &str) -> Result<()> {
+    let limit = resolve_limit(task, env::var(ENV_OVERRIDE).ok().as_deref())?;
+    arm_with(task, limit);
+    Ok(())
+}
+
+/// Arm an explicit budget, starting the clock now.
+pub(crate) fn arm_with(task: &str, limit: Option<Duration>) {
+    let _ = RUN.set(Run {
+        task: task.to_owned(),
+        limit,
+        start: Instant::now(),
+    });
+}
+
+/// The overrun for this run, once the wall clock passes the armed budget.
+pub(crate) fn overrun() -> Option<Overrun> {
+    let run = RUN.get()?;
+    let limit = run.limit?;
+    let elapsed = run.start.elapsed();
+    (elapsed >= limit).then(|| Overrun {
+        task: run.task.clone(),
+        limit,
+        elapsed,
+    })
+}
+
+/// The budget for `task`, with the environment override applied.
+fn resolve_limit(task: &str, raw_override: Option<&str>) -> Result<Option<Duration>> {
+    match raw_override {
+        Some(raw) => parse_budget(raw),
+        None => Ok(task_budget(task)),
+    }
+}
+
+/// `None` leaves a task unbounded: `sandbox` and `screenshot` hand the terminal
+/// to a command the operator drives, so their wall clock is the operator's.
+fn task_budget(task: &str) -> Option<Duration> {
+    match task {
+        "sandbox" | "screenshot" => None,
+        "ci" | "checks" | "lint" | "test" | "test-archive" | "coverage" | "perf" | "semver"
+        | "dist" | "install" | "install-dev" | "stage-install" | "profile-build" => {
+            Some(LONG_BUDGET)
+        }
+        _ => Some(DEFAULT_BUDGET),
+    }
+}
+
+fn parse_budget(raw: &str) -> Result<Option<Duration>> {
+    let raw = raw.trim();
+    if matches!(raw, "off" | "none" | "never" | "0") {
+        return Ok(None);
+    }
+    let (digits, unit_secs) = match raw.as_bytes().last() {
+        Some(b'h') => (&raw[..raw.len() - 1], 3600),
+        Some(b'm') => (&raw[..raw.len() - 1], 60),
+        Some(b's') => (&raw[..raw.len() - 1], 1),
+        _ => (raw, 1),
+    };
+    let Ok(count) = digits.trim().parse::<u64>() else {
+        bail!("{ENV_OVERRIDE} expects a duration like `15m`, `900s`, `900`, or `off`; got `{raw}`");
+    };
+    if count == 0 {
+        return Ok(None);
+    }
+    Ok(Some(Duration::from_secs(count * unit_secs)))
+}
+
+/// Minutes and seconds, the scales a gate budget is read in; a sub-second
+/// budget (an override, or a test) renders in milliseconds so it stays visible.
+pub(crate) fn format_duration(duration: Duration) -> String {
+    let secs = duration.as_secs();
+    if secs == 0 {
+        return format!("{}ms", duration.as_millis());
+    }
+    match (secs / 60, secs % 60) {
+        (0, secs) => format!("{secs}s"),
+        (mins, 0) => format!("{mins}m"),
+        (mins, secs) => format!("{mins}m{secs}s"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gate_carries_the_pre_pr_budget_and_full_passes_carry_the_wide_one() {
+        assert_eq!(task_budget("gate"), Some(DEFAULT_BUDGET));
+        assert_eq!(task_budget("docs-links"), Some(DEFAULT_BUDGET));
+        assert_eq!(task_budget("ci"), Some(LONG_BUDGET));
+        assert_eq!(task_budget("coverage"), Some(LONG_BUDGET));
+    }
+
+    #[test]
+    fn operator_driven_tasks_stay_unbounded() {
+        assert_eq!(task_budget("sandbox"), None);
+        assert_eq!(task_budget("screenshot"), None);
+    }
+
+    #[test]
+    fn budget_override_reads_every_documented_form() {
+        assert_eq!(
+            parse_budget("45m").unwrap(),
+            Some(Duration::from_secs(2700))
+        );
+        assert_eq!(parse_budget("90s").unwrap(), Some(Duration::from_secs(90)));
+        assert_eq!(
+            parse_budget(" 900 ").unwrap(),
+            Some(Duration::from_secs(900))
+        );
+        assert_eq!(parse_budget("2h").unwrap(), Some(Duration::from_secs(7200)));
+        for lifted in ["off", "none", "never", "0", "0m"] {
+            assert_eq!(parse_budget(lifted).unwrap(), None, "{lifted}");
+        }
+    }
+
+    #[test]
+    fn budget_override_rejects_unparseable_durations() {
+        let err = parse_budget("soon").unwrap_err().to_string();
+        assert!(
+            err.contains("RIMZ_XTASK_TIMEOUT expects a duration"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn budget_override_replaces_the_task_budget() {
+        assert_eq!(
+            resolve_limit("sandbox", Some("5m")).unwrap(),
+            Some(Duration::from_secs(300))
+        );
+        assert_eq!(resolve_limit("gate", Some("off")).unwrap(), None);
+        assert_eq!(resolve_limit("gate", None).unwrap(), Some(DEFAULT_BUDGET));
+    }
+
+    #[test]
+    fn durations_render_at_minute_and_second_scale() {
+        assert_eq!(format_duration(Duration::from_secs(900)), "15m");
+        assert_eq!(format_duration(Duration::from_secs(903)), "15m3s");
+        assert_eq!(format_duration(Duration::from_secs(42)), "42s");
+        assert_eq!(format_duration(Duration::from_millis(200)), "200ms");
+    }
+
+    #[test]
+    fn overrun_points_at_a_wider_budget() {
+        let overrun = Overrun {
+            task: "gate".to_owned(),
+            limit: DEFAULT_BUDGET,
+            elapsed: DEFAULT_BUDGET + Duration::from_secs(3),
+        };
+
+        assert_eq!(
+            overrun.to_string(),
+            "xtask `gate` exceeded its 15m budget after 15m3s"
+        );
+        assert!(
+            overrun.next_step().contains("RIMZ_XTASK_TIMEOUT=45m"),
+            "{}",
+            overrun.next_step()
+        );
+    }
+}

--- a/xtask/src/gates.rs
+++ b/xtask/src/gates.rs
@@ -515,13 +515,7 @@ fn extract_test_summary(output: &str) -> Option<String> {
 // crate, `CARGO_PKG_NAME=xtask` is inherited and machete treats argv[1]
 // ("machete") as a path. Clear it for the spawn.
 pub(crate) fn deps(root: &Path) -> Result<()> {
-    let status = Command::new("cargo")
-        .arg("machete")
-        .current_dir(root)
-        .env_remove("CARGO_PKG_NAME")
-        .status()
-        .context("running `cargo`")?;
-    ensure_success("cargo", &["machete"], status)
+    run_with_env_and_removed(root, "cargo", ["machete"], &[], &["CARGO_PKG_NAME"])
 }
 
 pub(crate) fn test(root: &Path, args: &[String]) -> Result<()> {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,6 +6,7 @@
 mod brew;
 mod build;
 mod complexity;
+mod deadline;
 mod docs_links;
 mod files;
 mod gates;
@@ -204,6 +205,7 @@ fn main() -> Result<()> {
     match parse_args(&args)? {
         Action::Run { task, args } => {
             let root = runner::workspace_root()?;
+            deadline::arm(task)?;
             run_task(task, args, &root)
         }
         Action::Help(None) => {
@@ -323,6 +325,10 @@ fn print_xtask_help() {
     println!("  cargo xtask              # run ci");
     println!("  cargo xtask <task>");
     println!("  cargo xtask <task> --help");
+    println!();
+    println!("Every task runs under a wall-clock budget (15m; 45m for full");
+    println!("compile-and-suite passes). Set RIMZ_XTASK_TIMEOUT=45m or =off to");
+    println!("change it for one run.");
     println!();
     println!("Tasks:");
     for task in TASKS {

--- a/xtask/src/runner.rs
+++ b/xtask/src/runner.rs
@@ -3,10 +3,20 @@ use std::ffi::OsStr;
 use std::fs;
 use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
-use std::process::{Command, ExitStatus, Stdio};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::mpsc;
 use std::thread;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
+
+use crate::deadline;
+
+/// How often a waiting task checks its child and its budget.
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+/// How long a terminated child gets to reap its own children before the kill.
+/// `cargo` and `nextest` both tear down their spawned processes on `SIGTERM`.
+const TERMINATE_GRACE: Duration = Duration::from_secs(5);
 
 pub(crate) struct Captured {
     pub(crate) status: ExitStatus,
@@ -46,10 +56,10 @@ where
     S: AsRef<OsStr>,
 {
     let args: Vec<_> = args.into_iter().collect();
-    let mut command = build_command(root, program, &args, envs, removed_envs);
-    let status = command
-        .status()
+    let mut child = build_command(root, program, &args, envs, removed_envs)
+        .spawn()
         .with_context(|| format!("running `{program}`"))?;
+    let status = wait_bounded(&mut child, program, &args, &mut || {})?;
     ensure_success(program, &args, status)
 }
 
@@ -78,14 +88,28 @@ where
         let mut stdout = stdout;
         stdout.read_to_end(&mut output).map(|_| output)
     });
+    // Stderr streams on its own thread and hands lines back over a channel, so
+    // the waiting thread stays free to watch the child and its budget.
+    let (lines_tx, lines_rx) = mpsc::channel();
+    let stderr_worker = thread::spawn(move || {
+        capture_lines_lossy(BufReader::new(stderr), &mut |line| {
+            let _ = lines_tx.send(line.to_owned());
+        })
+    });
 
-    let stderr_result = capture_lines_lossy(BufReader::new(stderr), on_line);
-    let status = child.wait().context("waiting for command")?;
+    let status = wait_bounded(&mut child, program, &args, &mut || {
+        while let Ok(line) = lines_rx.try_recv() {
+            on_line(&line);
+        }
+    })?;
     let stdout = stdout_worker
         .join()
         .map_err(|_| anyhow::anyhow!("command stdout reader panicked"))?
         .context("reading command stdout")?;
-    let stderr_output = stderr_result.context("reading command stderr")?;
+    let stderr_output = stderr_worker
+        .join()
+        .map_err(|_| anyhow::anyhow!("command stderr reader panicked"))?
+        .context("reading command stderr")?;
 
     let mut combined = String::from_utf8_lossy(&stdout).into_owned();
     combined.push_str(&stderr_output);
@@ -93,6 +117,56 @@ where
         status,
         output: combined,
     })
+}
+
+/// Wait for `child`, terminating it once the run spends its wall-clock budget.
+/// `on_tick` runs between polls so a streaming caller keeps draining output.
+fn wait_bounded<S: AsRef<OsStr>>(
+    child: &mut Child,
+    program: &str,
+    args: &[S],
+    on_tick: &mut dyn FnMut(),
+) -> Result<ExitStatus> {
+    loop {
+        on_tick();
+        if let Some(status) = child.try_wait().context("waiting for command")? {
+            return Ok(status);
+        }
+        if let Some(overrun) = deadline::overrun() {
+            terminate(child);
+            bail!(
+                "{overrun}: terminated `{program} {}`\n{}",
+                rendered_args(args),
+                overrun.next_step(),
+            );
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// Ask the child to stop, then insist. `SIGTERM` first gives `cargo` and
+/// `nextest` their own chance to tear down compiles and test processes; the
+/// kill covers a child that ignores it.
+fn terminate(child: &mut Child) {
+    signal_child(child.id(), "-TERM");
+    let deadline = Instant::now() + TERMINATE_GRACE;
+    while Instant::now() < deadline {
+        if child.try_wait().is_ok_and(|status| status.is_some()) {
+            return;
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn signal_child(pid: u32, signal: &str) {
+    let _ = Command::new("kill")
+        .args([signal, "--", &pid.to_string()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
 }
 
 fn capture_lines_lossy(
@@ -146,12 +220,14 @@ pub(crate) fn ensure_success<S: AsRef<OsStr>>(
     if status.success() {
         return Ok(());
     }
-    let rendered_args = args
-        .iter()
+    bail!("command failed: {program} {}", rendered_args(args));
+}
+
+fn rendered_args<S: AsRef<OsStr>>(args: &[S]) -> String {
+    args.iter()
         .map(|arg| arg.as_ref().to_string_lossy())
         .collect::<Vec<_>>()
-        .join(" ");
-    bail!("command failed: {program} {rendered_args}");
+        .join(" ")
 }
 
 pub(crate) fn workspace_root() -> Result<PathBuf> {
@@ -178,6 +254,27 @@ fn manifest_declares_workspace(manifest: &Path) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // The budget arms once per process; nextest runs each test in its own, so
+    // this test owns the armed budget for the whole process.
+    #[test]
+    fn a_spent_budget_terminates_the_child_and_names_the_next_step() {
+        crate::deadline::arm_with("gate", Some(Duration::from_millis(200)));
+        let started = Instant::now();
+
+        let err = run(Path::new("."), "sleep", ["120"])
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("exceeded its 200ms budget"), "{err}");
+        assert!(err.contains("terminated `sleep 120`"), "{err}");
+        assert!(err.contains("RIMZ_XTASK_TIMEOUT="), "{err}");
+        assert!(
+            started.elapsed() < TERMINATE_GRACE,
+            "child outlived its budget by {:?}",
+            started.elapsed()
+        );
+    }
 
     #[test]
     fn streamed_capture_preserves_lines_with_lossy_utf8() {


### PR DESCRIPTION
`cargo xtask` had no timeout anywhere. Tasks spawned `cargo` and waited forever, and nextest never terminated a hung test, so a wedged run could sit for 40 minutes until someone noticed. Continuous integration jobs carry `timeout-minutes`, so this was a local-run gap — exactly where agents run the gate before a hand-off.

## The run

`xtask/src/deadline.rs` arms a wall-clock budget once at startup:

- 15 minutes for `gate` and the fast tasks.
- 45 minutes for the tasks that pay a whole build plus every test tier: `ci`, `checks`, `lint`, `test`, `test-archive`, `coverage`, `perf`, and the release builds.
- No bound for `sandbox` and `screenshot`, whose wall clock belongs to the operator driving the terminal.

On overrun the running child gets `SIGTERM`, five seconds to reap its own compiles and test processes, then `SIGKILL`; the task fails naming the command, the elapsed time, and the next step. `RIMZ_XTASK_TIMEOUT` sets the budget for one run and takes `45m`, `900s`, a bare `900` for seconds, or `off`.

Enforcement lives in the one seam every gate already goes through: both `runner.rs` spawn paths poll the child against the budget, and the streamed path moves stderr onto its own thread so a waiting gate keeps feeding the spinner while it watches the clock. The unused-dependency check joins that seam too, so it is bounded like every other gate.

## One test

`slow-timeout = { period = "120s", terminate-after = 3 }` in `.config/nextest.toml` terminates a test at six minutes and names it in the run summary. The suite's slowest legitimate waits are a live spawn poll at 150s and the workspace lock at 120s, so six minutes clears them with room. Named profiles inherit the setting from `default`.

## Measurement

A real `cargo xtask gate` on a development machine came in at 15m30s wall clock, dominated by a cold lint compile with only 14 seconds of test execution. That sits right at the 15-minute budget, so a cold tree can trip it and report the overrun instead of a result; `RIMZ_XTASK_TIMEOUT=45m` is the escape hatch. Widening `gate` is a one-constant change if the false trips outweigh the bound.