### PR TITLE
Add `rimz sidebar frame`: render the live sidebar snapshot to text without the mux

### DIFF
--- a/crates/rimz/src/cli/sidebar.rs
+++ b/crates/rimz/src/cli/sidebar.rs
@@ -803,7 +803,7 @@ fn rollup_snapshot_fallback(
     reason: Option<&dyn std::fmt::Display>,
 ) -> Result<SidebarSnapshot> {
     if let Some(error) = reason {
-        tracing::warn!(%error, "sidebar snapshot pane discovery failed; emitting frameless rollup metadata");
+        tracing::warn!(%error, "pane discovery failed; falling back to the frameless rollup");
     }
     produce_rollup_snapshot_with_refresh(
         &mut RollupCursor::new(),

--- a/crates/rimz/src/cli/sidebar.rs
+++ b/crates/rimz/src/cli/sidebar.rs
@@ -1,11 +1,12 @@
 //! `rimz sidebar` — inspect, serve, and structurally repair the sidebar fleet.
 //!
-//! The snapshot arm is a thin delegate over the library produce pipeline
-//! ([`rimz::sidebar::produce`]): it resolves workspace/session/mux, calls
+//! Snapshot inspection and one-shot frame rendering are thin delegates over the
+//! library data plane. Snapshot resolves workspace/session/mux and calls
 //! `produce_snapshot_with_refresh` (or the in-process consumer read for
-//! `--no-produce`), and emits — the CLI owns argv, fallback intent, and stdout
-//! alone. The elder renderer produces in process on its fetch worker, so this
-//! arm serves inspection and scripting.
+//! `--no-produce`); frame prefers an already-published consumer frame and falls
+//! back to the same producer path. The CLI owns argv, fallback intent, and
+//! stdout alone. The elder renderer produces in process on its fetch worker, so
+//! these arms serve inspection and scripting.
 
 use std::io::{self, Read, Write};
 use std::path::PathBuf;
@@ -16,7 +17,7 @@ use clap::{ArgAction, Args, Subcommand, ValueEnum};
 use super::{GlobalFlags, current_channel, open_store};
 use crate::cli::render;
 use rimz::ids::{AgentKind, AgentSessionId, MuxName, PaneId, WorkspaceId};
-use rimz::sidebar::consumer::{PublishedSnapshotReader, RollupCursor};
+use rimz::sidebar::consumer::{PublishedSnapshotReader, RollupCursor, published_frame_exists};
 use rimz::sidebar::events::SidebarEvent;
 use rimz::sidebar::notify::{Notification, NotificationAgent, NotificationKind};
 use rimz::sidebar::presence::{
@@ -62,6 +63,26 @@ enum SidebarSubcmd {
         /// pays the mux/git round-trip exactly once, on the elder.
         #[arg(long)]
         no_produce: bool,
+    },
+    /// Render the live sidebar snapshot once without capturing a mux pane.
+    Frame {
+        #[arg(long)]
+        workspace_id: Option<String>,
+        #[arg(long)]
+        mux: Option<MuxName>,
+        #[arg(long)]
+        session_name: Option<String>,
+        #[arg(long, value_parser = clap::value_parser!(u16).range(1..))]
+        width: Option<u16>,
+        #[arg(
+            long,
+            conflicts_with = "expand",
+            value_parser = clap::value_parser!(u16).range(1..)
+        )]
+        height: Option<u16>,
+        /// Every card expanded, every group un-truncated; the frame grows to fit.
+        #[arg(long)]
+        expand: bool,
     },
     /// Run the terminal sidebar renderer.
     Serve {
@@ -345,6 +366,7 @@ impl SidebarArgs {
     pub(crate) fn command_label(&self) -> &'static str {
         match &self.command {
             SidebarSubcmd::Snapshot { .. } => "sidebar snapshot",
+            SidebarSubcmd::Frame { .. } => "sidebar frame",
             SidebarSubcmd::Serve { .. } => "sidebar serve",
             SidebarSubcmd::Repair => "sidebar repair",
             SidebarSubcmd::Render { .. } => "sidebar render",
@@ -381,6 +403,24 @@ pub fn run(args: SidebarArgs, globals: &GlobalFlags) -> Result<()> {
                 min_pane_cache_ms,
                 json,
                 no_produce,
+            },
+        ),
+        SidebarSubcmd::Frame {
+            workspace_id,
+            mux,
+            session_name,
+            width,
+            height,
+            expand,
+        } => frame(
+            globals,
+            FrameCommand {
+                workspace_id,
+                mux,
+                session_name,
+                width,
+                height,
+                expand,
             },
         ),
         SidebarSubcmd::Serve {
@@ -598,6 +638,15 @@ struct SnapshotCommand {
     no_produce: bool,
 }
 
+struct FrameCommand {
+    workspace_id: Option<String>,
+    mux: Option<MuxName>,
+    session_name: Option<String>,
+    width: Option<u16>,
+    height: Option<u16>,
+    expand: bool,
+}
+
 struct SnapshotContext {
     state: StatePaths,
     runtime: RuntimePaths,
@@ -611,7 +660,55 @@ fn snapshot(globals: &GlobalFlags, command: SnapshotCommand) -> Result<()> {
     if try_emit_consumer_snapshot(&context, !command.no_produce, command.json)? {
         return Ok(());
     }
-    emit_producer_snapshot(&context, command.mux, globals, command.json)
+    let snapshot = producer_snapshot(&context, command.mux, globals)?;
+    emit_snapshot(&snapshot, command.json)
+}
+
+fn frame(globals: &GlobalFlags, command: FrameCommand) -> Result<()> {
+    let context = resolve_snapshot_context(
+        globals,
+        &SnapshotCommand {
+            workspace_id: command.workspace_id,
+            mux: command.mux,
+            session_name: command.session_name,
+            exclude_pane_id: None,
+            min_pane_cache_ms: None,
+            json: false,
+            no_produce: false,
+        },
+    )?;
+    let snapshot = if !pane_fixture_active()
+        && let Some(session) = context.session_name.as_deref()
+        && published_frame_exists(&context.runtime, session)
+    {
+        PublishedSnapshotReader::new(context.runtime.clone(), session, None)
+            .read(&context.state)
+            .context("reading the consumer snapshot")?
+    } else {
+        producer_snapshot(&context, command.mux, globals)?
+    };
+
+    let sidebar_width = rimz::mux::SidebarWidth::from_config(&snapshot.theme);
+    let terminal_size = rimz::mux::detect_terminal_size();
+    let width = command.width.unwrap_or_else(|| {
+        terminal_size.map_or_else(
+            || sidebar_width.max_cols.get(),
+            |(cols, _)| {
+                u16::try_from(sidebar_width.target_cols(u64::from(cols))).unwrap_or(u16::MAX)
+            },
+        )
+    });
+    let height = command
+        .height
+        .unwrap_or_else(|| terminal_size.map_or(24, |(_, rows)| rows));
+
+    let mut out = render::out();
+    let write = if command.expand {
+        rimz::sidebar_pane::render::render_expanded_line_ansi(&mut out, &snapshot, width)
+    } else {
+        rimz::sidebar_pane::render::render_fixed_line_ansi(&mut out, &snapshot, None, width, height)
+    };
+    render::finish(write.and_then(|()| out.flush()))
 }
 
 fn resolve_snapshot_context(
@@ -672,17 +769,16 @@ fn try_emit_consumer_snapshot(
     Ok(true)
 }
 
-fn emit_producer_snapshot(
+fn producer_snapshot(
     context: &SnapshotContext,
     mux: Option<MuxName>,
     globals: &GlobalFlags,
-    json: bool,
-) -> Result<()> {
+) -> Result<SidebarSnapshot> {
     let mux = mux
         .or(globals.mux)
         .or_else(|| rimz::mux::auto_detect_backend(None).ok());
     let (Some(session_name), Some(mux)) = (context.session_name.clone(), mux) else {
-        return emit_rollup_snapshot(context, json, None);
+        return rollup_snapshot_fallback(context, None);
     };
     let opts = ProduceOptions {
         mux,
@@ -697,27 +793,26 @@ fn emit_producer_snapshot(
         &context.runtime,
         &opts,
     ) {
-        Ok(snapshot) => emit_snapshot(&snapshot, json),
-        Err(err) => emit_rollup_snapshot(context, json, Some(&err)),
+        Ok(snapshot) => Ok(snapshot),
+        Err(err) => rollup_snapshot_fallback(context, Some(&err)),
     }
 }
 
-fn emit_rollup_snapshot(
+fn rollup_snapshot_fallback(
     context: &SnapshotContext,
-    json: bool,
     reason: Option<&dyn std::fmt::Display>,
-) -> Result<()> {
+) -> Result<SidebarSnapshot> {
     if let Some(error) = reason {
         tracing::warn!(%error, "sidebar snapshot pane discovery failed; emitting frameless rollup metadata");
     }
-    let snapshot = produce_rollup_snapshot_with_refresh(
+    produce_rollup_snapshot_with_refresh(
         &mut RollupCursor::new(),
         &context.state,
         &context.runtime,
         context.exclude.as_ref(),
         context.min_pane_cache_ms,
-    )?;
-    emit_snapshot(&snapshot, json)
+    )
+    .map_err(Into::into)
 }
 
 fn emit_snapshot(snapshot: &rimz::SidebarSnapshot, json: bool) -> Result<()> {

--- a/crates/rimz/src/cli/sidebar/snapshots/rimz__cli__sidebar__tests__expanded_fixture_frame.snap
+++ b/crates/rimz/src/cli/sidebar/snapshots/rimz__cli__sidebar__tests__expanded_fixture_frame.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rimz/src/cli/sidebar/tests.rs
-assertion_line: 308
 expression: strip_sgr(&ansi)
 ---
   flightdeck                    /srv/code/flightdeck

--- a/crates/rimz/src/cli/sidebar/snapshots/rimz__cli__sidebar__tests__expanded_fixture_frame.snap
+++ b/crates/rimz/src/cli/sidebar/snapshots/rimz__cli__sidebar__tests__expanded_fixture_frame.snap
@@ -21,9 +21,9 @@ expression: strip_sgr(&ansi)
    󰕰 ━━━━━━━━━━━━━━━━╺━╺───────────────────────   24%
    󰿦 247k · 󱥸 212k  24k  9k  30k
     subagents (2)
-      Explore — audit auth watcher changes
+      Explore — audit auth watcher changes     $0.34
         22k · Haiku · xhigh
-     ⠁ Plan — run focused nextest
+     ⠁ Plan — run focused nextest               $0.12
         18k · Haiku · xhigh                    󰪞  3m
  ▁ claude · Opus 4.8 · xhigh · 1m              $28.90
    compact provider trace
@@ -69,9 +69,9 @@ expression: strip_sgr(&ansi)
    󰕰 ━━━━━━━━━━━━━━━━━━━╺━━╺───────────────────   31%
    󰿦 314k · 󱥸 270k  31k  12k  39k             󰪞 6m
     subagents (2)
-      Explore — audit auth watcher changes
+      Explore — audit auth watcher changes     $0.34
         22k · Haiku · xhigh
-     ⠁ Plan — run focused nextest
+     ⠁ Plan — run focused nextest               $0.12
         18k · Haiku · xhigh                    󰪞  3m
 
   mux-merge #91                                main

--- a/crates/rimz/src/cli/sidebar/snapshots/rimz__cli__sidebar__tests__expanded_fixture_frame.snap
+++ b/crates/rimz/src/cli/sidebar/snapshots/rimz__cli__sidebar__tests__expanded_fixture_frame.snap
@@ -1,0 +1,99 @@
+---
+source: crates/rimz/src/cli/sidebar/tests.rs
+assertion_line: 308
+expression: strip_sgr(&ansi)
+---
+  flightdeck                    /srv/code/flightdeck
+
+  78                           68M  47M  13M 󱥸 6M
+  13 (4)  2                                 $392.00
+ ────────────────────────────────────────────────────
+  2    1    2    1                      ⢿ 5    2
+
+▎ pricing-refresh  #91 ┄┄┄┄┄┄┄┄┄┄┄┄┄ ⇡1  +1180 -430🮇
+▌ codex · GPT 5.5 · xhigh · 272k               $4.82▐
+▌  approve pricing cache write                       ▐
+▌  󰕰 ━━━━━━━━━━━━━━━━━━━━━━━━╺─────────────────   58%▐
+▌  󰿦 158k · 󱥸 151k  6k  19k                   󰪠 18m▐
+
+  main                     ⇡3 ⇣1  +1840 -620   main
+ ⢄ claude · Opus 4.8 · xhigh · 1m               $8.64
+   stabilize render diff
+   󰕰 ━━━━━━━━━━━━━━━━╺━╺───────────────────────   24%
+   󰿦 247k · 󱥸 212k  24k  9k  30k
+    subagents (2)
+      Explore — audit auth watcher changes
+        22k · Haiku · xhigh
+     ⠁ Plan — run focused nextest
+        18k · Haiku · xhigh                    󰪞  3m
+ ▁ claude · Opus 4.8 · xhigh · 1m              $28.90
+   compact provider trace
+   󰕰 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╺━━━╺━────   79%
+   󰿦 797k · 󱥸 685k  79k  31k  99k ·  3       󰪟 8m
+ ⣾ cargo nextest               37%   402M     8M/s
+   integration::backend
+
+  observer-lag                 ⇡1  +980 -360   main
+  claude · Opus 4.8 · xhigh · 1m              $29.84
+   API Error: Overloaded
+   󰕰 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╺━━━╺━───   85%
+   󰿦 853k · 󱥸 734k  85k  34k  106k            ◉ 1h
+ ⠁ opencode · GPT 5.5 · xhigh · 272k            $3.07
+   trace tmux layout parity
+   󰕰 ━━━━━━━━━━━━━━━━╺─────────────────────────   38%
+   󰿦 103k · 󱥸 99k  4k  12k ·  1
+  pi · GPT 5.5 · xhigh
+ ⢄ codex · GPT 5.5 · xhigh · 272k               $3.83
+   triage stale pane sample
+   󰕰 ━━━━━━━━━━━━━━━━━━━━━━━━━━━╺━─────────────   68%
+   󰿦 185k · 󱥸 178k  7k  23k                   󰪥 54m
+    subagents (2)
+      Explore — audit auth watcher changes
+        22k · Haiku · xhigh
+     ⠁ Plan — run focused nextest
+        18k · Haiku · xhigh                    󰪞  3m
+  claude · Opus 4.8 · xhigh
+
+  zellij-health                        ⇡1  +760 -210
+  pi · GPT 5.5 · xhigh · 272k                  $5.76
+   API error
+   󰕰 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╺━──────   84%
+   󰿦 228k · 󱥸 219k  9k  28k                   󰪣 42m
+
+  theme-tune  #91         ⇡2 ⇣1  +1320 -540   main
+  opencode · GPT 5.5 · xhigh · 272k            $0.68
+   pick gallery color ramp
+   󰕰 ━━━━━━╺───────────────────────────────────   15%
+   󰿦 42k · 󱥸 40k  1k  5k                       󰪥 1h
+ ⢄ claude · Opus 4.8 · xhigh · 1m               $6.95
+   verify 256-color fallback
+   󰕰 ━━━━━━━━━━━━━━━━━━━╺━━╺───────────────────   31%
+   󰿦 314k · 󱥸 270k  31k  12k  39k             󰪞 6m
+    subagents (2)
+      Explore — audit auth watcher changes
+        22k · Haiku · xhigh
+     ⠁ Plan — run focused nextest
+        18k · Haiku · xhigh                    󰪞  3m
+
+  mux-merge #91                                main
+  claude · Opus 4.8 · xhigh · 1m              $15.38
+   API Error: Overloaded
+   󰕰 ━━━━━━━━━━━━━━━━━━━━━━━━╺━━╺━─────────────   46%
+   󰿦 469k · 󱥸 403k  46k  18k  58k             ◉ 1h
+  claude · Opus 4.8 · xhigh · 1m               $2.41
+   land tmux hook fix
+   󰕰 ━━━━━━━━━╺━╺──────────────────────────────   13%
+   󰿦 132k · 󱥸 114k  13k  5k  16k              ◉ 2h
+
+ ─── Claude ──── Codex ──── Pi ──── Open Code ───────
+
+           ChatGPT Pro · v0.135.0           󰑐 2  ⇅ rc
+  ▗▛▀▀▀▜▖   24   31M  21M  6M 󱥸 3M        $428.00
+ ▐█ ▜▖  █▌ 5h  ▰▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 󰑐  2h00m
+  ▝▀▀▀▀▀▘  7d  ▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 󰑐  4d21h
+
+  ── Total: ─────────────────────────────────────────
+  W:   269   255.1M  178.6M   51.0M 󱥸   $3,990.00
+  M:  1075     1.0B  714.2M  204.1M 󱥸  $15,960.00
+
+                                           ? for help

--- a/crates/rimz/src/cli/sidebar/tests.rs
+++ b/crates/rimz/src/cli/sidebar/tests.rs
@@ -250,12 +250,27 @@ fn strip_sgr(ansi: &[u8]) -> String {
     let mut stripped = String::new();
     let mut chars = text.chars().peekable();
     while let Some(ch) = chars.next() {
-        if ch == '\x1b' && chars.peek() == Some(&'[') {
-            chars.next();
-            for ch in chars.by_ref() {
-                if ch == 'm' {
-                    break;
+        if ch == '\x1b' {
+            match chars.peek() {
+                Some('[') => {
+                    chars.next();
+                    for ch in chars.by_ref() {
+                        if ch == 'm' {
+                            break;
+                        }
+                    }
                 }
+                Some(']') => {
+                    chars.next();
+                    let mut escaped = false;
+                    for ch in chars.by_ref() {
+                        if ch == '\x07' || (escaped && ch == '\\') {
+                            break;
+                        }
+                        escaped = ch == '\x1b';
+                    }
+                }
+                _ => stripped.push(ch),
             }
         } else {
             stripped.push(ch);
@@ -282,6 +297,15 @@ fn strip_sgr(ansi: &[u8]) -> String {
 #[test]
 fn provider_fixture_frame_is_deterministic() {
     assert_fixture_frame_snapshot(SidebarFixtureState::Provider, "provider_fixture_frame");
+}
+
+#[test]
+fn expanded_fixture_frame_is_deterministic() {
+    let snapshot = sidebar_fixture_snapshot(SidebarFixtureState::Cockpit).unwrap();
+    let mut ansi = Vec::new();
+    rimz::sidebar_pane::render::render_expanded_line_ansi(&mut ansi, &snapshot, 54).unwrap();
+
+    insta::assert_snapshot!("expanded_fixture_frame", strip_sgr(&ansi));
 }
 
 #[test]

--- a/crates/rimz/src/cli/snapshots/rimz__cli__surface_tests__cli_surface.snap
+++ b/crates/rimz/src/cli/snapshots/rimz__cli__surface_tests__cli_surface.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rimz/src/cli/surface_tests.rs
+assertion_line: 172
 expression: rendered
 ---
 rimz
@@ -942,6 +943,8 @@ rimz help sidebar fixture [hidden]
 
 rimz help sidebar focus [hidden]
 
+rimz help sidebar frame
+
 rimz help sidebar gallery [hidden]
 
 rimz help sidebar gallery-render [hidden]
@@ -1828,6 +1831,19 @@ rimz sidebar focus [hidden]
     --toggle  [action=set-true takes=0..=0]
     --zellij  [action=set-true takes=0..=0 global]
 
+rimz sidebar frame
+    --color <COLOR>  [action=set takes=1..=1 global default=auto values=auto|always|never]
+    --expand  [action=set-true takes=0..=0]
+    --height <HEIGHT>  [action=set takes=1..=1]
+    -h, --help  [action=help takes=0..=0]
+    --mux <MUX>  [action=set takes=1..=1]
+    --root <ROOT>  [action=set takes=1..=1 global]
+    --session-name <SESSION_NAME>  [action=set takes=1..=1]
+    --tmux  [action=set-true takes=0..=0 global]
+    --width <WIDTH>  [action=set takes=1..=1]
+    --workspace-id <WORKSPACE_ID>  [action=set takes=1..=1]
+    --zellij  [action=set-true takes=0..=0 global]
+
 rimz sidebar gallery [hidden]
     --color <COLOR>  [action=set takes=1..=1 global default=auto values=auto|always|never]
     -h, --help  [action=help takes=0..=0]
@@ -1851,6 +1867,8 @@ rimz sidebar help
 rimz sidebar help fixture [hidden]
 
 rimz sidebar help focus [hidden]
+
+rimz sidebar help frame
 
 rimz sidebar help gallery [hidden]
 

--- a/crates/rimz/src/cli/snapshots/rimz__cli__surface_tests__cli_surface.snap
+++ b/crates/rimz/src/cli/snapshots/rimz__cli__surface_tests__cli_surface.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rimz/src/cli/surface_tests.rs
-assertion_line: 172
 expression: rendered
 ---
 rimz

--- a/crates/rimz/src/sidebar/consumer.rs
+++ b/crates/rimz/src/sidebar/consumer.rs
@@ -189,6 +189,14 @@ pub fn read_published_snapshot(
     Ok(project_local(workspace, frame.as_deref(), exclude))
 }
 
+/// Whether the producer has published a pane frame for `session`.
+///
+/// The one-shot frame command uses this gate to prefer the passive consumer
+/// path without mistaking a valid frameless rollup for a published frame.
+pub fn published_frame_exists(runtime: &RuntimePaths, session: &str) -> bool {
+    read_snapshot_cache(&runtime.pane_frame_path(), session).is_some()
+}
+
 fn read_published_workspace_snapshot(
     cursor: &mut RollupCursor,
     state: &StatePaths,

--- a/crates/rimz/src/sidebar_pane/render/compose.rs
+++ b/crates/rimz/src/sidebar_pane/render/compose.rs
@@ -134,6 +134,7 @@ pub(crate) fn compose_lines_with_meter(
 
     let mut frame = top.window(0, layout.top_shown);
     frame.append(scroll_block);
+    let content_height = frame.lines.len().saturating_add(bottom_height);
     let pad = height.saturating_sub(frame.lines.len() + bottom_height);
     for _ in 0..pad {
         frame.push_inert(Line::from(""));
@@ -148,6 +149,7 @@ pub(crate) fn compose_lines_with_meter(
         scroll_offset: layout.offset,
         top_height: layout.top_shown,
         bottom_height,
+        content_height,
     }
 }
 
@@ -474,6 +476,8 @@ pub(crate) struct ComposedFrame {
     pub(crate) scroll_offset: usize,
     pub(crate) top_height: usize,
     pub(crate) bottom_height: usize,
+    /// Rows occupied by composed content before viewport padding.
+    pub(crate) content_height: usize,
 }
 
 fn resolve_scroll_offset(

--- a/crates/rimz/src/sidebar_pane/render/mod.rs
+++ b/crates/rimz/src/sidebar_pane/render/mod.rs
@@ -53,7 +53,7 @@ use std::num::NonZeroU16;
 
 use crate::agents::AgentStatus;
 use crate::agents::TurnPhase;
-use crate::config::{AnimationRole, GlyphRole};
+use crate::config::{AnimationRole, CardDensityMode, GlyphRole};
 use crate::sidebar_pane::pets::PetAction;
 use crate::sidebar_pane::view::VisibleRoster;
 use crate::{ProcessState, SidebarRow, SidebarSnapshot};
@@ -521,6 +521,43 @@ pub fn render_fixed_line_ansi<W: Write>(
     let mut terminal = infallible(Terminal::new(backend));
     infallible(terminal.clear());
     infallible(draw_to_terminal(&mut terminal, snapshot, alert));
+    write_buffer_line_ansi(&mut writer, terminal.backend().buffer())
+}
+
+/// Render the one-shot `rimz sidebar frame --expand` view as line-oriented ANSI.
+///
+/// Every card uses expanded density, every worktree group bypasses its row cap,
+/// and the offscreen viewport grows to the full composed height.
+pub fn render_expanded_line_ansi<W: Write>(
+    mut writer: W,
+    snapshot: &SidebarSnapshot,
+    width: u16,
+) -> io::Result<()> {
+    let mut snapshot = snapshot.clone();
+    snapshot.theme.display.card_density = CardDensityMode::Expanded;
+    let mut ui = UiState {
+        expanded_groups: snapshot
+            .worktree_groups
+            .iter()
+            .map(|group| group.key.clone())
+            .collect(),
+        ..UiState::default()
+    };
+    let theme = ui.theme(&snapshot.theme);
+    let composed =
+        compose_lines_with_meter(&snapshot, None, &ui, theme.as_ref(), width, u16::MAX, None);
+    let height =
+        u16::try_from(composed.content_height.clamp(1, usize::from(u16::MAX))).unwrap_or(u16::MAX);
+
+    let backend = TestBackend::new(width, height);
+    let mut terminal = infallible(Terminal::new(backend));
+    infallible(terminal.clear());
+    infallible(draw_to_terminal_with_ui(
+        &mut terminal,
+        &snapshot,
+        None,
+        &mut ui,
+    ));
     write_buffer_line_ansi(&mut writer, terminal.backend().buffer())
 }
 

--- a/crates/rimz/src/sidebar_pane/render/tests/mod.rs
+++ b/crates/rimz/src/sidebar_pane/render/tests/mod.rs
@@ -279,6 +279,69 @@ fn snapshot_with(mut agents: Vec<AgentState>) -> SidebarSnapshot {
     snapshot
 }
 
+#[test]
+fn expanded_line_frame_bypasses_group_cap_and_fits_content() {
+    let count = crate::sidebar_pane::view::WORKTREE_ROW_CAP + 2;
+    let agents = (0..count)
+        .map(|index| {
+            let handle = format!("expanded-{index}");
+            let mut agent = agent(
+                &handle,
+                "codex",
+                AgentStatus::Idle,
+                Some("/repo/main"),
+                Some("main"),
+                None,
+            );
+            agent.role = Some(handle);
+            agent
+        })
+        .collect();
+    let snapshot = snapshot_with(agents);
+
+    let mut ansi = Vec::new();
+    render_expanded_line_ansi(&mut ansi, &snapshot, 54).unwrap();
+    let rendered = String::from_utf8_lossy(&ansi);
+
+    for index in 0..count {
+        assert!(
+            rendered.contains(&format!("expanded-{index}")),
+            "expanded frame omitted row {index}: {rendered}"
+        );
+    }
+    assert!(!rendered.contains("+2 more"), "{rendered}");
+
+    let mut measured_snapshot = snapshot.clone();
+    measured_snapshot.theme.display.card_density = crate::config::CardDensityMode::Expanded;
+    let ui = fixed_theme_ui(
+        &measured_snapshot,
+        &UiState {
+            expanded_groups: measured_snapshot
+                .worktree_groups
+                .iter()
+                .map(|group| group.key.clone())
+                .collect(),
+            ..UiState::default()
+        },
+    );
+    let theme = ui
+        .cached_theme(&measured_snapshot.theme)
+        .expect("fixed theme is cached");
+    let composed = compose_lines_with_meter(
+        &measured_snapshot,
+        None,
+        &ui,
+        theme.as_ref(),
+        54,
+        u16::MAX,
+        None,
+    );
+    assert_eq!(
+        ansi.iter().filter(|byte| **byte == b'\n').count(),
+        composed.content_height
+    );
+}
+
 fn agent(
     id: &str,
     kind: &str,

--- a/crates/rimz/src/sidebar_pane/render/tests/mod.rs
+++ b/crates/rimz/src/sidebar_pane/render/tests/mod.rs
@@ -310,6 +310,13 @@ fn expanded_line_frame_bypasses_group_cap_and_fits_content() {
         );
     }
     assert!(!rendered.contains("+2 more"), "{rendered}");
+    assert!(
+        rendered
+            .lines()
+            .last()
+            .is_some_and(|line| line.contains("? for help")),
+        "expanded frame did not end with the footer: {rendered}"
+    );
 
     let mut measured_snapshot = snapshot.clone();
     measured_snapshot.theme.display.card_density = crate::config::CardDensityMode::Expanded;

--- a/crates/rimz/tests/integration/sidebar_snapshot.rs
+++ b/crates/rimz/tests/integration/sidebar_snapshot.rs
@@ -150,6 +150,50 @@ fn snapshot_exits_cleanly_when_the_consumer_closes_the_pipe() {
 }
 
 #[test]
+fn frame_emits_plain_text_over_a_pipe() {
+    let env = Env::new();
+    let session = "test-session";
+    let runtime = env.runtime_paths();
+    runtime.ensure_dirs().expect("runtime dirs");
+    let published = rimz::sidebar::frame::assemble_frame(
+        Vec::new(),
+        rimz::sidebar::timing::unix_now_ms(),
+        session,
+    );
+    rimz::store::atomic::write_temp_then_rename_cache(&runtime.pane_frame_path(), &published)
+        .expect("publish pane frame");
+
+    let output = env
+        .rimz()
+        .args([
+            "sidebar",
+            "frame",
+            "--workspace-id",
+            env.workspace_id.as_str(),
+            "--session-name",
+            session,
+            "--width",
+            "40",
+            "--height",
+            "12",
+        ])
+        .output()
+        .expect("spawn sidebar frame");
+
+    assert!(
+        output.status.success(),
+        "frame failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!output.stdout.is_empty(), "frame stdout is empty");
+    assert!(
+        !output.stdout.contains(&b'\x1b'),
+        "piped frame contains ANSI escapes: {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
 fn sidebar_lights_claude_rc_badge_from_claude_startup_setting() {
     let env = Env::new();
     let settings = write_claude_settings(&env, r#"{ "remoteControlAtStartup": true }"#);

--- a/docs/contributing/sidebar-screenshots.md
+++ b/docs/contributing/sidebar-screenshots.md
@@ -33,6 +33,8 @@ The task fails at entry when `freeze`, `rsvg-convert`, or JetBrainsMono Nerd Fon
 
 `cargo xtask screenshot state <empty|fleet|provider|cockpit|focus|economy|reach> [--width W] [--height H] [--output PATH]` renders deterministic fixture frames through the same headless sidebar renderer used by tests. `cockpit` (fleet breadth), `focus` (expanded team cards and the remote footer), `economy` and `reach` (provider spend; pets appear in the gallery with `--pets`) are packed gallery states for review.
 
+Live sidebar state can also be captured as line-oriented terminal output without the mux through `rimz sidebar frame`.
+
 `rimz sidebar gallery [--pets]` opens one frameless compositor pane in the current room with those packed states side by side, split by thin `│` delimiter rules and no real sidebar dock; outside any mux session, the same command renders the compositor inline in the current terminal. The compositor chooses four columns when the terminal is wider than 240 columns and three at or below that width, decided once at launch. `--pets` turns the dashboard companion on in every column.
 
 Set `RIMZ_BIN=/path/to/rimz` to capture with a specific binary. Without it, `xtask` runs the current checkout through `cargo run --quiet -p rimz --bin rimz -- ...`.

--- a/docs/internals/diagnostics.md
+++ b/docs/internals/diagnostics.md
@@ -230,6 +230,8 @@ Card-content questions (a wrong gauge, a missing cost, a card resting in the wro
 
 `rimz sidebar snapshot --json --no-produce`, run from anywhere inside the workspace or with `--workspace-id` from outside it, prints the fused `SidebarSnapshot` a node renders: the event-fresh rollup folded over the published pane frame plus the per-session sidecars ([state.md](./sidebar/state.md)). `--no-produce` keeps the read passive, with no mux or git forks, so inspection never perturbs the room. Omit it to pay one producing refresh when no fresh producer cache exists.
 
+`rimz sidebar frame` prints the rendered frame itself through the same passive read when a producer frame exists, falling back to one producing refresh otherwise. ANSI color is stripped when stdout is piped; `--expand` expands every card, reveals every capped worktree row, and grows the output so large fleets do not clip.
+
 ```sh
 rimz sidebar snapshot --json --no-produce | jq '
   .agents[] | select(.worktree_branch == "truecolor") | {

--- a/docs/internals/sidebar/sidebar.md
+++ b/docs/internals/sidebar/sidebar.md
@@ -28,6 +28,8 @@ Steps 1 through 8 happen in the elected producer and are published once for ever
 
 The command `rimz sidebar snapshot --json` runs steps 1 through 8 and prints the result. It is the fastest way to see what the renderer sees, and the fastest way to settle whether a bug lives in the producer or the renderer: if the wrong answer is already in the JSON, stop looking at `sidebar_pane/`.
 
+If the snapshot JSON is right and the pane looks wrong, `rimz sidebar frame` reproduces the renderer's output without capturing through the mux.
+
 ## Where the code lives
 
 The sidebar spans three module trees, one per half of the split above plus the data plane that feeds it.


### PR DESCRIPTION
## Context

Debugging sidebar state today means choosing between `rimz sidebar snapshot --json`, which gives data rather than pixels, and capturing the live pane through the multiplexer. The renderer already renders a snapshot deterministically offscreen for tests and for `rimz sidebar fixture`, so this change exposes that as a hidden one-shot verb: `rimz sidebar frame` prints what the sidebar pane currently displays to stdout, in color on a terminal and as plain text when piped. `--expand` prints every card fully expanded and every worktree group un-truncated, tall enough that nothing clips, for fleets too large to fit the real pane.

The verb sits inside the already-hidden `rimz sidebar` family, so it is documented in internals rather than the CLI reference.

## Design choices

- **One-shot only.** No watch or follow mode; `watch rimz sidebar frame` covers casual live viewing.
- **The default mirrors the live sidebar.** When a published producer frame exists, the verb reads it passively through `PublishedSnapshotReader` — zero store writes, honoring the sidebar's read-only invariant, and literally the snapshot the pane rendered. Otherwise it falls back to the producer path, the same as `sidebar snapshot`'s default. An explicit existence gate is required because `read_published_snapshot` succeeds with a frameless rollup when no producer cache exists, so a missing frame is not an error the caller can branch on.
- **Emission through `render::out()`,** unlike `fixture` which writes raw stdout. That anstream wrapper is what buys plain text when piped or under `NO_COLOR` with no new stripping code; its strip path also handles the OSC-8 hyperlinks embedded in cell symbols, so hyperlink painting stays on.
- **`--expand` lives in the renderer,** as one new public function, because the group-expansion state is crate-private and the row-cap, density, and height logic is renderer knowledge. The alternative — populating that state from the CLI — is not reachable across the crate boundary and would invert the handler contract.
- **Default dimensions come from the terminal,** since there is no pane to measure: width is the configured `SidebarWidth` percent policy applied to the detected columns, height is the detected rows, falling back to the width cap and 24 rows when no terminal is detected. `--width` and `--height` override; `--height` conflicts with `--expand`, which owns its own height.
- **The selection artifact is accepted.** The pane's selection lives in its own process memory, so the mirrored frame renders with the default selection (first card selected), matching `sidebar render` and `fixture` today. Deriving selection from focus state is out of scope for a debug verb.

## Implementation

The renderer gained `content_height` on its composed frame — the unclipped height, computed once in the compose pass — and one new public entry, `render_expanded_line_ansi`. That entry clones the snapshot to force expanded card density, opens every worktree group, measures the frame at an unbounded height, then draws at exactly the measured height through the existing offscreen backend and per-row ANSI serializer. Two deterministic composition passes and one snapshot clone buy keeping height and expansion policy inside the renderer instead of leaking renderer-local state to the CLI; for a one-shot debug verb that trade favors simplicity. Frames taller than 65,535 rows clamp at the backend's viewport ceiling rather than growing pagination.

The data plane gained `published_frame_exists`, a session-validating wrapper over the pane-frame cache read, so the consumer-versus-producer decision stays out of the CLI. The existence check and the subsequent read are two calls into a cache that memoizes per thread by path stamp, so they do not double-read the file; a frame removed in the narrow interval between them yields a valid frameless passive rollup rather than retrying the producer path, which this inspection verb does not justify guarding.

The CLI verb reuses `resolve_snapshot_context` unchanged. Sharing the produce path with `sidebar snapshot` meant extracting the two emit helpers into snapshot-returning functions; unlike the plan, no thin emit wrappers were kept, since the single remaining caller now takes the snapshot and calls the existing emitter directly, which preserves `sidebar snapshot` behavior with less indirection. Also unlike the plan, both dimension flags reject zero at the argument boundary: the ANSI serializer chunks by width and would panic at width zero.

Coverage spans three tiers: a renderer unit test proving the expanded frame bypasses the six-row worktree cap, fits its measured height, and ends on the footer rather than a clipped or padded tail; a CLI golden for the expanded cockpit fixture; and an out-of-process integration test that publishes a pane frame, runs the real binary, and asserts the piped output carries no escape bytes — which also exercises the passive read path. The CLI surface snapshot picks up the new verb additively. Both hand-promoted goldens were reviewed diff by diff, because `cargo insta` is unavailable in this environment.

Docs: one paragraph in diagnostics internals for the triage flow, one line in sidebar internals beside the producer-versus-renderer triage sentence, and one line in the screenshot workflow noting that live state can now be captured without the multiplexer.

## Advisories

- **The default width follows the configured percent policy, not the room's stored per-room target.** The live pane resolves width through a persisted permille and a `pinned` flag with a 24-column floor. Today the two agree within a column for an unpinned room, but a user who pinned the sidebar wide would see the mirror render materially narrower, and `--width` is the escape hatch. The plan locked the percent formula deliberately; revisiting it is a follow-up product decision, not a defect in this change.
- **The weakest coverage is the acquisition choice itself.** The existence gate is a one-line wrapper over an already-tested cache read, and the integration test drives its true branch, but no test stands up a producer cache and asserts the producer branch is taken instead. Verified by hand: the default invocation executes no multiplexer command at all, where `sidebar snapshot` captures a pane.