### PR TITLE
refactor(room): deepen birth and inventory seams

### DIFF
--- a/crates/rimz/src/cli/room/mod.rs
+++ b/crates/rimz/src/cli/room/mod.rs
@@ -409,7 +409,7 @@ enum ReadyRoom {
 
 fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom> {
     let mut machine_config = machine_config();
-    let remote_control_readiness = if matches!(
+    let background_view = if matches!(
         entry,
         RoomEntry::Start { .. } | RoomEntry::StartDetached { .. }
     ) {
@@ -422,9 +422,9 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
         let readiness =
             rimz::remote_control::ReadinessSnapshot::probe(&machine_config.remote_control);
         readiness.start_gate()?;
-        Some(readiness)
+        BackgroundViewBirth::Launch(readiness)
     } else {
-        None
+        BackgroundViewBirth::Skip
     };
 
     let mux = match &entry {
@@ -524,9 +524,6 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
                 mux,
                 RoomSizing::Birth,
             )?;
-            if let Some(readiness) = remote_control_readiness.clone() {
-                context.set_remote_control_readiness(readiness);
-            }
             context.claim_owner()?;
             birth_managed_room(
                 &mut context,
@@ -534,7 +531,7 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
                 entry.no_resume(),
                 entry.resume_prompt_mode(),
                 entry.refresh_ms(),
-                true,
+                background_view,
                 workspace.worktree_root.clone(),
             )?;
             ReadyRoom::Managed(Box::new(context))
@@ -553,7 +550,7 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
                 entry.no_resume(),
                 entry.resume_prompt_mode(),
                 entry.refresh_ms(),
-                false,
+                BackgroundViewBirth::Skip,
                 workspace.worktree_root.clone(),
             )?;
             ReadyRoom::Managed(Box::new(context))
@@ -567,7 +564,7 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
                 entry.no_resume(),
                 entry.resume_prompt_mode(),
                 entry.refresh_ms(),
-                false,
+                BackgroundViewBirth::Skip,
                 record.project_root.clone(),
             )?;
             ReadyRoom::Managed(Box::new(context))
@@ -590,7 +587,7 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
                     entry.no_resume(),
                     entry.resume_prompt_mode(),
                     entry.refresh_ms(),
-                    false,
+                    BackgroundViewBirth::Skip,
                     record.project_root.clone(),
                 )?;
                 ReadyRoom::Managed(Box::new(context))
