### PR TITLE
Render agent handles from the addressable peer set

### DIFF
--- a/crates/rimz/src/cli/agents_cmd/attribution.rs
+++ b/crates/rimz/src/cli/agents_cmd/attribution.rs
@@ -31,9 +31,8 @@ pub(super) fn attribution(
     let channel = super::list::list_channel_filter(all, scope.as_deref(), &ctx.workspace);
     let default_worktree =
         (!all && channel.is_none()).then_some(ctx.workspace.worktree_root.as_path());
-    let agents = peers
-        .iter()
-        .copied()
+    let agents = snapshot
+        .root_agents()
         .filter(|agent| {
             if let Some(filter) = channel.as_deref() {
                 rimz::harness::target::agent_in_worktree(agent, filter)

--- a/crates/rimz/src/cli/agents_cmd/attribution.rs
+++ b/crates/rimz/src/cli/agents_cmd/attribution.rs
@@ -27,7 +27,7 @@ pub(super) fn attribution(
         jiff::Timestamp::now(),
     )
     .with_agent_context(rimz::store::agent_context::read_all(ctx.runtime()));
-    let peers = snapshot.root_agents().collect::<Vec<_>>();
+    let peers = rimz::harness::target::addressable_agents(&snapshot);
     let channel = super::list::list_channel_filter(all, scope.as_deref(), &ctx.workspace);
     let default_worktree =
         (!all && channel.is_none()).then_some(ctx.workspace.worktree_root.as_path());

--- a/crates/rimz/src/cli/agents_cmd/refresh.rs
+++ b/crates/rimz/src/cli/agents_cmd/refresh.rs
@@ -92,10 +92,8 @@ pub(super) fn refresh_targets<'a>(
     snapshot: &'a rimz::SidebarSnapshot,
     channel: Option<&str>,
 ) -> Vec<&'a AgentState> {
-    snapshot
-        .agents
-        .iter()
-        .filter(|agent| agent.parent_agent_id.is_none())
+    rimz::harness::target::addressable_agents(snapshot)
+        .into_iter()
         .filter(|agent| !agent.agent_id.is_empty())
         .filter(|agent| rimz::agents::find_definition(agent.kind.as_str()).is_some())
         .filter(|agent| {

--- a/crates/rimz/src/cli/agents_cmd/refresh.rs
+++ b/crates/rimz/src/cli/agents_cmd/refresh.rs
@@ -45,7 +45,7 @@ pub(super) fn run_refresh(args: RefreshArgs, globals: &GlobalFlags) -> Result<()
         return Ok(());
     }
 
-    let peers: Vec<&AgentState> = snapshot.root_agents().collect();
+    let peers = rimz::harness::target::addressable_agents(&snapshot);
     let mut failed = false;
     let mut out = render::out();
     for agent in targets {

--- a/crates/rimz/src/cli/agents_cmd/report.rs
+++ b/crates/rimz/src/cli/agents_cmd/report.rs
@@ -185,8 +185,8 @@ impl SelfIdentity {
         }
 
         let kind = self.kind.as_ref()?;
-        let mut matches = snapshot
-            .root_agents()
+        let mut matches = rimz::harness::target::addressable_agents(snapshot)
+            .into_iter()
             .filter(|agent| agent.ended_at.is_none())
             .filter(|agent| {
                 launch_identity_matches(
@@ -791,7 +791,7 @@ mod tests {
             vec![state.clone()],
             now,
         );
-        let agents = snapshot.root_agents().collect::<Vec<_>>();
+        let agents = rimz::harness::target::addressable_agents(&snapshot);
         let list = build_list_report(&snapshot, &agents, now, Some(&runtime));
         assert_eq!(list.agents[0].budget.cap.as_deref(), Some("$6.00/day"));
         assert_eq!(list.agents[0].budget.spent_usd, Some(5.25));

--- a/crates/rimz/src/cli/agents_cmd/restart.rs
+++ b/crates/rimz/src/cli/agents_cmd/restart.rs
@@ -19,7 +19,7 @@ pub(super) fn restart_agent(reference: String, globals: &GlobalFlags) -> Result<
     let ctx = Ctx::open(globals)?;
     let snapshot = ctx.alive_snapshot()?;
     let agent = crate::cli::resolve_agent_one(&snapshot, &reference, None, ctx.channel())?.clone();
-    let peers = snapshot.root_agents().collect::<Vec<_>>();
+    let peers = rimz::harness::target::addressable_agents(&snapshot);
     let message = restart_resolved(&ctx, &agent, &peers)?;
     writeln!(crate::cli::render::out(), "{message}")?;
     Ok(())

--- a/crates/rimz/src/cli/agents_cmd/show.rs
+++ b/crates/rimz/src/cli/agents_cmd/show.rs
@@ -93,7 +93,7 @@ fn collect_show_report(
         None => None,
     }
     .filter(|view| !view.entries.is_empty());
-    let peers: Vec<&AgentState> = snapshot.root_agents().collect();
+    let peers = rimz::harness::target::addressable_agents(snapshot);
     let me = SelfIdentity::from_env().resolve(snapshot);
     let report_agent = agent.as_ref().map(|agent| {
         let session_cost = cost.as_ref().and_then(|cost| cost.total_cost_usd);

--- a/crates/rimz/src/cli/agents_cmd/stop.rs
+++ b/crates/rimz/src/cli/agents_cmd/stop.rs
@@ -11,7 +11,7 @@ pub(super) fn stop_agent(reference: String, all: bool, globals: &GlobalFlags) ->
     if all {
         let agents =
             rimz::harness::target::resolve_many(&snapshot, &reference, None, current_channel)?;
-        let peers: Vec<&AgentState> = snapshot.root_agents().collect();
+        let peers = rimz::harness::target::addressable_agents(&snapshot);
         let mut failed = false;
         let mut out = render::out();
         for agent in agents {

--- a/crates/rimz/src/cli/agents_cmd/tests.rs
+++ b/crates/rimz/src/cli/agents_cmd/tests.rs
@@ -11,7 +11,7 @@ use rimz::forge::Forge;
 use rimz::harness::launch::{ExecAction, ExecIdentity, ExecRequest, ProviderAccountState};
 use rimz::harness::run::{PermissionMode, RunRecord, RunStatus};
 use rimz::harness::run_wake::{ExpectedRunFrame, RunWakeOutcome};
-use rimz::ids::{AgentKind, AgentSessionId, WorkspaceId};
+use rimz::ids::{AgentKind, AgentSessionId, MuxName, PaneId, WorkspaceId};
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -562,9 +562,15 @@ mod parse {
 #[test]
 fn refresh_targets_honor_channel_filter() {
     let now = Timestamp::from_second(2_000).unwrap();
+    let pane_id = PaneId::from_parts(MuxName::Zellij, "terminal_1");
     let mut auth = rimz::testkit::agent_state("claude", "auth", now);
     auth.channel = Some("auth-refresh".to_owned());
     auth.worktree_path = Some("/repo/worktrees/auth-refresh".to_owned());
+    auth.pane = Some(rimz::pane::PaneRef::from_id(pane_id.clone()));
+    let mut auth_shadow = rimz::testkit::agent_state("claude", "auth-shadow", now);
+    auth_shadow.channel = auth.channel.clone();
+    auth_shadow.worktree_path = auth.worktree_path.clone();
+    auth_shadow.pane = auth.pane.clone();
     let mut docs = rimz::testkit::agent_state("codex", "docs", now);
     docs.channel = Some("docs".to_owned());
     docs.worktree_path = Some("/repo/main".to_owned());
@@ -573,11 +579,27 @@ fn refresh_targets_honor_channel_filter() {
     child.parent_agent_id = Some(AgentSessionId::from("auth"));
     let mut unknown = rimz::testkit::agent_state("ghost", "unknown", now);
     unknown.channel = auth.channel.clone();
-    let snapshot = rimz::SidebarSnapshot::build_with_agents(
+    let mut snapshot = rimz::SidebarSnapshot::build_with_agents(
         WorkspaceId::from_project_root(Path::new("/repo/main")),
-        vec![auth, docs, child, unknown],
+        vec![auth, auth_shadow, docs, child, unknown],
         now,
     );
+    let owner = &snapshot.agents[0];
+    let owner_pane = rimz::PaneAgent {
+        kind: owner.kind.clone(),
+        kind_ordinal: owner.kind_ordinal,
+        name: owner.name.clone(),
+        name_explicit: owner.name_explicit,
+        profile: owner.profile.clone(),
+        role: owner.role.clone(),
+        channel: owner.channel.clone(),
+        agent_id: Some(owner.agent_id.clone()),
+        pane_id,
+        pane_pid: None,
+        worktree_path: owner.worktree_path.clone(),
+        worktree_branch: owner.worktree_branch.clone(),
+    };
+    snapshot.agent_panes = vec![owner_pane];
 
     let scoped: Vec<&str> = super::refresh::refresh_targets(&snapshot, Some("auth-refresh"))
         .into_iter()

--- a/crates/rimz/src/cli/answer.rs
+++ b/crates/rimz/src/cli/answer.rs
@@ -463,11 +463,7 @@ fn transcript_has_answer(paths: &rimz::StatePaths, ask_id: &AskId) -> Result<boo
 }
 
 fn root_peers(snapshot: &rimz::SidebarSnapshot) -> Vec<&rimz::agents::AgentState> {
-    snapshot
-        .agents
-        .iter()
-        .filter(|agent| agent.parent_agent_id.is_none())
-        .collect()
+    rimz::harness::target::addressable_agents(snapshot)
 }
 
 fn parse_wait(raw: &str) -> std::result::Result<Duration, String> {

--- a/crates/rimz/src/cli/answer.rs
+++ b/crates/rimz/src/cli/answer.rs
@@ -58,7 +58,7 @@ pub fn run(args: AnswerArgs, globals: &GlobalFlags) -> Result<()> {
     let ctx = Ctx::open(globals)?;
     let store = &ctx.store;
     let snapshot = ctx.cached_snapshot()?;
-    let peers = root_peers(&snapshot);
+    let peers = rimz::harness::target::addressable_agents(&snapshot);
     let agent = resolve_current_agent(&snapshot, &args.target, ctx.channel())
         .unwrap_or_else(|message| answer_exit(2, &message));
     let detail = rimz::agents::read_open_ask(store.paths(), agent)
@@ -460,10 +460,6 @@ fn transcript_has_answer(paths: &rimz::StatePaths, ask_id: &AskId) -> Result<boo
     Ok(rimz::transcript::read_all(paths)?
         .into_iter()
         .any(|entry| entry.entry == TranscriptKind::Answer && entry.id.as_ref() == Some(ask_id)))
-}
-
-fn root_peers(snapshot: &rimz::SidebarSnapshot) -> Vec<&rimz::agents::AgentState> {
-    rimz::harness::target::addressable_agents(snapshot)
 }
 
 fn parse_wait(raw: &str) -> std::result::Result<Duration, String> {

--- a/crates/rimz/src/cli/asks.rs
+++ b/crates/rimz/src/cli/asks.rs
@@ -129,7 +129,7 @@ fn list(all: bool, json: bool, globals: &GlobalFlags) -> Result<()> {
     let store = &ctx.store;
     let snapshot = ctx.cached_snapshot()?;
     let channel = ctx.channel();
-    let peers = root_peers(&snapshot);
+    let peers = rimz::harness::target::addressable_agents(&snapshot);
     let mut views = snapshot
         .agents
         .iter()
@@ -169,7 +169,7 @@ fn show(target: &str, json: bool, globals: &GlobalFlags) -> Result<()> {
     let ctx = Ctx::open(globals)?;
     let store = &ctx.store;
     let snapshot = ctx.cached_snapshot()?;
-    let peers = root_peers(&snapshot);
+    let peers = rimz::harness::target::addressable_agents(&snapshot);
     let agent = if target.starts_with("ask_") {
         let ask_id = AskId::parse(target)?;
         snapshot
@@ -267,10 +267,6 @@ fn view_for_agent(
         },
         detail,
     })
-}
-
-fn root_peers(snapshot: &rimz::SidebarSnapshot) -> Vec<&AgentState> {
-    rimz::harness::target::addressable_agents(snapshot)
 }
 
 fn first_line(view: &OpenAskView) -> &str {

--- a/crates/rimz/src/cli/asks.rs
+++ b/crates/rimz/src/cli/asks.rs
@@ -270,11 +270,7 @@ fn view_for_agent(
 }
 
 fn root_peers(snapshot: &rimz::SidebarSnapshot) -> Vec<&AgentState> {
-    snapshot
-        .agents
-        .iter()
-        .filter(|agent| agent.parent_agent_id.is_none())
-        .collect()
+    rimz::harness::target::addressable_agents(snapshot)
 }
 
 fn first_line(view: &OpenAskView) -> &str {

--- a/crates/rimz/src/cli/channel.rs
+++ b/crates/rimz/src/cli/channel.rs
@@ -104,13 +104,7 @@ fn list_channels(
     let snapshot = store.snapshot_cached().ok();
     let agents: Vec<&AgentState> = snapshot
         .as_ref()
-        .map(|snapshot| {
-            snapshot
-                .agents
-                .iter()
-                .filter(|agent| agent.parent_agent_id.is_none())
-                .collect()
-        })
+        .map(rimz::harness::target::addressable_agents)
         .unwrap_or_default();
     let mut live_by_channel: BTreeMap<String, LiveChannelAgents<'_>> = BTreeMap::new();
     for agent in agents {

--- a/crates/rimz/src/cli/doctor/messages.rs
+++ b/crates/rimz/src/cli/doctor/messages.rs
@@ -41,7 +41,7 @@ pub(super) fn collect_messages(
     let snapshot = store.snapshot_cached().ok();
     let agents = snapshot
         .as_ref()
-        .map(|snapshot| snapshot.root_agents().collect::<Vec<_>>())
+        .map(rimz::harness::target::addressable_agents)
         .unwrap_or_default();
     for message in &live {
         match message.status {

--- a/crates/rimz/src/cli/loop_cmd/add.rs
+++ b/crates/rimz/src/cli/loop_cmd/add.rs
@@ -450,11 +450,7 @@ fn resolve_delivery_target(
             "`{address}` has not registered a real session yet; run /schedule from inside the agent pane"
         );
     }
-    let peers: Vec<_> = snapshot
-        .agents
-        .iter()
-        .filter(|peer| peer.parent_agent_id.is_none())
-        .collect();
+    let peers = rimz::harness::target::addressable_agents(&snapshot);
     Ok(TaskTarget {
         kind: agent.kind.as_str().to_owned(),
         session: agent.agent_id.as_str().to_owned(),

--- a/crates/rimz/src/cli/message/dispatch.rs
+++ b/crates/rimz/src/cli/message/dispatch.rs
@@ -346,8 +346,8 @@ pub(super) fn message_miss(
 ) -> Result<()> {
     let mut out = render::err();
     writeln!(out, "{err:#}")?;
-    let agents = snapshot
-        .root_agents()
+    let agents = rimz::harness::target::addressable_agents(snapshot)
+        .into_iter()
         .filter(|agent| {
             channel.is_none_or(|filter| rimz::harness::target::agent_in_worktree(agent, filter))
         })

--- a/crates/rimz/src/cli/message/edit.rs
+++ b/crates/rimz/src/cli/message/edit.rs
@@ -205,7 +205,7 @@ pub(super) fn message_target_for_record(
     snapshot: &SidebarSnapshot,
 ) -> String {
     let row = MessageListRow::from_record(record.clone());
-    let agents: Vec<&AgentState> = snapshot.root_agents().collect();
+    let agents = rimz::harness::target::addressable_agents(snapshot);
     scoped_handle(message_target(&row, &agents), row.channel.as_deref())
 }
 

--- a/crates/rimz/src/cli/message/list.rs
+++ b/crates/rimz/src/cli/message/list.rs
@@ -204,7 +204,7 @@ pub(super) fn list_messages(
     if json {
         render::json_pretty(&messages)?;
     } else {
-        let agents: Vec<&AgentState> = snapshot.root_agents().collect();
+        let agents = rimz::harness::target::addressable_agents(&snapshot);
         let mut out = render::out();
         render_message_digest(&mut out, messages, &agents, &lane_scope, hidden, status)?;
     }
@@ -545,7 +545,7 @@ mod tests {
             DeliveryGate::Done,
         );
         let message = MessageListRow::from_record(message);
-        let agents: Vec<&AgentState> = snapshot.root_agents().collect();
+        let agents = rimz::harness::target::addressable_agents(&snapshot);
         assert_eq!(message_target(&message, &agents), "@coder#project");
     }
 

--- a/crates/rimz/src/cli/message/show.rs
+++ b/crates/rimz/src/cli/message/show.rs
@@ -45,7 +45,7 @@ pub(super) fn show_message(message_id: MessageId, json: bool, globals: &GlobalFl
         });
     }
 
-    let agents: Vec<&AgentState> = cached_snapshot.root_agents().collect();
+    let agents = rimz::harness::target::addressable_agents(&cached_snapshot);
     let raw_target = message_target(&message, &agents);
     let target = scoped_handle(raw_target.clone(), message.channel.as_deref());
     let sender = scoped_handle(message.sender.render(), message.channel.as_deref());
@@ -106,7 +106,7 @@ fn open_delivery(
         snapshot = snapshot.with_agent_context(rimz::store::agent_context::read_all(&runtime));
     }
     let check = deliver::explain(record, live_messages, &snapshot, now);
-    let agents: Vec<&AgentState> = snapshot.root_agents().collect();
+    let agents = rimz::harness::target::addressable_agents(&snapshot);
     let target = message_target(message, &agents);
     let verdict = check.verdict();
     let audit_receiver = if verdict == deliver::DeliveryVerdict::ReceiverGone {

--- a/crates/rimz/src/cli/teams/cohort.rs
+++ b/crates/rimz/src/cli/teams/cohort.rs
@@ -69,7 +69,7 @@ fn select<'a>(
 }
 
 fn root_peers(snapshot: &rimz::SidebarSnapshot) -> Vec<&AgentState> {
-    snapshot.root_agents().collect()
+    rimz::harness::target::addressable_agents(snapshot)
 }
 
 pub(super) fn stop(team: &str, worktree: Option<&str>, globals: &GlobalFlags) -> Result<()> {

--- a/crates/rimz/src/cli/teams/cohort.rs
+++ b/crates/rimz/src/cli/teams/cohort.rs
@@ -68,15 +68,11 @@ fn select<'a>(
     bail!("team `{team}` has live cohorts in {lanes}; select one with `-w <worktree>`")
 }
 
-fn root_peers(snapshot: &rimz::SidebarSnapshot) -> Vec<&AgentState> {
-    rimz::harness::target::addressable_agents(snapshot)
-}
-
 pub(super) fn stop(team: &str, worktree: Option<&str>, globals: &GlobalFlags) -> Result<()> {
     let ctx = Ctx::open(globals)?;
     let snapshot = ctx.alive_snapshot()?;
     let cohort = select(team, worktree, ctx.channel(), &snapshot.agents)?;
-    let peers = root_peers(&snapshot);
+    let peers = rimz::harness::target::addressable_agents(&snapshot);
     let mut failed = false;
     let mut out = render::out();
     for agent in cohort.members.iter().copied() {
@@ -155,7 +151,7 @@ pub(super) fn restart(team: &str, worktree: Option<&str>, globals: &GlobalFlags)
     let ctx = Ctx::open(globals)?;
     let snapshot = ctx.alive_snapshot()?;
     let mut cohort = select(team, worktree, ctx.channel(), &snapshot.agents)?;
-    let peers = root_peers(&snapshot);
+    let peers = rimz::harness::target::addressable_agents(&snapshot);
     cohort
         .members
         .sort_by_key(|agent| agent.launch_ordinal.unwrap_or(u32::MAX));
@@ -266,7 +262,7 @@ mod tests {
             vec![team_member, ad_hoc],
             jiff::Timestamp::UNIX_EPOCH,
         );
-        let peers = root_peers(&snapshot);
+        let peers = rimz::harness::target::addressable_agents(&snapshot);
 
         assert_eq!(
             rimz::harness::target::agent_handle(peers[0], &peers, true),

--- a/crates/rimz/src/harness/AGENTS.md
+++ b/crates/rimz/src/harness/AGENTS.md
@@ -8,6 +8,7 @@ Topic detail lives in [harness.md](../../../../docs/internals/harness/harness.md
 
 - The harness owns layout specs, effective launch resolution, profile prompt-file validation, launch finalization, provider-process compilation and argv, stable handles, supervised run records, the durable blocking-wait policy and run-wake socket (`run_wake.rs`), rebirth inspection and materialization, cohort and lane qualification/resume planning, relaunch posture resolution (`resume::resolve_posture`, shared by restart, fork, and every resume path), lane restore materialization, loop scheduling, hidden runner domain, auto-continue policy, and idle-compaction policy.
 - Harness delivery rides `message`; it never reimplements queues, gates, retries, or transcript audit.
+- Handle rendering and address resolution read the addressable peer set; raw root rows are for accounting scans.
 - CLI handlers keep argument parsing, presentation, and cross-command orchestration. Harness modules own pure domain rules, durable records, helper argv shape, and side-effect boundaries.
 - Elder-fired helpers in `schedule/fire.rs`, `auto_continue.rs`, `auto_redeem.rs`, and `idle_compact.rs` spawn hidden CLI subprocesses with fresh null stdio.
 - `auto_continue.rs`, `auto_redeem.rs`, and `idle_compact.rs` are in the sidebar import graph. Keep them free of store-writer, run-wake, and broker imports; runtime-cache writes through `store::atomic::write_temp_then_rename_cache` are the allowed durability path.

--- a/crates/rimz/src/harness/auto_continue.rs
+++ b/crates/rimz/src/harness/auto_continue.rs
@@ -383,7 +383,7 @@ fn fire_if_due(agent: &AgentState, path: &Path, ctx: FireContext<'_>) {
     let Some(pane_id) = live_pane(&ctx.snapshot.agent_panes, &agent.kind, &agent.agent_id) else {
         return;
     };
-    let peers = ctx.snapshot.agents.iter().collect::<Vec<_>>();
+    let peers = crate::harness::target::addressable_agents(ctx.snapshot);
     let label = crate::harness::target::agent_handle(agent, &peers, false);
     if !spawn_auto_continue(
         ctx.runtime,

--- a/crates/rimz/src/harness/idle_compact.rs
+++ b/crates/rimz/src/harness/idle_compact.rs
@@ -81,7 +81,7 @@ pub(crate) fn compact_idle_agents(
         let (Some(command), Some(occupied)) = (command, occupied) else {
             continue;
         };
-        let peers = snapshot.root_agents().collect::<Vec<_>>();
+        let peers = crate::harness::target::addressable_agents(snapshot);
         let label = crate::harness::target::agent_handle(agent, &peers, false);
         if spawn_idle_compact(
             runtime,

--- a/crates/rimz/src/harness/target.rs
+++ b/crates/rimz/src/harness/target.rs
@@ -232,7 +232,7 @@ pub fn resolve_one<'a>(
     worktree_flag: Option<&str>,
     current_channel: Option<&str>,
 ) -> Result<&'a AgentState, TargetErr> {
-    let candidates = root_agents(snapshot);
+    let candidates = addressable_agents(snapshot);
     let matches = resolve_mentions(raw, worktree_flag, current_channel, &candidates)?;
     match matches.as_slice() {
         [one] => Ok(one),
@@ -252,7 +252,7 @@ pub fn resolve_many<'a>(
     worktree_flag: Option<&str>,
     current_channel: Option<&str>,
 ) -> Result<Vec<&'a AgentState>, TargetErr> {
-    let candidates = root_agents(snapshot);
+    let candidates = addressable_agents(snapshot);
     resolve_agents(raw, worktree_flag, current_channel, &candidates)
 }
 
@@ -366,7 +366,13 @@ pub fn bind_agent<'a>(
         .find(|binding| binding.matches_agent(agent))
 }
 
-fn root_agents(snapshot: &SidebarSnapshot) -> Vec<&AgentState> {
+/// The root agents that can be named in this snapshot.
+///
+/// One physical agent instance contributes at most one addressable row. Handle
+/// rendering uses this same set so [`agent_handle`] stays the inverse of
+/// [`parse_target`]. A pure rollup has no `agent_panes`, cannot observe
+/// shadowing, and therefore yields every root.
+pub fn addressable_agents(snapshot: &SidebarSnapshot) -> Vec<&AgentState> {
     snapshot
         .root_agents()
         .filter(|agent| !shadowed_by_pane_owner(snapshot, agent))

--- a/crates/rimz/src/harness/target/tests.rs
+++ b/crates/rimz/src/harness/target/tests.rs
@@ -193,12 +193,18 @@ fn at_all_fans_to_the_channel_only() {
 fn pane_owner_shadows_co_resident_session_from_every_address() {
     let mut snapshot = empty_snapshot();
     let mut older = agent("codex", "session-older", Some("main"), "terminal_1");
+    older.name = Some("coder-agent".to_owned());
+    older.kind_ordinal = Some(1);
     older.role = Some("coder".to_owned());
     older.origin = Some(crate::agents::SessionOrigin::Fresh);
     let mut owner = agent("codex", "session-owner", Some("main"), "terminal_1");
+    owner.name = Some("coder-agent".to_owned());
+    owner.kind_ordinal = Some(2);
     owner.role = Some("coder".to_owned());
     owner.origin = Some(crate::agents::SessionOrigin::Fresh);
     let mut hidden_fork = agent("codex", "session-fork", Some("main"), "terminal_1");
+    hidden_fork.name = Some("coder-agent".to_owned());
+    hidden_fork.kind_ordinal = Some(3);
     hidden_fork.role = Some("coder".to_owned());
     hidden_fork.origin = Some(crate::agents::SessionOrigin::Forked);
     snapshot.agents = vec![older, owner, hidden_fork];
@@ -223,6 +229,25 @@ fn pane_owner_shadows_co_resident_session_from_every_address() {
             .unwrap()
             .len(),
         1
+    );
+
+    let unfiltered = snapshot.root_agents().collect::<Vec<_>>();
+    assert_eq!(
+        agent_handle(&snapshot.agents[1], &unfiltered, false),
+        "@codex-2"
+    );
+    let peers = addressable_agents(&snapshot);
+    assert_eq!(agent_handle(peers[0], &peers, false), "@coder");
+    let sender = MessageSender::Agent {
+        kind: AgentKind::new_unchecked("codex"),
+        name: Some("coder-agent".to_owned()),
+        profile: None,
+        role: Some("coder".to_owned()),
+        channel: Some("main".to_owned()),
+    };
+    assert_eq!(
+        sender_prefix(&sender, &peers, Some("main")).as_deref(),
+        Some("from @coder: ")
     );
 }
 

--- a/crates/rimz/src/message/dispatch.rs
+++ b/crates/rimz/src/message/dispatch.rs
@@ -358,7 +358,7 @@ struct ResolvedTarget {
 impl ResolvedTarget {
     fn label(&self, snapshot: &SidebarSnapshot) -> String {
         if let Some(agent) = self.agent.as_ref() {
-            let peers = snapshot.root_agents().collect::<Vec<_>>();
+            let peers = crate::harness::target::addressable_agents(snapshot);
             crate::harness::target::agent_handle(agent, &peers, true)
         } else if let Some(pane) = self.pane.as_ref() {
             format!("@{}", pane.label())

--- a/crates/rimz/src/message/send.rs
+++ b/crates/rimz/src/message/send.rs
@@ -183,7 +183,7 @@ pub(crate) fn send_batch_to_live_pane(
         ) {
             Ok(PaneWrite::Sent) => {
                 compacted = true;
-                let peers = snapshot.root_agents().collect::<Vec<_>>();
+                let peers = crate::harness::target::addressable_agents(snapshot);
                 crate::harness::assist_log::append(&crate::harness::assist_log::AssistRecord {
                     at: jiff::Timestamp::now(),
                     assist: crate::harness::assist_log::Assist::AutoCompact {
@@ -282,7 +282,7 @@ fn write_batch(
                     .iter()
                     .all(|message| message.body == MessageBody::Prompt)
             );
-            let peers: Vec<&AgentState> = snapshot.root_agents().collect();
+            let peers = crate::harness::target::addressable_agents(snapshot);
             let payload = batch
                 .iter()
                 .map(|message| {

--- a/crates/rimz/tests/integration/message.rs
+++ b/crates/rimz/tests/integration/message.rs
@@ -1482,6 +1482,51 @@ fn steer_agent_env_prefixes_sender_and_no_from_suppresses_it() {
 }
 
 #[test]
+fn steer_sender_prefix_ignores_shadowed_co_resident_session() {
+    let env = Env::new();
+    register_role_agent(
+        &env,
+        "claude",
+        "sess-prefix-target",
+        "reviewer",
+        true,
+        Some(TRACE_PANE),
+    );
+    register_role_agent(
+        &env,
+        "codex",
+        "sess-prefix-owner",
+        "coder",
+        true,
+        Some("terminal_4"),
+    );
+    register_role_agent(
+        &env,
+        "codex",
+        "sess-prefix-shadow",
+        "coder",
+        true,
+        Some("terminal_4"),
+    );
+    let target_pane = agent_pane(&env, "claude");
+    let mut sender_pane = agent_pane(&env, "codex");
+    sender_pane.pane_id = PaneId::from_parts(MuxName::Zellij, "terminal_4");
+    let pane_fixture = env.write_pane_fixture(&[target_pane, sender_pane]);
+
+    let trace_log = env.project_root.join("zellij-shadowed-sender-trace.log");
+    run_success(
+        traced_rimz(&env, "zellij-shadowed-sender-trace.log")
+            .env("RIMZ_TEST_PANE_LIST", pane_fixture)
+            .env("RIMZ_AGENT_KIND", "codex")
+            .env("RIMZ_AGENT_NAME", "coder-agent")
+            .env("RIMZ_AGENT_ROLE", "coder")
+            .args(["message", "--steer", "@reviewer", "--", "re-review"]),
+        "steer from reborn agent",
+    );
+    assert_text_then_enter(&trace_log, "from @coder: re-review");
+}
+
+#[test]
 fn boundary_dispatch_sends_when_idle_then_parks_and_delivers_when_running() {
     let env = Env::new();
     env.install_agent_hooks("claude");

--- a/docs/internals/harness/messaging.md
+++ b/docs/internals/harness/messaging.md
@@ -250,7 +250,7 @@ What the send path spaces is *messages*, not the paste and its submit: it sleeps
 
 A send from a RimZ-launched agent arrives prefixed `from @sender: `, gaining `#channel` when it crosses lanes. The recipient's lane comes from its registered channel, its live pane channel, or the addressed channel, so a just-launched same-lane teammate does not gain a spurious suffix before pane capture lands.
 
-The handle is the shortest unique selector: role when unique in scope, then explicit launch name, then profile when unique, else kind, else kind ordinal, else pet name. `--no-from` delivers verbatim.
+The handle is the shortest unique selector over addressable agents: role when unique in scope, then explicit launch name, then profile when unique, else kind, else kind ordinal, else pet name. A session rebirth's co-resident audit row is not addressable, so it never pushes the live pane owner's handle down this ladder. `--no-from` delivers verbatim.
 
 The receiver's turn-start hook parses the prefix once and writes a first-class `Message` transcript entry with structured `from`. The queue record supplies the confirmed message id and parentage stamped onto that entry, while the parsed hook text stays the transcript content.
 


### PR DESCRIPTION
## Context

An agent-to-agent hand-off in the `loops-enable` lane pasted into the receiving pane as `from @codex-2: …` instead of `from @coder: …`. The team protocol keys off that prefix, so a handle no teammate recognizes breaks the reply path.

The cause is a session rebirth: a Codex lifecycle hook reported a new session id carrying the same pane, PID, process start, and agent name as the running session — a new rollout on the same process. The fold keys rows on `(kind, agent_id)`, so the lane held two live root rows for one pane, both `role = coder`. This is not lane-specific; the published snapshot regularly carries several co-resident rows on one pane.

Address *resolution* already treated a co-resident row as non-addressable: `harness/target.rs` filtered its candidate set through `shadowed_by_pane_owner`, whose contract is that one physical instance contributes at most one recipient. Handle *rendering* skipped that filter and built its peer set straight from `snapshot.root_agents()`. With both rows in scope, the handle ladder found every short candidate ambiguous — role, name, profile, and kind each matched two rows — and fell through to the kind ordinal. `agent_handle` documents itself as the inverse of `parse_target`, and rendering against a peer set containing rows the resolver refuses to address is what broke that inverse. Every handle-rendering site built its peer set the same raw way, so they all carried the defect.

## Design choices

**Fix rendering, not the fold.** Co-resident rows are deliberate: shadowing keeps them as audit records while making them unaddressable. Retiring them in the projection would risk the spend attribution they carry, so the rebirth bookkeeping is untouched.

**One helper, one rule.** The private filter in `harness/target.rs` is promoted to `pub fn addressable_agents(snapshot) -> Vec<&AgentState>`, and every peer set that feeds `agent_handle`, `sender_prefix`, or address resolution routes through it. Rendering and resolution now share one definition of who is addressable.

**Accounting keeps the raw accessor.** A shadowed row still holds real tokens and dollars, so budget, stats, attribution, and roster scans continue to read `snapshot.root_agents()` unfiltered. In `rimz agents attribution` the two sets stay explicitly separate: the accounting input is the raw root set, the rendering input is the addressable set.

**No second, pane-free shadow rule.** The filter is knowingly inert on a pure rollup — `agent_panes` is frame-derived and empty there, so `snapshot_cached()` surfaces cannot detect shadowing and behave exactly as before. The delivery path is unaffected because it builds a resolution snapshot carrying the live pane list. Inventing a fallback such as "newest registered row wins" was rejected: here the live pane owner is the *older* row, so a second rule would disagree with the resolver and split the truth.

## Implementation

`harness/target.rs` — the private `root_agents` accessor becomes `addressable_agents`, keeping its body and gaining a doc comment stating the three properties callers depend on: one physical instance contributes at most one addressable row; handle rendering uses this same set so `agent_handle` stays the inverse of `parse_target`; a snapshot with no `agent_panes` cannot observe shadowing and yields every root.

The load-bearing sites route through it: the sender prefix in `message/send.rs` (the reported bug), the auto-compaction assist label, `ResolvedTarget::label`, and the idle-compaction and auto-continue labels. The CLI handle surfaces follow: `rimz message` list/show/edit/dispatch, `rimz agents` show/stop/restart/refresh/attribution and self-identity, `rimz teams` cohort actions, `rimz channel`, `rimz pane`, `rimz asks`, `rimz answer`, `rimz loop add`, and `rimz doctor`. Several of these hand-rolled `parent_agent_id.is_none()` filters, which the helper now expresses once.

Deviations from the plan, both extensions of its governing rule rather than departures from it: the plan's site list missed the raw peer constructions in `harness/auto_continue.rs`, `cli/asks.rs`, `cli/answer.rs`, `cli/loop_cmd/add.rs`, and the pane overlay, so those were converted too. In `auto_continue.rs` the old peer set was every agent including children; narrowing it to addressable roots matches the resolver and cannot degrade a label, because the firing path already requires the agent to own a live pane. `rimz agents refresh` needed its *target* list filtered as well, not just its peers — a shadowed row that is a target but not a peer renders through the absent-agent path and collapses onto the pane owner's exact handle, so the command printed the same handle twice; filtering the targets also stops refreshing context for a session that no longer owns its pane.

Tests: a unit regression asserts that the raw peer set degrades the pane owner to `@codex-2` while the addressable set renders `@coder` and the sender prefix reads `from @coder: `, so it pins the mechanism and not just the symptom. An integration test drives `rimz message --steer` through the real binary against a two-pane fixture with a co-resident Codex shadow and asserts the pasted text carries `from @coder: `; it passes only because the producer genuinely binds the pane to one row and shadows the other. The `refresh_targets` channel-filter test gained a pane owner plus its twin and asserts only the owner is targeted. Docs: the handle-ladder paragraph in the messaging internals gains the scope rule, and the harness contract gains one boundary bullet — prose only, no new invariant grep.

## Advisories

- `harness/idle_compact.rs` — `teammate_working` still scans raw root agents, so a co-resident twin of the candidate itself reads as a second running teammate in the lane and suppresses that agent's idle compaction. Same defect family, outside this change's rendering scope; a follow-up.
- The fix only bites where a pane frame exists. A resolution snapshot falls back to the rollup when there is no mux to enumerate, and every cached-snapshot surface has an empty `agent_panes`, so those renders still degrade to `@codex-<ordinal>`. This is the accepted consequence of refusing a pane-free shadow rule, and the helper's doc comment states it.
- `cli/complete.rs` still builds a raw peer set for `agent_handle`. Inert today and cosmetically identical, but it is the last handle-rendering peer set outside the helper.