### PR TITLE
refactor(agents): deepen spending and parsing modules

### DIFF
--- a/crates/rimz/src/agents/adapters/claude/mod.rs
+++ b/crates/rimz/src/agents/adapters/claude/mod.rs
@@ -65,7 +65,7 @@ use super::definition::{
 };
 use super::hook_types::{BackgroundTask, HookEventSpec, SessionSource, decode_catalog_hook};
 use super::lifecycle::LifecycleSignal;
-use super::observation::payload_total_tokens;
+use super::observation::{payload_has_context_observation, payload_total_tokens};
 use super::pricing::PriceBook;
 use super::{
     AgentHookClass, AgentLifecycleObservation, AgentTurnError, HookOutput, HookRouting, Result,
@@ -581,18 +581,7 @@ impl crate::agents::capabilities::HookCapability for ClaudeAdapter {
             })
         });
         decoded.set_final_message(final_message);
-        if [
-            "model",
-            "effort",
-            "rate_limits",
-            "total_cost_usd",
-            "context_window",
-            "total_tokens",
-            "context_pct",
-        ]
-        .into_iter()
-        .any(|key| payload.get(key).is_some())
-        {
+        if payload_has_context_observation(payload) {
             decoded.set_observed_context(self.observe_context(self.spec().kind, payload));
         }
         Ok(decoded)

--- a/crates/rimz/src/agents/adapters/claude/spend.rs
+++ b/crates/rimz/src/agents/adapters/claude/spend.rs
@@ -36,7 +36,7 @@ use crate::agents::spending::{
     CachedEntry, SpendCursor, SpendParse, iso_to_unix_secs, origin_path, price_split,
 };
 
-use crate::agents::transcript_fs::{bytes_contains, expand_tilde, home_dir, read_spend_lines};
+use crate::agents::transcript_fs::{bytes_contains, expand_tilde, home_dir, read_transcript_lines};
 
 // ── Typed structs ─────────────────────────────────────────────────────────────
 
@@ -303,7 +303,7 @@ fn is_semver_prefix(value: &str) -> bool {
 /// the spending walk. A suffix parse therefore never needs the
 /// lines before its resume point.
 pub fn parse_claude_spend(path: &Path, from_offset: u64, prices: &PriceBook) -> SpendParse {
-    let Some((content, next_offset)) = read_spend_lines(path, from_offset) else {
+    let Some((content, next_offset)) = read_transcript_lines(path, from_offset) else {
         return SpendParse {
             entries: Vec::new(),
             origin: None,

--- a/crates/rimz/src/agents/adapters/codex/spend/parse.rs
+++ b/crates/rimz/src/agents/adapters/codex/spend/parse.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::agents::spending::origin_path;
-use crate::agents::transcript_fs::read_spend_lines;
+use crate::agents::transcript_fs::read_transcript_lines;
 
 use super::super::rollout::{
     CodexModelMetadata, CodexRawUsage, CodexTimestamp, RolloutKind, RolloutRecord, decode_line,
@@ -121,7 +121,7 @@ pub(super) fn parse_codex_session(
     from_offset: u64,
     state: &mut CodexSpendState,
 ) -> (Vec<CodexTokenEvent>, u64) {
-    let Some((content, next_offset)) = read_spend_lines(path, from_offset) else {
+    let Some((content, next_offset)) = read_transcript_lines(path, from_offset) else {
         return (Vec::new(), from_offset);
     };
     let fallback_timestamp = file_mtime_rfc3339(path);

--- a/crates/rimz/src/agents/adapters/copilot/mod.rs
+++ b/crates/rimz/src/agents/adapters/copilot/mod.rs
@@ -38,6 +38,7 @@ use super::hook_types::{HookEventSpec, decode_catalog_hook};
 use super::lifecycle::LifecycleSignal;
 use super::managed_source::ManagedSource;
 use super::managed_statusline::{ManagedStatusLineSpec, RenderingOptions, WrapPolicy};
+use super::observation::payload_has_context_observation;
 use super::{
     AgentLifecycleObservation, AgentTurnError, AskKind, HookOutput, HookRouting,
     LocalContextRefresh, LocalContextRefreshCtx, RefreshTrigger, Result, SessionOrigin,
@@ -416,18 +417,7 @@ impl crate::agents::capabilities::HookCapability for CopilotAdapter {
                 })
                 .flatten(),
         );
-        if [
-            "model",
-            "effort",
-            "rate_limits",
-            "total_cost_usd",
-            "context_window",
-            "total_tokens",
-            "context_pct",
-        ]
-        .into_iter()
-        .any(|key| payload.get(key).is_some())
-        {
+        if payload_has_context_observation(payload) {
             decoded.set_observed_context(self.observe_context(self.spec().kind, payload));
         }
         let signal = match event_name {

--- a/crates/rimz/src/agents/adapters/kimi/wire.rs
+++ b/crates/rimz/src/agents/adapters/kimi/wire.rs
@@ -6,7 +6,7 @@ use jiff::Timestamp;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
-use crate::agents::transcript_fs::{home_dir, read_spend_lines};
+use crate::agents::transcript_fs::{home_dir, read_transcript_lines};
 
 #[derive(Clone, Debug)]
 pub struct WireRecord {
@@ -441,7 +441,7 @@ pub struct WireSnapshot {
 
 impl WireSnapshot {
     pub fn read(path: &Path) -> Option<Self> {
-        let (bytes, consumed_offset) = read_spend_lines(path, 0)?;
+        let (bytes, consumed_offset) = read_transcript_lines(path, 0)?;
         let tail_byte_start = record_aligned_tail_start(&bytes);
         let mut records = Vec::new();
         let mut tail_start = 0;
@@ -627,7 +627,7 @@ fn loop_event(value: Value) -> LoopEvent {
 }
 
 pub fn read_records(path: &Path, offset: u64) -> Option<(Vec<WireRecord>, u64)> {
-    let (bytes, next) = read_spend_lines(path, offset)?;
+    let (bytes, next) = read_transcript_lines(path, offset)?;
     Some((records_from_bytes(&bytes), next))
 }
 

--- a/crates/rimz/src/agents/adapters/pi/mod.rs
+++ b/crates/rimz/src/agents/adapters/pi/mod.rs
@@ -54,7 +54,7 @@ use super::definition::{
 use super::hook_types::{HookEventSpec, decode_catalog_hook};
 use super::lifecycle::LifecycleSignal;
 use super::managed_source::ManagedSource;
-use super::observation::payload_context_pct;
+use super::observation::{payload_context_pct, payload_has_context_observation};
 use super::pricing::PriceBook;
 use super::{
     AgentLifecycleObservation, AnswerPlanErr, AnswerStep, AskReply, HookOutput, HookRouting,
@@ -366,18 +366,7 @@ impl crate::agents::capabilities::HookCapability for PiAdapter {
             .then(|| ask::answer_detail(payload))
             .flatten(),
         );
-        if [
-            "model",
-            "effort",
-            "rate_limits",
-            "total_cost_usd",
-            "context_window",
-            "total_tokens",
-            "context_pct",
-        ]
-        .into_iter()
-        .any(|key| payload.get(key).is_some())
-        {
+        if payload_has_context_observation(payload) {
             decoded.set_observed_context(pi_observed_context(self.spec().kind, payload));
         }
         if matches!(event_name, "subagent_started" | "subagent_stopped") {

--- a/crates/rimz/src/agents/adapters/pi/spend.rs
+++ b/crates/rimz/src/agents/adapters/pi/spend.rs
@@ -38,7 +38,8 @@ use crate::agents::spending::{CachedEntry, SpendCursor, SpendParse, origin_path,
 
 use crate::agents::transcript_fs::{
     deserialize_optional_f64_lossy, deserialize_optional_object_lossy,
-    deserialize_optional_string_lossy, deserialize_optional_u64_lossy, home_dir, read_spend_lines,
+    deserialize_optional_string_lossy, deserialize_optional_u64_lossy, home_dir,
+    read_transcript_lines,
 };
 
 // ── Typed structs ─────────────────────────────────────────────────────────────
@@ -190,7 +191,7 @@ pub(crate) fn pi_config_dir() -> PathBuf {
 pub fn parse_pi_spend(path: &Path, resume: Option<&SpendCursor>, prices: &PriceBook) -> SpendParse {
     let from_offset = resume.map_or(0, |cursor| cursor.offset);
     let mut state: PiSpendState = resume.map(SpendCursor::state_as).unwrap_or_default();
-    let Some((content, next_offset)) = read_spend_lines(path, from_offset) else {
+    let Some((content, next_offset)) = read_transcript_lines(path, from_offset) else {
         return SpendParse {
             origin: state.cwd.clone(),
             ..SpendParse::stalled(resume)

--- a/crates/rimz/src/agents/adapters/qwen/mod.rs
+++ b/crates/rimz/src/agents/adapters/qwen/mod.rs
@@ -28,7 +28,7 @@ use super::definition::{
 };
 use super::hook_types::{BackgroundTask, HookEventSpec, SessionSource, decode_catalog_hook};
 use super::lifecycle::{AskKind, LifecycleSignal};
-use super::observation::payload_total_tokens;
+use super::observation::{payload_has_context_observation, payload_total_tokens};
 use super::pricing::PriceBook;
 use super::transcript::{TranscriptMessage, TranscriptRole};
 use super::{
@@ -504,18 +504,7 @@ impl crate::agents::capabilities::HookCapability for QwenAdapter {
                 label,
             }));
         }
-        if [
-            "model",
-            "effort",
-            "rate_limits",
-            "total_cost_usd",
-            "context_window",
-            "total_tokens",
-            "context_pct",
-        ]
-        .into_iter()
-        .any(|key| payload.get(key).is_some())
-        {
+        if payload_has_context_observation(payload) {
             decoded.set_observed_context(self.observe_context(self.spec().kind, payload));
         }
         decoded.set_final_message(

--- a/crates/rimz/src/agents/observation.rs
+++ b/crates/rimz/src/agents/observation.rs
@@ -354,9 +354,49 @@ pub(crate) fn payload_total_tokens(payload: &Value, fallback: Option<u64>) -> Op
         .or(fallback)
 }
 
+/// Whether a hook payload carries any canonical context observation field.
+/// Presence is evidence even when the provider explicitly reports JSON null.
+pub(crate) fn payload_has_context_observation(payload: &Value) -> bool {
+    [
+        "model",
+        "effort",
+        "rate_limits",
+        "total_cost_usd",
+        "context_window",
+        "total_tokens",
+        "context_pct",
+    ]
+    .into_iter()
+    .any(|key| payload.get(key).is_some())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::AgentUsageSummary;
+    use serde_json::json;
+
+    use super::{AgentUsageSummary, payload_has_context_observation};
+
+    #[test]
+    fn context_observation_evidence_is_presence_based() {
+        assert!(!payload_has_context_observation(&json!({})));
+        assert!(!payload_has_context_observation(
+            &json!({"unrelated": null})
+        ));
+        for key in [
+            "model",
+            "effort",
+            "rate_limits",
+            "total_cost_usd",
+            "context_window",
+            "total_tokens",
+            "context_pct",
+        ] {
+            assert!(
+                payload_has_context_observation(&json!({key: null})),
+                "{key} presence is context evidence"
+            );
+        }
+    }
 
     #[test]
     fn usage_merge_carries_sparse_values_and_resolves_percentage_once() {

--- a/crates/rimz/src/agents/spending/aggregate.rs
+++ b/crates/rimz/src/agents/spending/aggregate.rs
@@ -11,6 +11,7 @@ use sha2::{Digest, Sha256};
 use crate::agents::AgentDefinition;
 use crate::agents::definition::ThreadKey;
 
+use super::SpendingWalkResult;
 use super::cache::{CachedEntry, FileCacheEntry, SpendingDiskCache};
 use super::user_input::UserInputRecord;
 
@@ -185,18 +186,6 @@ pub struct DaySpend {
     pub tokens: u64,
 }
 
-pub(crate) struct CountedRollups {
-    pub(crate) spending: Spending,
-    pub(crate) workspace_tally: SpendTally,
-    pub(crate) workspace_headline_cutoff_secs: u64,
-    pub(crate) workspace_live_baselines: BTreeMap<String, f64>,
-    pub(crate) workspace_day: SpendWindow,
-    pub(crate) provider_day: BTreeMap<String, SpendWindow>,
-    pub(crate) day_cutoff_secs: u64,
-    pub(crate) days: BTreeMap<i64, DaySpend>,
-    pub(crate) models: BTreeMap<String, SpendTally>,
-}
-
 #[derive(Clone, Copy)]
 pub(crate) struct HeadlineContext<'a> {
     pub(crate) user_inputs: &'a [UserInputRecord],
@@ -211,7 +200,7 @@ pub(crate) fn aggregate_counted_rollups(
     workspace: Option<&SpendScope>,
     headline: HeadlineContext<'_>,
     include_history_rollups: bool,
-) -> CountedRollups {
+) -> SpendingWalkResult {
     let HeadlineContext {
         user_inputs,
         now_secs,
@@ -309,7 +298,7 @@ pub(crate) fn aggregate_counted_rollups(
             sessions.len().try_into().unwrap_or(u32::MAX);
     }
 
-    CountedRollups {
+    SpendingWalkResult {
         spending,
         workspace_tally,
         workspace_headline_cutoff_secs: workspace.map(|_| cutoffs.scoped()).unwrap_or_default(),
@@ -331,6 +320,7 @@ pub(crate) fn aggregate_counted_rollups(
         } else {
             BTreeMap::new()
         },
+        stats: Default::default(),
     }
 }
 

--- a/crates/rimz/src/agents/spending/discovery.rs
+++ b/crates/rimz/src/agents/spending/discovery.rs
@@ -415,7 +415,7 @@ impl SpendingDiscoveryIndex {
         self.last_authoritative
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "testkit"))]
     pub(crate) fn mark_non_authoritative_for_test(&mut self) {
         self.last_authoritative = false;
     }

--- a/crates/rimz/src/agents/spending/engine.rs
+++ b/crates/rimz/src/agents/spending/engine.rs
@@ -9,8 +9,9 @@ use std::time::Duration;
 
 use crate::RuntimePaths;
 use crate::agents::spending::{
-    ProviderSpendingCache, SESSION_GAP_SECS, SpendProgress, SpendScope, SpendingCaches,
-    WorkspaceSpendingCache, compute_scoped_spending, read_provider_spending_cache, user_input,
+    HeadlineSpec, ProviderSpendingCache, SESSION_GAP_SECS, SpendProgress, SpendScope,
+    SpendingCaches, WorkspaceSpendingCache, compute_scoped_spending, read_provider_spending_cache,
+    user_input,
 };
 
 use super::{SPENDING_STALE_GRACE, unix_now_ms};
@@ -47,31 +48,45 @@ pub(super) fn serve_request(
     request: &crate::agents::spending::service::SpendingServiceRequest,
     progress: &mut dyn FnMut(SpendProgress),
 ) -> SpendingCaches {
-    let context = SpendingRequestContext {
-        project_root: request.project_root.as_deref(),
-        worktree_roots: &request.worktree_roots,
-        worktree_home: request.worktree_home.as_deref(),
-        origin_overrides: request.origin_overrides.clone(),
-        headline: &request.headline,
-        allow_local_fallback: false,
-    };
+    let context = request_context(request, false);
     compute_fleet_spending(walker, runtime, &context, progress)
 }
 
 pub(super) fn serve_direct(
-    walker: &mut crate::agents::spending::SpendingWalker,
     runtime: &RuntimePaths,
     request: &crate::agents::spending::service::SpendingServiceRequest,
 ) -> SpendingCaches {
+    let context = request_context(request, true);
+    serve_one_shot(runtime, &context, &mut |_| {})
+}
+
+/// Run one account-global spending refresh directly in this process. The CLI
+/// uses this path to retain per-file progress without traversing the framed
+/// warm-owner transport.
+#[doc(hidden)]
+pub fn refresh_global_spending_direct(
+    runtime: &RuntimePaths,
+    headline: &HeadlineSpec,
+    progress: &mut dyn FnMut(SpendProgress),
+) -> ProviderSpendingCache {
     let context = SpendingRequestContext {
-        project_root: request.project_root.as_deref(),
-        worktree_roots: &request.worktree_roots,
-        worktree_home: request.worktree_home.as_deref(),
-        origin_overrides: request.origin_overrides.clone(),
-        headline: &request.headline,
+        project_root: None,
+        worktree_roots: &[],
+        worktree_home: None,
+        origin_overrides: HashMap::new(),
+        headline,
         allow_local_fallback: true,
     };
-    compute_fleet_spending(walker, runtime, &context, &mut |_| {})
+    serve_one_shot(runtime, &context, progress).provider
+}
+
+fn serve_one_shot(
+    runtime: &RuntimePaths,
+    context: &SpendingRequestContext<'_>,
+    progress: &mut dyn FnMut(SpendProgress),
+) -> SpendingCaches {
+    let mut walker = crate::agents::spending::SpendingWalker::new();
+    compute_fleet_spending(&mut walker, runtime, context, progress)
 }
 
 /// Serve a fully fresh durable result without waiting for the warm walker. The
@@ -96,6 +111,20 @@ struct SpendingRequestContext<'a> {
     origin_overrides: HashMap<PathBuf, PathBuf>,
     headline: &'a crate::agents::spending::HeadlineSpec,
     allow_local_fallback: bool,
+}
+
+fn request_context<'a>(
+    request: &'a crate::agents::spending::service::SpendingServiceRequest,
+    allow_local_fallback: bool,
+) -> SpendingRequestContext<'a> {
+    SpendingRequestContext {
+        project_root: request.project_root.as_deref(),
+        worktree_roots: &request.worktree_roots,
+        worktree_home: request.worktree_home.as_deref(),
+        origin_overrides: request.origin_overrides.clone(),
+        headline: &request.headline,
+        allow_local_fallback,
+    }
 }
 
 fn compute_fleet_spending(
@@ -300,9 +329,9 @@ fn walk_fleet_spending_files(
 ) -> crate::agents::spending::SpendingCaches {
     use crate::agents::pricing;
     use crate::agents::spending::{
-        PROVIDER_SPENDING_VERSION, ProviderSpendingCache, SilentWalk, SpendScope, Spending,
-        SpendingCaches, WORKSPACE_SPENDING_VERSION, WalkRequest, WorkspaceSpendingCache,
-        read_provider_spending_cache, write_provider_spending_cache,
+        ProviderSpendingCache, SilentWalk, SpendProgress, SpendScope, SpendingCaches,
+        SpendingWalkResult, WORKSPACE_SPENDING_VERSION, WalkRequest, WorkspaceSpendingCache,
+        read_provider_spending_cache, write_provider_spending_cache_value,
         write_workspace_spending_cache,
     };
 
@@ -313,6 +342,10 @@ fn walk_fleet_spending_files(
         context.worktree_home,
     );
     let scope_hash = (!scope.is_empty()).then(|| scope.hash());
+    progress(SpendProgress {
+        finished_files: 0,
+        total_files: files.len(),
+    });
     if files.is_empty() {
         // A non-authoritative empty scan retains prior publications; an
         // authoritative empty index is a real deletion and publishes zero.
@@ -324,7 +357,7 @@ fn walk_fleet_spending_files(
             };
         }
         let refreshed_at_ms = unix_now_ms();
-        let spending = Spending::default();
+        let result = SpendingWalkResult::default();
         let user_inputs = user_input::load();
         let scoped = compute_scoped_spending(
             files,
@@ -344,10 +377,11 @@ fn walk_fleet_spending_files(
             day_cutoff_secs: scoped.day_cutoff_secs,
             live_baselines: scoped.live_baselines,
         };
+        let provider = ProviderSpendingCache::from_walk(&result, refreshed_at_ms);
         if publish {
             // Stamp the empty result too: an agentless machine must not re-run
             // the (empty) discovery readdirs every tick.
-            write_provider_spending_cache(&provider_path, refreshed_at_ms, &spending);
+            write_provider_spending_cache_value(&provider_path, &provider);
             if let Some(scope_hash) = scope_hash.as_deref() {
                 write_workspace_spending_cache(
                     &runtime.workspace_spending_path(scope_hash),
@@ -357,15 +391,7 @@ fn walk_fleet_spending_files(
             }
         }
         return SpendingCaches {
-            provider: ProviderSpendingCache {
-                version: PROVIDER_SPENDING_VERSION,
-                refreshed_at_ms,
-                day_by_provider: Default::default(),
-                day_cutoff_secs: 0,
-                days: Default::default(),
-                models: Default::default(),
-                spending,
-            },
+            provider,
             workspace,
         };
     }
@@ -412,6 +438,7 @@ fn walk_fleet_spending_files(
         walker.walk_local(&cache_path, &req, &mut observer)
     };
     let refreshed_at_ms = unix_now_ms();
+    let provider = ProviderSpendingCache::from_walk(&result, refreshed_at_ms);
     let workspace = if let Some(scope_hash) = scope_hash.as_deref() {
         reconciled_workspace_cache(
             scope_hash,
@@ -430,15 +457,7 @@ fn walk_fleet_spending_files(
         }
     };
     if publish {
-        crate::agents::spending::write_provider_spending_cache_with_day(
-            &provider_path,
-            refreshed_at_ms,
-            &result.spending,
-            &result.days,
-            &result.models,
-            &result.provider_day,
-            result.day_cutoff_secs,
-        );
+        write_provider_spending_cache_value(&provider_path, &provider);
         if let Some(scope_hash) = scope_hash.as_deref() {
             write_workspace_spending_cache(
                 &runtime.workspace_spending_path(scope_hash),
@@ -448,15 +467,7 @@ fn walk_fleet_spending_files(
         }
     }
     SpendingCaches {
-        provider: ProviderSpendingCache {
-            version: PROVIDER_SPENDING_VERSION,
-            refreshed_at_ms,
-            day_by_provider: result.provider_day,
-            day_cutoff_secs: result.day_cutoff_secs,
-            days: result.days,
-            models: result.models,
-            spending: result.spending,
-        },
+        provider,
         workspace,
     }
 }
@@ -488,14 +499,10 @@ impl crate::agents::spending::WalkObserver for PublishingWalkObserver<'_> {
             self.spec,
         );
         let refreshed_at_ms = unix_now_ms();
-        crate::agents::spending::write_provider_spending_cache_with_day(
+        let provider = ProviderSpendingCache::from_walk(&result, refreshed_at_ms);
+        crate::agents::spending::write_provider_spending_cache_value(
             &self.provider_path,
-            refreshed_at_ms,
-            &result.spending,
-            &result.days,
-            &result.models,
-            &result.provider_day,
-            result.day_cutoff_secs,
+            &provider,
         );
         if let Some(scope_hash) = self.scope_hash.as_deref() {
             let workspace = reconciled_workspace_cache(

--- a/crates/rimz/src/agents/spending/engine/tests.rs
+++ b/crates/rimz/src/agents/spending/engine/tests.rs
@@ -31,11 +31,9 @@ fn compute_fleet_spending_with_walker(
     project_root: Option<&std::path::Path>,
     spec: &HeadlineSpec,
 ) -> crate::agents::spending::SpendingCaches {
-    super::serve_direct(
-        walker,
-        runtime,
-        &service_request(runtime, project_root, spec),
-    )
+    let request = service_request(runtime, project_root, spec);
+    let context = super::request_context(&request, true);
+    super::compute_fleet_spending(walker, runtime, &context, &mut |_| {})
 }
 
 fn walk_fleet_spending(

--- a/crates/rimz/src/agents/spending/mod.rs
+++ b/crates/rimz/src/agents/spending/mod.rs
@@ -26,7 +26,7 @@ mod time;
 pub mod user_input;
 
 use std::cell::Cell;
-#[cfg(test)]
+#[cfg(any(test, feature = "testkit"))]
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
@@ -47,11 +47,12 @@ pub(crate) fn unix_now_ms() -> u64 {
         .map_or(0, |duration| duration.as_millis() as u64)
 }
 
+#[cfg(test)]
+pub(crate) use aggregate::CountedPayload;
 pub(crate) use aggregate::{
-    CountedLocation, CountedPayload, HeadlineContext, NO_BURST_CUTOFF, SESSION_GAP_SECS,
-    aggregate_counted_rollups, dedup_cached_entries, dedup_cached_entry_locations,
-    indexed_counted_entries, live_session_keys, origin_path, should_replace_usage_duplicate,
-    spending_files_signature,
+    CountedLocation, HeadlineContext, NO_BURST_CUTOFF, SESSION_GAP_SECS, aggregate_counted_rollups,
+    dedup_cached_entries, dedup_cached_entry_locations, indexed_counted_entries, live_session_keys,
+    origin_path, should_replace_usage_duplicate, spending_files_signature,
 };
 pub use aggregate::{
     DaySpend, HeadlineSpec, SpendScope, SpendTally, SpendWindow, SpendWindowMode, Spending,
@@ -72,7 +73,11 @@ pub use effort::{
     EffortParseMemo, EffortSessionRef, EffortTokens, SlotEffort, slot_effort,
     slot_effort_with_memo, sum_optional_cost,
 };
-pub(crate) use publish::{PROVIDER_SPENDING_VERSION, WORKSPACE_SPENDING_VERSION};
+#[doc(hidden)]
+pub use engine::refresh_global_spending_direct;
+pub(crate) use publish::{
+    PROVIDER_SPENDING_VERSION, WORKSPACE_SPENDING_VERSION, write_provider_spending_cache_value,
+};
 pub use publish::{
     ProviderSpendingCache, WorkspaceSpendingCache, read_provider_spending_cache,
     read_workspace_spending_cache, write_provider_spending_cache,
@@ -145,22 +150,27 @@ pub struct WalkStats {
     pub parse_bytes: u64,
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testkit"))]
 type DiscoveredSpendingFiles = Vec<(&'static AgentDefinition, PathBuf)>;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testkit"))]
 thread_local! {
     static DISCOVER_SPENDING_FILES_OVERRIDE: RefCell<Option<DiscoveredSpendingFiles>> =
         const { RefCell::new(None) };
+}
+
+#[cfg(test)]
+thread_local! {
     static PANIC_AFTER_REFRESH_FOR_TEST: Cell<bool> = const { Cell::new(false) };
 }
 
-#[cfg(test)]
-pub(crate) struct DiscoverSpendingFilesOverride {
+#[cfg(any(test, feature = "testkit"))]
+#[doc(hidden)]
+pub struct DiscoverSpendingFilesOverride {
     prior: Option<DiscoveredSpendingFiles>,
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testkit"))]
 impl Drop for DiscoverSpendingFilesOverride {
     fn drop(&mut self) {
         let prior = self.prior.take();
@@ -170,8 +180,9 @@ impl Drop for DiscoverSpendingFilesOverride {
     }
 }
 
-#[cfg(test)]
-pub(crate) fn override_discovered_spending_files_for_test(
+#[cfg(any(test, feature = "testkit"))]
+#[doc(hidden)]
+pub fn override_discovered_spending_files_for_test(
     files: DiscoveredSpendingFiles,
 ) -> DiscoverSpendingFilesOverride {
     let prior = DISCOVER_SPENDING_FILES_OVERRIDE.with(|slot| slot.replace(Some(files)));
@@ -240,7 +251,7 @@ impl SpendingWalker {
         &mut self,
         now_secs: u64,
     ) -> Vec<(&'static AgentDefinition, PathBuf)> {
-        #[cfg(test)]
+        #[cfg(any(test, feature = "testkit"))]
         if let Some(files) = DISCOVER_SPENDING_FILES_OVERRIDE.with(|slot| slot.borrow().clone()) {
             if files.is_empty() {
                 self.discovery.mark_non_authoritative_for_test();
@@ -385,7 +396,7 @@ impl SpendingWalker {
         self.ensure_memo(req.files, &mut stats);
         let locations = &self.memo.as_ref().expect("memo seeded above").counted;
         let counted = indexed_counted_entries(req.files, &self.cache, locations);
-        aggregate_walk_publish_from_counted(
+        let mut result = aggregate_counted_rollups(
             req.files,
             &self.cache,
             &counted,
@@ -395,8 +406,10 @@ impl SpendingWalker {
                 now_secs: req.now_secs,
                 spec: req.spec,
             },
-            stats,
-        )
+            true,
+        );
+        result.stats = stats;
+        result
     }
 
     fn sync_from_disk(&mut self, cache_path: &Path, stats: &mut WalkStats) {
@@ -624,7 +637,7 @@ pub(crate) fn aggregate_walk_publish(
     spec: &HeadlineSpec,
 ) -> SpendingWalkResult {
     let counted = dedup_cached_entries(files, cache).into_counted();
-    aggregate_walk_publish_from_counted(
+    aggregate_counted_rollups(
         files,
         cache,
         &counted,
@@ -634,32 +647,8 @@ pub(crate) fn aggregate_walk_publish(
             now_secs,
             spec,
         },
-        WalkStats::default(),
+        true,
     )
-}
-
-fn aggregate_walk_publish_from_counted<C: CountedPayload>(
-    files: &[(&'static AgentDefinition, PathBuf)],
-    cache: &SpendingDiskCache,
-    counted: &[C],
-    workspace: Option<&SpendScope>,
-    headline: HeadlineContext<'_>,
-    stats: WalkStats,
-) -> SpendingWalkResult {
-    let aggregate = aggregate_counted_rollups(files, cache, counted, workspace, headline, true);
-
-    SpendingWalkResult {
-        spending: aggregate.spending,
-        workspace_tally: aggregate.workspace_tally,
-        workspace_headline_cutoff_secs: aggregate.workspace_headline_cutoff_secs,
-        workspace_live_baselines: aggregate.workspace_live_baselines,
-        workspace_day: aggregate.workspace_day,
-        provider_day: aggregate.provider_day,
-        day_cutoff_secs: aggregate.day_cutoff_secs,
-        days: aggregate.days,
-        models: aggregate.models,
-        stats,
-    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/crates/rimz/src/agents/spending/publish.rs
+++ b/crates/rimz/src/agents/spending/publish.rs
@@ -7,9 +7,9 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
-use super::SPENDING_TTL;
 use super::aggregate::{DaySpend, SpendTally, SpendWindow, Spending};
 use super::cache::peek_cache_version;
+use super::{SPENDING_TTL, SpendingWalkResult};
 
 /// Gates the aggregate meaning in provider-spending.json, independent of the
 /// raw per-file cache version. An older stamp reads as stale, so the producer
@@ -78,6 +78,18 @@ pub struct ProviderSpendingCache {
 }
 
 impl ProviderSpendingCache {
+    pub(crate) fn from_walk(result: &SpendingWalkResult, refreshed_at_ms: u64) -> Self {
+        Self {
+            version: PROVIDER_SPENDING_VERSION,
+            refreshed_at_ms,
+            day_by_provider: result.provider_day.clone(),
+            day_cutoff_secs: result.day_cutoff_secs,
+            days: result.days.clone(),
+            models: result.models.clone(),
+            spending: result.spending.clone(),
+        }
+    }
+
     /// Whether this cache carries the current published aggregate shape.
     pub fn is_current_version(&self) -> bool {
         self.version == PROVIDER_SPENDING_VERSION
@@ -147,6 +159,13 @@ pub fn write_provider_spending_cache_with_day(
         models: models.clone(),
         spending: spending.clone(),
     };
+    write_provider_spending_cache_value(path, &cache)
+}
+
+pub(crate) fn write_provider_spending_cache_value(
+    path: &Path,
+    cache: &ProviderSpendingCache,
+) -> bool {
     if let Some(on_disk) = peek_cache_version(path)
         && on_disk > cache.version
     {

--- a/crates/rimz/src/agents/spending/service.rs
+++ b/crates/rimz/src/agents/spending/service.rs
@@ -378,9 +378,8 @@ fn direct_fallback(
             .ensure_workspace_root()
             .map_err(|error| std::io::Error::other(error.to_string()))?;
     }
-    let mut walker = SpendingWalker::new();
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        super::engine::serve_direct(&mut walker, runtime, request)
+        super::engine::serve_direct(runtime, request)
     }))
     .map_err(|_| {
         SpendingServiceFailure::new(

--- a/crates/rimz/src/agents/transcript_fs.rs
+++ b/crates/rimz/src/agents/transcript_fs.rs
@@ -259,22 +259,15 @@ pub(crate) fn read_transcript_tail_with_status(path: &Path) -> Option<Transcript
     })
 }
 
-/// Read a torn-write-safe JSONL suffix from a transcript path, returning the
-/// consumed bytes and next cursor offset. Same cursor discipline as spending,
-/// exposed for `rimz agents wait --stream` without making the helper module public.
-pub fn read_transcript_lines(path: &Path, offset: u64) -> Option<(Vec<u8>, u64)> {
-    read_spend_lines(path, offset)
-}
-
 /// The consumable JSONL suffix of `path` past byte `offset`, plus the offset
-/// just past what was consumed — the incremental read every spend parser
-/// shares. Consumes every newline-terminated line, and the trailing fragment
-/// only when it is complete JSON: a writer appends whole lines, so a torn
-/// write is a strict prefix of a JSON document and never parses — it stays
-/// unconsumed for the next pass (the event log's torn-line discipline), while
-/// a final line still missing only its newline is counted without waiting.
+/// just past what was consumed — the incremental read transcript and spending
+/// parsers share. Consumes every newline-terminated line, and the trailing
+/// fragment only when it is complete JSON: a writer appends whole lines, so a
+/// torn write is a strict prefix of a JSON document and never parses — it stays
+/// unconsumed for the next pass (the event log's torn-line discipline), while a
+/// final line still missing only its newline is counted without waiting.
 /// `None` on any IO error or when nothing consumable lies past `offset`.
-pub(crate) fn read_spend_lines(path: &Path, offset: u64) -> Option<(Vec<u8>, u64)> {
+pub fn read_transcript_lines(path: &Path, offset: u64) -> Option<(Vec<u8>, u64)> {
     use std::io::{Read, Seek, SeekFrom};
     let mut file = fs::File::open(path).ok()?;
     file.seek(SeekFrom::Start(offset)).ok()?;
@@ -294,25 +287,26 @@ mod tests {
     use std::io::Write as _;
 
     #[test]
-    fn read_spend_lines_consumes_lines_and_complete_json_fragments_only() {
+    fn read_transcript_lines_consumes_lines_and_complete_json_fragments_only() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("log.jsonl");
         let mut f = fs::File::create(&path).unwrap();
         // One full line, then a torn write (a strict JSON prefix).
         f.write_all(b"{\"a\":1}\n{\"b\":").unwrap();
-        let (buf, next) = read_spend_lines(&path, 0).expect("the full line is consumable");
+        let (buf, next) = read_transcript_lines(&path, 0).expect("the full line is consumable");
         assert_eq!(buf, b"{\"a\":1}\n");
         assert_eq!(next, 8, "the torn fragment stays unconsumed");
 
         // The tear heals: the rest of the line lands. No newline yet, but the
         // fragment is complete JSON, so it is counted without waiting.
         f.write_all(b"2}").unwrap();
-        let (buf, next) = read_spend_lines(&path, next).expect("the healed line is consumable");
+        let (buf, next) =
+            read_transcript_lines(&path, next).expect("the healed line is consumable");
         assert_eq!(buf, b"{\"b\":2}");
         assert_eq!(next, 15);
 
         // Nothing new past the cursor.
-        assert!(read_spend_lines(&path, next).is_none());
+        assert!(read_transcript_lines(&path, next).is_none());
     }
 
     #[test]
@@ -411,6 +405,6 @@ mod tests {
         let tail = read_transcript_tail_with_status(&path).unwrap();
         assert_eq!(tail.text, "");
         assert!(!tail.torn_suffix);
-        assert!(read_spend_lines(&path, 0).is_none());
+        assert!(read_transcript_lines(&path, 0).is_none());
     }
 }

--- a/crates/rimz/src/cli/stats/mod.rs
+++ b/crates/rimz/src/cli/stats/mod.rs
@@ -15,13 +15,13 @@
 //! frame after five seconds, then repaints in place every minute and re-centres
 //! promptly after a width change.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::{IsTerminal, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock, mpsc};
 use std::thread;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 use anyhow::{Result, anyhow};
 use clap::Args;
@@ -34,16 +34,12 @@ use super::GlobalFlags;
 use crate::cli::render;
 use crate::cli::spinner::Spinner;
 use rimz::RuntimePaths;
-use rimz::agents::AgentDefinition;
-use rimz::agents::pricing;
 use rimz::agents::spending::{
-    DaySpend, ProviderSpendingCache, SilentWalk, SpendProgress, SpendTally, SpendWindow, Spending,
-    SpendingWalker, WalkObserver, WalkRequest, read_provider_spending_cache, unix_secs_now,
-    user_input, utc_date, write_provider_spending_cache_with_day,
+    DaySpend, ProviderSpendingCache, SpendProgress, SpendTally, SpendWindow, Spending,
+    read_provider_spending_cache, refresh_global_spending_direct, unix_secs_now, utc_date,
 };
 use rimz::config::{GlyphRole, MachineConfig, ThemeConfig};
 use rimz::store::paths::state_home;
-use rimz::store::single_flight::{Coalesced, coalesce};
 use rimz::tui::{MouseCapture, Screen, TerminalModeGuard};
 
 const DAY_SECS: i64 = 86_400;
@@ -67,8 +63,6 @@ const SPINNER_MIN_AGE: Duration = Duration::from_millis(150);
 const PROGRESS_BAR_WIDTH: usize = 20;
 const MIN_SHARE_BAR_WIDTH: usize = 10;
 const STAT_GUTTER: usize = 3;
-const SPENDING_WAIT_STEP: Duration = Duration::from_millis(20);
-const SPENDING_WAIT_STEPS: u32 = 15;
 const REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 const EMPTY_REFRESH_RETRY: Duration = Duration::from_secs(5);
 const REFRESH_POLL_TICK: Duration = Duration::from_millis(100);
@@ -254,8 +248,7 @@ fn load_stats_from_paths(paths: &RuntimePaths, human: bool) -> Result<LoadedStat
         return load_cold_stats_with_spinner(paths);
     }
 
-    let mut walker = SpendingWalker::new();
-    let stats = load_or_refresh_stats(paths, None, &mut walker)?;
+    let stats = load_or_refresh_stats(paths, None)?;
     Ok(LoadedStats {
         stats,
         header_printed: false,
@@ -271,47 +264,18 @@ fn load_published_stats(paths: &RuntimePaths) -> Option<Stats> {
 
 fn load_or_refresh_stats(
     paths: &RuntimePaths,
-    mut progress: Option<&mut dyn FnMut(SpendProgress)>,
-    walker: &mut SpendingWalker,
+    progress: Option<&mut dyn FnMut(SpendProgress)>,
 ) -> Result<Stats> {
     if let Some(stats) = load_published_stats(paths) {
         return Ok(stats);
     }
-    let fresh = || load_published_stats(paths);
-    match coalesce(
-        &paths.shared_spending_lock(),
-        SPENDING_WAIT_STEP,
-        SPENDING_WAIT_STEPS,
-        fresh,
-    ) {
-        Coalesced::Shared(stats) => Ok(stats),
-        Coalesced::Produce(_guard) => {
-            let now_secs = unix_secs_now();
-            let files = walker.discover_spending_files(now_secs);
-            if let Some(progress) = progress.as_deref_mut() {
-                progress(SpendProgress {
-                    finished_files: 0,
-                    total_files: files.len(),
-                });
-            }
-            Ok(compute_stats_from_files_at(
-                paths, files, true, progress, walker, now_secs,
-            ))
-        }
-        Coalesced::ProduceLocal => {
-            let now_secs = unix_secs_now();
-            let files = walker.discover_spending_files(now_secs);
-            if let Some(progress) = progress.as_deref_mut() {
-                progress(SpendProgress {
-                    finished_files: 0,
-                    total_files: files.len(),
-                });
-            }
-            Ok(compute_stats_from_files_at(
-                paths, files, false, progress, walker, now_secs,
-            ))
-        }
-    }
+    let spec = MachineConfig::load_lenient().headline_spec();
+    let provider = if let Some(progress) = progress {
+        refresh_global_spending_direct(paths, &spec, progress)
+    } else {
+        refresh_global_spending_direct(paths, &spec, &mut |_| {})
+    };
+    Ok(Stats::from_provider(provider))
 }
 
 fn load_or_refresh_stats_via_service(paths: &RuntimePaths) -> Result<Stats> {
@@ -336,103 +300,12 @@ fn load_direct_stats_with_progress(
     paths: &RuntimePaths,
     progress: &mut dyn FnMut(SpendProgress),
 ) -> Result<Stats> {
-    let mut walker = SpendingWalker::new();
-    load_or_refresh_stats(paths, Some(progress), &mut walker)
-}
-
-struct ProgressObserver<'a>(&'a mut dyn FnMut(SpendProgress));
-
-impl WalkObserver for ProgressObserver<'_> {
-    fn on_file(&mut self, progress: SpendProgress) {
-        (self.0)(progress);
-    }
-}
-
-#[cfg(test)]
-fn compute_stats_from_files(
-    paths: &RuntimePaths,
-    files: Vec<(&'static AgentDefinition, PathBuf)>,
-    publish: bool,
-    progress: Option<&mut dyn FnMut(SpendProgress)>,
-    walker: &mut SpendingWalker,
-) -> Stats {
-    compute_stats_from_files_at(paths, files, publish, progress, walker, unix_secs_now())
-}
-
-fn compute_stats_from_files_at(
-    paths: &RuntimePaths,
-    files: Vec<(&'static AgentDefinition, PathBuf)>,
-    publish: bool,
-    progress: Option<&mut dyn FnMut(SpendProgress)>,
-    walker: &mut SpendingWalker,
-    now_secs: u64,
-) -> Stats {
-    let cursor_path = paths.shared_spending_cursor_path();
-    let prices = if publish {
-        let unknowns = walker.recorded_unknown_models(&cursor_path, &files, now_secs);
-        Arc::new(pricing::load_for_spending(
-            &paths.shared_pricing_cache_path(),
-            &unknowns,
-        ))
-    } else {
-        pricing::cached_book(&paths.shared_pricing_cache_path())
-    };
-    let origin_overrides = HashMap::new();
-    let user_inputs = user_input::load();
-    let spec = MachineConfig::load_lenient().headline_spec();
-    let req = WalkRequest {
-        files: &files,
-        prices: &prices,
-        now_secs,
-        origin_overrides: &origin_overrides,
-        user_inputs: &user_inputs,
-        scope: None,
-        spec: &spec,
-    };
-    let result = match (publish, progress) {
-        (true, Some(progress)) => {
-            let mut observer = ProgressObserver(progress);
-            walker.walk(&cursor_path, &req, &mut observer)
-        }
-        (true, None) => {
-            let mut observer = SilentWalk;
-            walker.walk(&cursor_path, &req, &mut observer)
-        }
-        (false, _) => {
-            let mut observer = SilentWalk;
-            walker.walk_local(&cursor_path, &req, &mut observer)
-        }
-    };
-    if publish {
-        write_provider_spending_cache_with_day(
-            &paths.shared_provider_spending_path(),
-            unix_millis_now(),
-            &result.spending,
-            &result.days,
-            &result.models,
-            &result.provider_day,
-            result.day_cutoff_secs,
-        );
-    }
-    let Spending { total, by_provider } = result.spending;
-    Stats {
-        by_day: result.days,
-        by_model: result.models,
-        by_agent: by_provider,
-        total,
-    }
+    load_or_refresh_stats(paths, Some(progress))
 }
 
 fn ensure_shared_runtime(paths: &RuntimePaths) -> Result<()> {
     paths.ensure_shared_dirs()?;
     Ok(())
-}
-
-fn unix_millis_now() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
 }
 
 #[cfg(test)]

--- a/crates/rimz/src/cli/stats/tests.rs
+++ b/crates/rimz/src/cli/stats/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use rimz::theme::theme_glyphs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 fn day(tokens: u64, usd: f64) -> DaySpend {
     DaySpend { tokens, usd }
@@ -201,16 +201,14 @@ fn stats_serves_published_cache_without_walking() {
         .insert("claude".to_owned(), tally(120, 12.0, 3));
     rimz::agents::spending::write_provider_spending_cache_with_rollups(
         &runtime.shared_provider_spending_path(),
-        unix_millis_now(),
+        1,
         &spending,
         &by_day,
         &by_model,
     );
     let cursor_path = runtime.shared_spending_cursor_path();
     assert!(!cursor_path.exists());
-    let mut walker = SpendingWalker::new();
-
-    let stats = load_or_refresh_stats(&runtime, None, &mut walker).unwrap();
+    let stats = load_or_refresh_stats(&runtime, None).unwrap();
 
     assert_eq!(stats.by_day, by_day);
     assert_eq!(stats.by_model, by_model);
@@ -228,25 +226,46 @@ fn cold_refresh_publishes_sidebar_provider_rollups() {
     let runtime =
         RuntimePaths::under(rimz::WorkspaceId::from_project_root(dir.path()), dir.path()).unwrap();
     ensure_shared_runtime(&runtime).unwrap();
-    let transcript = write_jsonl(
+    let first = write_jsonl(
         dir.path(),
-        "claude.jsonl",
+        "claude-1.jsonl",
         &[&claude_line_today(1.25, "msg-1", "req-1")],
     );
-    let files = vec![(
-        rimz::agents::definition_by_kind("claude").unwrap(),
-        transcript.clone(),
-    )];
+    let second = write_jsonl(
+        dir.path(),
+        "claude-2.jsonl",
+        &[&claude_line_today(2.5, "msg-2", "req-2")],
+    );
+    let claude = rimz::agents::definition_by_kind("claude").unwrap();
+    let _discovery = rimz::agents::spending::override_discovered_spending_files_for_test(vec![
+        (claude, first.clone()),
+        (claude, second.clone()),
+    ]);
+    let mut progress = Vec::new();
+    let mut record_progress = |reading| progress.push(reading);
 
-    let mut walker = SpendingWalker::new();
-    let stats = compute_stats_from_files(&runtime, files, true, None, &mut walker);
+    let stats = load_or_refresh_stats(&runtime, Some(&mut record_progress)).unwrap();
     let published = read_provider_spending_cache(&runtime.shared_provider_spending_path());
     let fresh = load_published_stats(&runtime)
         .expect("published stats are current after a stats-owned refresh");
     let cursor =
         rimz::agents::spending::read_spending_cache(&runtime.shared_spending_cursor_path());
 
-    assert!(published.is_fresh(unix_millis_now()));
+    assert!(published.refreshed_at_ms > 0);
+    assert_eq!(
+        progress.first(),
+        Some(&SpendProgress {
+            finished_files: 0,
+            total_files: 2,
+        })
+    );
+    assert_eq!(
+        progress.last(),
+        Some(&SpendProgress {
+            finished_files: 2,
+            total_files: 2,
+        })
+    );
     assert!((published.spending.total.month.usd - stats.total.month.usd).abs() < 1e-9);
     assert!((fresh.total.month.usd - stats.total.month.usd).abs() < 1e-9);
     assert_eq!(
@@ -254,12 +273,14 @@ fn cold_refresh_publishes_sidebar_provider_rollups() {
         stats.total.month.tokens
     );
     assert_eq!(published.spending.by_provider, stats.by_agent);
-    assert!(
-        cursor
-            .files
-            .contains_key(&transcript.to_string_lossy().into_owned()),
-        "stats publishes the cursor cache that makes the next run history-independent"
-    );
+    for transcript in [first, second] {
+        assert!(
+            cursor
+                .files
+                .contains_key(&transcript.to_string_lossy().into_owned()),
+            "stats publishes the cursor cache that makes the next run history-independent"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Context

`crates/rimz/src/agents/` carries roughly 63k non-test lines, and an architecture survey found three places where the same knowledge was written twice.

Cold `rimz stats` reimplemented the spending producer. It had its own single-flight election on `shared_spending_lock`, its own discovery call, its own producer-versus-local price selection, its own `WalkRequest` construction, and its own provider publication — a second copy of the orchestration `agents/spending/engine.rs` already owned. The CLI layer is supposed to parse, call the domain, and present; spend arithmetic in a command handler is knowledge in the wrong module. `docs/internals/stats.md` already claimed "this module owns no spend arithmetic", which was aspirational rather than true.

Two smaller duplications sat nearby. `CountedRollups` and `SpendingWalkResult` repeated the same nine fields with a manual field-by-field conversion between them, and provider publication rebuilt the same `ProviderSpendingCache` after writing it. Separately, Claude, Pi, Qwen, and Copilot each carried a byte-identical seven-key array testing whether a hook payload contains context evidence, and `read_transcript_lines` was a pure pass-through to `read_spend_lines` — two names for one torn-write-safe JSONL suffix read.

This is a behavior-preserving pass: structure changes, observable behavior does not.

## Design choices

**Kept the ten caller-aligned capability traits.** Collapsing them was the highest-ranked candidate and was cut before any source edit. The partitions are the recorded post-migration target, and their traits ship in the `rimz` crate's public Rust interface, so removing them would break caller compilation — disqualifying in a behavior-preserving pass. Earlier history already rejected the two alternatives: optional per-workflow trait objects cost more in slots and forwarding than they hid, and one broad provider trait was deliberately passed over in favour of keeping defaults and workflow knowledge local. Empty impls are the cheaper price.

**Kept all three public provider-cache writer signatures.** `rimz` ships as a library, so `write_provider_spending_cache`, `write_provider_spending_cache_with_rollups`, and `write_provider_spending_cache_with_day` stay as-is with their exact defaults. They became thin constructors over one internal typed writer that alone owns downgrade protection, stale-temp sweep, and the atomic write. The shared implementation deepened; the interface did not move.

**Kept `ScopedSpending` separate from `SpendingWalkResult`.** It is a smaller scope-only contract with different leverage, not a duplicate full-rollup shape.

**Left Pi's parallel transcript and spending parsers alone.** They deserialize the same durable message row through two structs, but their malformed-field tolerance differs, so unification carries more risk than the small line count would win back.

## Implementation

Two commits, ordered as independent passes.

**`refactor(spending): unify direct refresh and publication`.** `aggregate_counted_rollups` now returns `SpendingWalkResult` directly and the walker stamps `WalkStats` once after aggregation; `CountedRollups` and the nine-field conversion are gone. `ProviderSpendingCache::from_walk` is the single conversion from a walk result plus a refresh stamp, and the same value is both written and returned rather than reconstructed. Cold stats now calls one direct-global engine entry, and `cli/stats/mod.rs` maps the returned cache to `Stats` and nothing else — `ProgressObserver`, `compute_stats_from_files*`, a local timestamp helper, and the duplicated wait constants are deleted. Direct CLI progress still runs in-process and does not traverse the framed warm-owner transport, so spinner timing and service wire frames are untouched.

**`refactor(agents): centralize context and transcript parsing`.** `payload_has_context_observation` joins `payload_context_pct` and `payload_total_tokens` in `agents/observation.rs`, replacing the four copied key arrays; a table test pins that presence counts as evidence even when the provider reports JSON null. The torn-write-safe reader implementation and its full contract doc move onto `read_transcript_lines` and `read_spend_lines` is deleted, shrinking the public surface from one `pub` wrapper plus one `pub(crate)` implementation to one function.

Source-only change is 208 insertions against 339 deletions, a net reduction of 131 lines; including tests the diff is 253 against 365.

Two deviations from the plan, both forced by the binary/library split. The plan called the direct global entry internal, but `cli/` is a separate binary crate consuming the `rimz` library, so it landed as a `#[doc(hidden)] pub` seam — the existing convention for internal, unsupported API in this crate. For the same reason the thread-local discovery override the stats tests need widened from `cfg(test) pub(crate)` to `cfg(any(test, feature = "testkit")) #[doc(hidden)] pub`, matching `state.rs`, `session.rs`, and `adapters/cursor/session.rs`. `testkit` is non-default and stripped from shipped binaries, so production builds carry neither.

**Evidence the pass preserved behavior.** `ProviderSpendingCache::from_walk` is field-identical to the construction it replaces, including the empty-walk branch. The stats short-circuit ladder is unchanged: any current-version publication still returns before the engine is entered. The engine coalesces on the same `shared_spending_lock` with the same 20ms × 15 wait budget the deleted stats copy used, and its Produce and ProduceLocal arms take the same publish decisions. Stats passes no project root, so it derives no workspace scope and never writes or prunes workspace-spending files. The new zero-progress emission is not a wire change — both framed service callers discard progress, and the walker's own per-file tick fires only after a file completes, so the cold CLI sequence is unchanged. `cargo xtask gate` passes; `cargo xtask test` reports 1175 agents, 107 spending, and 120 stats tests green; `cargo xtask sandbox -- rimz stats --json` returns valid empty-account JSON.

## Advisories

One behavior delta is worth naming rather than burying. Cold stats now inherits the engine's non-authoritative-empty-discovery rule, which it previously lacked. Where the old path walked zero files and published a current-version zero aggregate, the new path returns the prior publication unwalked. Because the current-version short-circuit runs first, the only cache reachable in that branch is a version-mismatched one, which then renders as if current. Reaching it needs a stale-version cache with nonzero spend plus a discovery scan driven non-authoritative by an I/O failure — a permission error or an unavailable network home, not a normal cold start. The new behavior is the safer of the two and is the rule every other spending consumer already follows; adding a stats-only special case back would be a shallower fix than the shared rule it would bypass. Flagged for a decision rather than silently kept.

Three cleanups were left for a follow-up. `load_direct_stats_with_progress` is now a one-line forward to `load_or_refresh_stats` with a doc comment referring to a local walker the module no longer has, and its single caller is a sibling submodule that could call through directly — the same pass-through shape this PR deletes elsewhere. The `#[cfg(test)]` helper `walk_request_for_test` still hand-builds the request context that the newly added `request_context` helper now produces. And the cold-refresh test traded `is_fresh` for a nonzero-stamp assertion when the local timestamp helper was deleted, so TTL freshness is no longer pinned on that path; current-version coverage survives indirectly through the published-stats read.