@@ -642,7 +639,7 @@ fn birth_managed_room(
     no_resume: bool,
     resume_prompt: ResumePromptMode,
     refresh_ms: Option<u16>,
-    launch_background_view: bool,
+    background_view: BackgroundViewBirth,
     cwd: std::path::PathBuf,
 ) -> Result<()> {
     let rebirth = if was_live {
@@ -672,11 +669,7 @@ fn birth_managed_room(
         context.birth(RoomBirth::Normal(NormalBirth {
             cwd,
             rebirth,
-            background_view: if launch_background_view {
-                BackgroundViewBirth::Launch
-            } else {
-                BackgroundViewBirth::Skip
-            },
+            background_view,
             refresh_ms,
             recovery: if std::io::stdin().is_terminal() {
                 AttendedRecovery::Reset

--- a/crates/rimz/src/cli/sessions/mod.rs
+++ b/crates/rimz/src/cli/sessions/mod.rs
@@ -19,8 +19,8 @@ pub fn run(_args: SessionsArgs, globals: &GlobalFlags) -> Result<()> {
         );
     }
     if !picker_available() {
-        let rooms = rimz::room::session::live_rooms()?;
-        bail!("{}", session_listing(&rooms));
+        let inventory = rimz::room::session::room_inventory()?;
+        bail!("{}", session_listing(&inventory.live));
     }
     if !picker::run(picker::Mode::Terminal, None, None, globals)? {
         bail!("could not open the session manager in this terminal");

--- a/crates/rimz/src/cli/sessions/picker.rs
+++ b/crates/rimz/src/cli/sessions/picker.rs
@@ -222,8 +222,8 @@ fn probe_inventory(
     readers: &mut BTreeMap<String, PublishedSnapshotReader>,
 ) -> rimz::room::LiveRoomResult<(Vec<RoomRow>, Vec<KnownWorkspace>)> {
     let live = LiveSessions::probe();
-    let rooms = rimz::room::session::live_rooms_with(&live)?;
-    let dormant = rimz::room::session::dormant_workspaces(&live)?;
+    let inventory = rimz::room::session::room_inventory_with(&live)?;
+    let rooms = inventory.live;
     let live_names = rooms
         .iter()
         .map(|room| room.session_name.clone())
@@ -236,7 +236,7 @@ fn probe_inventory(
             RoomRow { room, stats }
         })
         .collect();
-    Ok((rows, dormant))
+    Ok((rows, inventory.dormant))
 }
 
 fn stats_for_room(

--- a/crates/rimz/src/room/birth.rs
+++ b/crates/rimz/src/room/birth.rs
@@ -6,7 +6,10 @@ use anyhow::{Context, Result};
 
 use crate::harness::rebirth::{RebirthChoice, RebirthPlan};
 use crate::harness::resume::ResumePlan;
-use crate::mux::{BackgroundViewLaunch, BackgroundViewOptions, DaemonView, SessionHealth};
+use crate::mux::{
+    BackgroundViewLaunch, BackgroundViewOptions, DaemonView, SessionHealth, SidebarPaneOptions,
+};
+use crate::remote_control::ReadinessSnapshot;
 use crate::{StatePaths, Store};
 
 use super::RoomContext;
@@ -32,9 +35,9 @@ pub enum AttendedRecovery {
 }
 
 /// Whether normal room birth carries the configured daemon view.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BackgroundViewBirth {
-    Launch,
+    Launch(ReadinessSnapshot),
     Skip,
 }
 
@@ -146,7 +149,9 @@ impl RoomContext {
         }
 
         let background_view = match background_view {
-            BackgroundViewBirth::Launch => Some(self.background_view(refresh_ms)),
+            BackgroundViewBirth::Launch(readiness) => {
+                Some(self.background_view(&readiness, refresh_ms))
+            }
             BackgroundViewBirth::Skip => None,
         };
 
@@ -177,30 +182,30 @@ impl RoomContext {
             }
         };
 
+        let sidebar = self.sidebar_options(&cwd, resume.tabs.clone(), refresh_ms);
+
         self.register_focus_key();
 
         let background_view = background_view.as_ref();
         let daemon = background_view.map(|options| &options.view);
-        self.launch_sidebar(&cwd, refresh_ms, !pre_existed, &resume, daemon);
+        self.launch_sidebar(&sidebar, !pre_existed, daemon);
 
         if let Some(options) = background_view {
             self.launch_background_view(options);
         }
 
-        let reset = self.ensure_healthy(&cwd, refresh_ms, &resume, daemon, recovery)?;
+        let reset = self.ensure_healthy(&sidebar, daemon, recovery)?;
         self.load_presence();
         Ok(BirthOutcome { resume, reset })
     }
 
     fn launch_sidebar(
         &self,
-        cwd: &std::path::Path,
-        refresh_ms: Option<u16>,
+        options: &SidebarPaneOptions,
         pristine_birth: bool,
-        resume: &ResumePlan,
         daemon: Option<&DaemonView>,
     ) {
-        let mut opts = self.sidebar_options(cwd, resume.tabs.clone(), refresh_ms);
+        let mut opts = options.clone();
         opts.pristine_birth = pristine_birth;
         let _ = crate::sidebar::launch_sidebar_if_needed(
             self.backend.as_ref(),
@@ -247,13 +252,11 @@ impl RoomContext {
 
     fn ensure_healthy(
         &self,
-        cwd: &std::path::Path,
-        refresh_ms: Option<u16>,
-        resume: &ResumePlan,
+        sidebar: &SidebarPaneOptions,
         daemon: Option<&DaemonView>,
         recovery: AttendedRecovery,
     ) -> Result<Option<RoomResetReport>> {
-        if self.clean_session(cwd, refresh_ms, resume, daemon)? != SessionHealth::Stuck {
+        if self.clean_session(sidebar, daemon)? != SessionHealth::Stuck {
             return Ok(None);
         }
         if recovery == AttendedRecovery::RequireExplicitReset {
@@ -263,7 +266,7 @@ impl RoomContext {
             .into());
         }
         let reset = self.reset(false)?;
-        match self.clean_session(cwd, refresh_ms, resume, daemon) {
+        match self.clean_session(sidebar, daemon) {
             Ok(SessionHealth::Healthy | SessionHealth::Reborn) => Ok(Some(reset)),
             Ok(SessionHealth::Stuck) => Err(ResetRecoveryError {
                 report: reset,
@@ -281,13 +284,10 @@ impl RoomContext {
 
     fn clean_session(
         &self,
-        cwd: &std::path::Path,
-        refresh_ms: Option<u16>,
-        resume: &ResumePlan,
+        options: &SidebarPaneOptions,
         daemon: Option<&DaemonView>,
     ) -> Result<SessionHealth> {
-        let opts = self.sidebar_options(cwd, resume.tabs.clone(), refresh_ms);
-        match self.backend.ensure_clean_session(&opts, daemon) {
+        match self.backend.ensure_clean_session(options, daemon) {
             Ok(health) => Ok(health),
             Err(
                 err @ (crate::mux::MuxErr::SocketPathTooLong { .. }

--- a/crates/rimz/src/room/mod.rs
+++ b/crates/rimz/src/room/mod.rs
@@ -16,6 +16,7 @@ use crate::mux::{
     BackgroundViewOptions, CommandSpec, MuxBackend, MuxErr, PresencePluginOptions, SessionHealth,
     SessionOptions, SidebarPaneOptions, SidebarWidth,
 };
+use crate::remote_control::ReadinessSnapshot;
 use crate::store::workspace_record;
 use crate::workspace::ResolvedWorkspace;
 use crate::{RuntimePaths, StatePaths, Store, WorkspaceRecord};
@@ -122,7 +123,6 @@ pub struct RoomContext {
     detected_size: Option<(u16, u16)>,
     rimz_bin: PathBuf,
     runtime: RuntimePaths,
-    remote_control_readiness: Option<crate::remote_control::ReadinessSnapshot>,
 }
 
 impl RoomContext {
@@ -205,7 +205,6 @@ impl RoomContext {
             detected_size,
             rimz_bin,
             runtime,
-            remote_control_readiness: None,
         })
     }
 
@@ -237,13 +236,6 @@ impl RoomContext {
 
     pub fn backend(&self) -> &dyn MuxBackend {
         self.backend.as_ref()
-    }
-
-    pub fn set_remote_control_readiness(
-        &mut self,
-        readiness: crate::remote_control::ReadinessSnapshot,
-    ) {
-        self.remote_control_readiness = Some(readiness);
     }
 
     /// Probe a selected backend before first-run config can construct final context.
@@ -286,20 +278,10 @@ impl RoomContext {
         resume_tabs: Vec<crate::mux::ResumeTab>,
         refresh_ms: Option<u16>,
     ) -> SidebarPaneOptions {
-        self.sidebar_options_with_size(cwd, resume_tabs, refresh_ms, self.detected_size)
-    }
-
-    fn sidebar_options_with_size(
-        &self,
-        cwd: &Path,
-        resume_tabs: Vec<crate::mux::ResumeTab>,
-        refresh_ms: Option<u16>,
-        detected_size: Option<(u16, u16)>,
-    ) -> SidebarPaneOptions {
         let target = crate::sidebar::width_target::resolve(
             &self.runtime,
             self.width,
-            detected_size.map(|(cols, _)| cols),
+            self.detected_size.map(|(cols, _)| cols),
         );
         SidebarPaneOptions {
             session_name: self.workspace.session_name.clone(),
@@ -308,7 +290,7 @@ impl RoomContext {
             extra_env: self.extra_env.clone(),
             cwd: cwd.to_path_buf(),
             target,
-            detected_view_size: detected_size,
+            detected_view_size: self.detected_size,
             rimz_bin: self.rimz_bin.clone(),
             pristine_birth: false,
             config: self.mux_config.clone(),
@@ -346,12 +328,8 @@ impl RoomContext {
             .attach_command(&self.workspace.session_name, &self.mux_config)
     }
 
-    fn presence_options(&self, materialize_artifact: bool) -> Option<PresencePluginOptions> {
-        let wasm = if materialize_artifact {
-            crate::mux::zellij::ensure_presence_plugin_artifact()?
-        } else {
-            crate::mux::zellij::presence_plugin_path()?
-        };
+    fn presence_options(&self) -> Option<PresencePluginOptions> {
+        let wasm = crate::mux::zellij::presence_plugin_path()?;
         Some(PresencePluginOptions {
             session_name: self.workspace.session_name.clone(),
             workspace_id: self.workspace.workspace_id.clone(),
@@ -371,7 +349,7 @@ impl RoomContext {
     }
 
     fn load_presence(&self) {
-        let Some(opts) = self.presence_options(false) else {
+        let Some(opts) = self.presence_options() else {
             tracing::debug!(
                 session = %self.workspace.session_name,
                 "presence plugin unavailable; the producer keeps its pane poll",
@@ -405,14 +383,15 @@ impl RoomContext {
     }
 
     /// Assemble configured daemon view for a normal start flow.
-    fn background_view(&self, refresh_ms: Option<u16>) -> BackgroundViewOptions {
+    fn background_view(
+        &self,
+        readiness: &ReadinessSnapshot,
+        refresh_ms: Option<u16>,
+    ) -> BackgroundViewOptions {
         let rimz_bin = self.rimz_bin.clone();
-        let remote_control = self.remote_control_readiness.clone().unwrap_or_else(|| {
-            crate::remote_control::ReadinessSnapshot::probe(&self.machine_config.remote_control)
-        });
         BackgroundViewOptions {
             view: crate::daemon_view::daemon_view_spec(crate::daemon_view::DaemonViewSpecParams {
-                claude_host_argv: remote_control.claude_host_argv(),
+                claude_host_argv: readiness.claude_host_argv(),
                 daemon: &self.machine_config.daemon,
                 rimz_bin: &rimz_bin,
                 workspace_id: &self.workspace.workspace_id,

--- a/crates/rimz/src/room/session.rs
+++ b/crates/rimz/src/room/session.rs
@@ -29,58 +29,45 @@ pub struct LiveRoom {
     pub updated_at: jiff::Timestamp,
 }
 
-/// Every known workspace whose managed mux session is currently live.
-pub fn live_rooms() -> LiveRoomResult<Vec<LiveRoom>> {
-    live_rooms_with(&LiveSessions::probe())
+/// Every durable RimZ workspace partitioned by current mux-session liveness.
+pub struct RoomInventory {
+    pub live: Vec<LiveRoom>,
+    pub dormant: Vec<KnownWorkspace>,
 }
 
-/// Every known workspace whose managed mux session is live under this probe.
-pub fn live_rooms_with(live: &LiveSessions) -> LiveRoomResult<Vec<LiveRoom>> {
+/// Inventory every known workspace against one batch mux-session probe.
+pub fn room_inventory() -> LiveRoomResult<RoomInventory> {
+    room_inventory_with(&LiveSessions::probe())
+}
+
+/// Inventory every known workspace against an existing mux-session probe.
+pub fn room_inventory_with(live: &LiveSessions) -> LiveRoomResult<RoomInventory> {
     let known = crate::workspace::known_workspaces()
         .map_err(|source| LiveRoomErr::WorkspaceRecords { source })?;
-    Ok(live_rooms_from(known, |session| live.mux_of(session)))
+    Ok(room_inventory_from(known, |session| live.mux_of(session)))
 }
 
-/// Known workspaces without a live mux session, newest record first.
-pub fn dormant_workspaces(live: &LiveSessions) -> LiveRoomResult<Vec<KnownWorkspace>> {
-    let known = crate::workspace::known_workspaces()
-        .map_err(|source| LiveRoomErr::WorkspaceRecords { source })?;
-    Ok(dormant_workspaces_from(known, |session| {
-        live.mux_of(session).is_some()
-    }))
-}
-
-fn live_rooms_from(
+fn room_inventory_from(
     known: Vec<KnownWorkspace>,
     mux_of: impl Fn(&str) -> Option<MuxName>,
-) -> Vec<LiveRoom> {
-    let mut rooms = known
-        .into_iter()
-        .filter_map(|workspace| {
-            let mux = mux_of(&workspace.session_name)?;
-            Some(LiveRoom {
+) -> RoomInventory {
+    let mut live = Vec::new();
+    let mut dormant = Vec::new();
+    for workspace in known {
+        match mux_of(&workspace.session_name) {
+            Some(mux) => live.push(LiveRoom {
                 session_name: workspace.session_name,
                 mux,
                 project_root: workspace.project_root,
                 workspace_id: workspace.workspace_id,
                 updated_at: workspace.updated_at,
-            })
-        })
-        .collect::<Vec<_>>();
-    rooms.sort_by(|left, right| left.session_name.cmp(&right.session_name));
-    rooms
-}
-
-fn dormant_workspaces_from(
-    known: Vec<KnownWorkspace>,
-    is_live: impl Fn(&str) -> bool,
-) -> Vec<KnownWorkspace> {
-    let mut dormant = known
-        .into_iter()
-        .filter(|workspace| !is_live(&workspace.session_name))
-        .collect::<Vec<_>>();
+            }),
+            None => dormant.push(workspace),
+        }
+    }
+    live.sort_by(|left, right| left.session_name.cmp(&right.session_name));
     dormant.sort_by_key(|workspace| std::cmp::Reverse(workspace.updated_at));
-    dormant
+    RoomInventory { live, dormant }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -516,9 +503,10 @@ mod tests {
             _ => None,
         };
 
-        let rooms = live_rooms_from(workspaces.clone(), mux_of);
+        let inventory = room_inventory_from(workspaces, mux_of);
         assert_eq!(
-            rooms
+            inventory
+                .live
                 .iter()
                 .map(|room| (room.session_name.as_str(), room.mux))
                 .collect::<Vec<_>>(),
@@ -528,9 +516,9 @@ mod tests {
             ]
         );
 
-        let dormant = dormant_workspaces_from(workspaces, |session| mux_of(session).is_some());
         assert_eq!(
-            dormant
+            inventory
+                .dormant
                 .iter()
                 .map(|workspace| workspace.session_name.as_str())
                 .collect::<Vec<_>>(),

--- a/crates/rimz/src/web/mod.rs
+++ b/crates/rimz/src/web/mod.rs
@@ -13,7 +13,9 @@ use serde::{Deserialize, Serialize};
 use crate::config::MachineConfig;
 use crate::ids::MuxName;
 use crate::mux::CommandSpec;
-use crate::room::session::{LiveRoom, LiveSessions, live_rooms_with, workspace_record_for_session};
+use crate::room::session::{
+    LiveRoom, LiveSessions, room_inventory_with, workspace_record_for_session,
+};
 use crate::store::atomic;
 
 mod gate;
@@ -555,7 +557,7 @@ pub fn existing_session_attach_command(session: Option<&str>) -> Result<CommandS
     let live = LiveSessions::probe();
     let target = live_session_target_with_probe(session, &live);
     let Some((session, mux)) = target else {
-        let rooms = live_rooms_with(&live)?;
+        let rooms = room_inventory_with(&live)?.live;
         return Err(WebErr::InvalidSession(invalid_session_message(
             session, &rooms,
         )));


### PR DESCRIPTION
## Context

`crates/rimz/src/room/` had accumulated three seams that were wider than the work they did, each visible from the call sites rather than only from inside the module.

Room inventory was split across three public functions — `live_rooms`, `live_rooms_with`, and `dormant_workspaces` — and the live and dormant halves each read the durable workspace catalog independently. The session picker calls both every two seconds, so it read the catalog twice per refresh and could partition two different snapshots against one liveness probe.

Normal room birth reached the daemon view through mutable context state. `rimz start` probed remote-control readiness, gated on it, then stored the snapshot on `RoomContext` through a setter, and `background_view` re-probed as a fallback when the field was empty. That fallback was unreachable — the only flow that asks for a daemon view is the only flow that sets the field — but nothing in the types said so.

Birth also derived the sidebar pane options three separate times from the same inputs: once for the launch, once for the health gate, and once more for the health retry after a reset.

Two smaller vestiges sat alongside: `presence_options` took a `materialize_artifact` flag whose `true` branch lost its last caller when `share_web()` was removed in an earlier change, and `sidebar_options_with_size` existed only to be called by `sidebar_options` with `self.detected_size`.

This is a behavior-preserving pass. Structure changes; observable behavior does not.

## Design choices

**One inventory snapshot, not two queries.** `RoomInventory { live, dormant }` is built from one `known_workspaces()` read partitioned against one `LiveSessions` probe. The alternative — keeping the two functions and having the picker pass a shared catalog into both — was rejected because it widens the public surface rather than narrowing it, and leaves the two-snapshot mistake available to the next caller.

**Readiness travels in the type that needs it.** `BackgroundViewBirth::Launch` now carries the `ReadinessSnapshot` that `rimz start` already probed and gated. This makes the daemon view's precondition a value the caller must supply instead of context state the callee hopes was set, which is what lets the fallback probe and the `set_remote_control_readiness` setter be deleted rather than merely left unused. The cost is that `BackgroundViewBirth` is no longer `Copy`; that was judged the right trade for deleting optional mutable state from `RoomContext`.

**One canonical options value per birth.** The sidebar pane options are derived once, after resume materialization, and reused by the sidebar launch and both health attempts. Only the launch clones it, to set the launch-only `pristine_birth` bit. Deriving them once before launch rather than re-deriving at each health attempt is safe because `width_target::resolve` is idempotent for a fixed view width, and the health gate that would consume a stale value returns early for a live session without reading the options at all.

## Implementation

- `crates/rimz/src/room/session.rs` — `live_rooms`, `live_rooms_with`, and `dormant_workspaces` replaced by `room_inventory` and `room_inventory_with` returning `RoomInventory`. The two private partition passes collapse into one loop that calls the liveness lookup once per workspace instead of twice. Both sort orders are unchanged: live rooms by session name, dormant workspaces newest record first. The unit test now asserts both partitions from one catalog, with input ordering that distinguishes each sort.
- `crates/rimz/src/room/birth.rs` — `BackgroundViewBirth::Launch` carries `ReadinessSnapshot`; the canonical `SidebarPaneOptions` is derived once and threaded into `launch_sidebar`, `ensure_healthy`, and `clean_session`, which lose their `cwd`, `refresh_ms`, and `ResumePlan` parameters.
- `crates/rimz/src/room/mod.rs` — the `remote_control_readiness` field, its setter, and the fallback probe are gone; `background_view` takes the readiness explicitly. `sidebar_options_with_size` is inlined into `sidebar_options`. `presence_options` loses its parameter and its dead materialization branch. `ensure_presence_plugin_artifact` itself is untouched and still serves `reload.rs` and the Zellij sidebar path.
- `crates/rimz/src/cli/room/mod.rs` — `prepare_room` builds a typed `BackgroundViewBirth` directly and passes it through `birth_managed_room`, replacing the boolean that was reconstructed into the enum at the far end. Start and detached-start carry the gated readiness; attach and web variants pass `Skip`.
- Callers updated in `crates/rimz/src/cli/sessions/mod.rs`, `crates/rimz/src/cli/sessions/picker.rs`, and `crates/rimz/src/web/mod.rs`.

No deviations from the plan. No documentation changed: no document names a removed interface.

### Behavior-preservation evidence

- The removed fallback probe was unreachable by construction: `BackgroundViewBirth::Launch` is built at exactly one site, guarded by `matches!(entry, Start | StartDetached)`, and consumed by exactly the arm that guard selects. Every other arm passes `Skip` literally, and supervised birth hardcodes `Skip`. The same `ReadinessSnapshot` value reaches `daemon_view_spec` as before.
- The deleted `materialize_artifact` branch had no caller at the merge base; the sole call site passed `false`.
- Reusing one options value across the health attempts cannot go stale. `width_target::resolve` writes only when the resolved value differs from what is stored, so repeated calls with the same view width return the same target; the view width is not mutated between the old call sites. The only external writer is the sidebar renderer, which exists only once the session is live — and for a live session the Zellij health gate returns healthy without reading the options, while the tmux path ignores them entirely. A reset does not clear the width target: teardown sweeps heartbeats, sockets, and read marks only.
- Partitioning in one pass is equivalent because the liveness lookup reads an already-captured probe snapshot. Sourcing both halves from one catalog read additionally removes a time-of-check gap the picker had between its two reads.

### Verification

`cargo xtask gate` passes: fmt, invariants, docs-links, lint, test. Focused runs: `cargo xtask test room` (103 passed), `zellij_health` (5 passed), `sessions` (95 passed), `fresh_background_supervised_run_uses_shared_room_birth` (1 passed), `start_checks_hooks_on_birth_but_not_live_reattach` (1 passed).

The live-backend tier was escalated to because this change touches room birth: `cargo xtask test -P live` gives 85 passed, 1 failed. The single failure, `backend::tmux::agent_lifecycle::resumed_lazy_agent_is_addressable_before_provider_registration`, is pre-existing — it fails with the identical panic at the identical line on the merge base, and it drives tmux directly without going through `RoomContext`, `room::birth`, or `room::session`.

## Advisories

- `RoomInventory` derives nothing, while the four other public types in `room/session.rs` all derive at least `Debug`. Adding `#[derive(Clone, Debug, PartialEq, Eq)]` would match the file's idiom. Left as reviewer's discretion; no workspace lint requires it.
- `rimz sessions` and the web attach-command error path take only the `live` half of the inventory and discard `dormant`. Both are one-shot paths over the workspace catalog, so the extra partition and sort are not worth a second API shape.
- `cli/uninstall.rs` keeps its own private live-room join over `KnownWorkspace`. It was left alone as outside this pass's paths; it is a candidate for the same inventory seam later.