### PR TITLE
Refactor store transaction and projection seams

### DIFF
--- a/crates/rimz/src/cli/hooks/lifecycle/observe.rs
+++ b/crates/rimz/src/cli/hooks/lifecycle/observe.rs
@@ -330,14 +330,37 @@ fn log_lifecycle_receipt(
         }
     }
 
-    for derived in &receipt.derived {
-        log_transition(
+    for event in receipt
+        .events
+        .iter()
+        .filter(|event| receipt.primary_event_id.as_ref() != Some(&event.event_id))
+    {
+        log_canonical_transition(kind, event);
+    }
+}
+
+fn log_canonical_transition(kind: &str, event: &rimz::agents::LifecycleEvent) {
+    match &event.transition {
+        rimz::agents::LifecycleTransition::Reconciled { from, reason } => warn!(
+            target: "rimz::agent::lifecycle",
             kind,
-            derived.agent_id.as_str(),
-            derived.parent_agent_id.as_deref(),
-            &derived.signal,
-            derived.transition,
-        );
+            agent_id = event.agent_id.as_str(),
+            parent_agent_id = event.parent_agent_id.as_deref().unwrap_or(""),
+            from = ?from,
+            to = ?event.status,
+            signal = ?event.signal,
+            reason,
+            "reconciled lifecycle transition",
+        ),
+        rimz::agents::LifecycleTransition::Ignored { reason } => debug!(
+            target: "rimz::agent::lifecycle",
+            kind,
+            agent_id = event.agent_id.as_str(),
+            signal = ?event.signal,
+            reason,
+            "ignored lifecycle signal",
+        ),
+        rimz::agents::LifecycleTransition::Normal => {}
     }
 }
 

--- a/crates/rimz/src/room/birth.rs
+++ b/crates/rimz/src/room/birth.rs
@@ -315,7 +315,7 @@ impl RoomContext {
             .record_workspace(&self.workspace)
             .context("recording workspace metadata for reset")?;
         let records = store
-            .reset_records(&self.workspace.session_name, hard)
+            .reset_records(hard)
             .context("resetting workspace records")?;
         Ok(RoomResetReport { teardown, records })
     }

--- a/crates/rimz/src/store/active_time.rs
+++ b/crates/rimz/src/store/active_time.rs
@@ -6,11 +6,6 @@
 //! cannot accrue forever. The files are runtime-sidecar projection inputs, not
 //! durable event-log truth.
 
-use std::cell::RefCell;
-use std::collections::{BTreeSet, HashMap};
-use std::fs::{File, OpenOptions};
-use std::path::PathBuf;
-
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
@@ -153,73 +148,26 @@ fn update_record(
     at: Timestamp,
     update: impl FnOnce(&mut ActiveTimeRecord, bool) -> bool,
 ) -> Result<bool, atomic::AtomicErr> {
-    let _lock = RecordLock::acquire(runtime, kind, agent_id)?;
-    let prior = sidecar::read_one(&runtime.active_time_dir, kind, agent_id);
-    let existed = prior.is_some();
-    let mut record = prior.unwrap_or_else(|| ActiveTimeRecord {
-        kind: AgentKind::new_unchecked(kind),
-        agent_id: agent_id.into(),
-        credited_ms: 0,
-        last_progress: at,
-        active: false,
-    });
-    if !update(&mut record, existed) {
-        return Ok(false);
-    }
-    sidecar::write_record(&runtime.active_time_dir, &record)?;
-    Ok(true)
-}
-
-struct RecordLock {
-    file: File,
-}
-
-impl RecordLock {
-    fn acquire(
-        runtime: &RuntimePaths,
-        kind: &str,
-        agent_id: &str,
-    ) -> Result<Self, atomic::AtomicErr> {
-        std::fs::create_dir_all(&runtime.active_time_dir).map_err(|source| {
-            atomic::AtomicErr::Io {
-                path: runtime.active_time_dir.clone(),
-                source,
-            }
-        })?;
-        let path = sidecar::lock_path(
-            &runtime.active_time_dir,
-            <ActiveTimeRecord as sidecar::SidecarRecord>::FILE_PREFIX,
-            kind,
-            agent_id,
-        );
-        let file = OpenOptions::new()
-            .create(true)
-            .read(true)
-            .write(true)
-            .truncate(false)
-            .open(&path)
-            .map_err(|source| atomic::AtomicErr::Io {
-                path: path.clone(),
-                source,
-            })?;
-        file.lock()
-            .map_err(|source| atomic::AtomicErr::Io { path, source })?;
-        Ok(Self { file })
-    }
-}
-
-impl Drop for RecordLock {
-    fn drop(&mut self) {
-        let _ = self.file.unlock();
-    }
+    sidecar::update(
+        &runtime.active_time_dir,
+        kind,
+        agent_id,
+        || ActiveTimeRecord {
+            kind: AgentKind::new_unchecked(kind),
+            agent_id: agent_id.into(),
+            credited_ms: 0,
+            last_progress: at,
+            active: false,
+        },
+        update,
+    )
 }
 
 thread_local! {
     /// The long-lived consumer pays one stat per queried live identity and
     /// reparses only records whose atomic rename changed `(mtime, len)`.
     static ACTIVE_TIME_PARSE_CACHE:
-        RefCell<HashMap<PathBuf, sidecar::ParsedSidecar<ActiveTimeRecord>>> =
-        RefCell::new(HashMap::new());
+        sidecar::ParseCache<ActiveTimeRecord> = sidecar::ParseCache::default();
 }
 
 /// Read records only for identities already present in the snapshot.
@@ -227,52 +175,8 @@ pub fn read_for_keys<'a>(
     runtime: &RuntimePaths,
     keys: impl IntoIterator<Item = (&'a str, &'a str)>,
 ) -> Vec<ActiveTimeRecord> {
-    let mut seen = BTreeSet::new();
-    ACTIVE_TIME_PARSE_CACHE.with_borrow_mut(|cache| {
-        let records = keys
-            .into_iter()
-            .filter_map(|(kind, agent_id)| {
-                let path = sidecar::path(
-                    &runtime.active_time_dir,
-                    <ActiveTimeRecord as sidecar::SidecarRecord>::FILE_PREFIX,
-                    kind,
-                    agent_id,
-                );
-                if !seen.insert(path.clone()) {
-                    return None;
-                }
-                let Ok(meta) = std::fs::metadata(&path) else {
-                    cache.remove(&path);
-                    return None;
-                };
-                let mtime = meta.modified().ok()?;
-                let len = meta.len();
-                let record = match cache.get(&path) {
-                    Some(parsed) if parsed.mtime == mtime && parsed.len == len => {
-                        parsed.record.clone()
-                    }
-                    _ => {
-                        let record = std::fs::read(&path)
-                            .ok()
-                            .and_then(|bytes| serde_json::from_slice(&bytes).ok());
-                        cache.insert(
-                            path,
-                            sidecar::ParsedSidecar {
-                                mtime,
-                                len,
-                                record: record.clone(),
-                            },
-                        );
-                        record
-                    }
-                }?;
-                (record.kind.as_str() == kind && record.agent_id.as_str() == agent_id)
-                    .then_some(record)
-            })
-            .collect();
-        cache.retain(|path, _| seen.contains(path));
-        records
-    })
+    ACTIVE_TIME_PARSE_CACHE
+        .with(|cache| sidecar::read_for_keys(&runtime.active_time_dir, keys, cache))
 }
 
 #[cfg(test)]

--- a/crates/rimz/src/store/agent_context.rs
+++ b/crates/rimz/src/store/agent_context.rs
@@ -18,10 +18,6 @@
 //! durable truth: nothing here reaches the event log, and the
 //! `cargo xtask invariants` greps enforce that boundary.
 
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::path::PathBuf;
-
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
@@ -199,42 +195,19 @@ pub fn update_record(
     observed_at: Timestamp,
     update: impl FnOnce(&mut AgentContextRecord, bool) -> bool,
 ) -> Result<bool, atomic::AtomicErr> {
-    let _lock = sidecar::RecordLock::acquire(
+    sidecar::update(
         &runtime.agent_context_dir,
-        <AgentContextRecord as sidecar::SidecarRecord>::FILE_PREFIX,
         kind,
         agent_id,
-    )?;
-    let prior = read_one_unlocked(runtime, kind, agent_id);
-    let existed = prior.is_some();
-    let mut record =
-        prior.unwrap_or_else(|| new_record(kind, agent_id, AgentContext::new(kind, observed_at)));
-    if !update(&mut record, existed) {
-        return Ok(false);
-    }
-    write_record_unlocked(runtime, &record)?;
-    Ok(true)
-}
-
-fn write_record_unlocked(
-    runtime: &RuntimePaths,
-    record: &AgentContextRecord,
-) -> Result<(), atomic::AtomicErr> {
-    sidecar::write_record(&runtime.agent_context_dir, record)
+        || new_record(kind, agent_id, AgentContext::new(kind, observed_at)),
+        update,
+    )
 }
 
 /// Read one sidecar directly from disk, bypassing the long-lived parse cache.
 /// Writers use this before a read-modify-write so they merge against the latest
 /// published bytes, not the last value a sidebar consumer happened to parse.
 pub fn read_one(runtime: &RuntimePaths, kind: &str, agent_id: &str) -> Option<AgentContextRecord> {
-    read_one_unlocked(runtime, kind, agent_id)
-}
-
-fn read_one_unlocked(
-    runtime: &RuntimePaths,
-    kind: &str,
-    agent_id: &str,
-) -> Option<AgentContextRecord> {
     sidecar::read_one(&runtime.agent_context_dir, kind, agent_id)
 }
 
@@ -473,8 +446,8 @@ thread_local! {
     /// freshly-written temp file, so `(mtime, len)` validates content; the
     /// long-lived consumer fetch thread re-reads these sidecars on every
     /// wakeup, and this caps its steady-state cost at one stat per file.
-    static CONTEXT_PARSE_CACHE: RefCell<HashMap<PathBuf, sidecar::ParsedSidecar<AgentContextRecord>>> =
-        RefCell::new(HashMap::new());
+    static CONTEXT_PARSE_CACHE: sidecar::ParseCache<AgentContextRecord> =
+        sidecar::ParseCache::default();
 }
 
 /// Read every session's context sidecar. Tolerant: an unreadable or malformed
@@ -489,17 +462,11 @@ pub fn read_all(runtime: &RuntimePaths) -> Vec<AgentContextRecord> {
 /// Remove a session's sidecar on `SessionEnd` or reap. Best-effort:
 /// a missing file is success.
 pub fn remove(runtime: &RuntimePaths, kind: &str, agent_id: &str) -> std::io::Result<()> {
-    let _lock = sidecar::RecordLock::acquire(
-        &runtime.agent_context_dir,
-        <AgentContextRecord as sidecar::SidecarRecord>::FILE_PREFIX,
-        kind,
-        agent_id,
-    )
-    .map_err(|error| match error {
-        atomic::AtomicErr::Io { source, .. } => source,
-        atomic::AtomicErr::Json(source) => std::io::Error::other(source),
-    })?;
-    sidecar::remove::<AgentContextRecord>(&runtime.agent_context_dir, kind, agent_id)
+    sidecar::remove_locked::<AgentContextRecord>(&runtime.agent_context_dir, kind, agent_id)
+        .map_err(|error| match error {
+            atomic::AtomicErr::Io { source, .. } => source,
+            atomic::AtomicErr::Json(source) => std::io::Error::other(source),
+        })
 }
 
 #[cfg(test)]

--- a/crates/rimz/src/store/mod.rs
+++ b/crates/rimz/src/store/mod.rs
@@ -79,8 +79,7 @@ pub use crate::store::workspace_record::WorkspaceRecord;
 pub(crate) use crate::store::writer::DeliverySweepUpdate;
 pub use crate::store::writer::{
     AgentLifecycleIntent, AgentLifecycleReceipt, DEFAULT_EVENT_LOG_ROTATE_BYTES, DeliveryAck,
-    DeliveryFailureDisposition, DerivedLifecycleKind, DerivedLifecycleOutcome, EditOutcome,
-    LifecycleAppendOutcome, MessageEdit,
+    DeliveryFailureDisposition, EditOutcome, MessageEdit,
 };
 
 /// Terminal audit-only message outcome for a target that never resolved to a

--- a/crates/rimz/src/store/sidecar.rs
+++ b/crates/rimz/src/store/sidecar.rs
@@ -8,7 +8,6 @@
 //! consumers keep a per-thread `(mtime, len)` parse cache, capping steady-state
 //! scans at one stat per file per tick.
 
-use std::cell::RefCell;
 use std::collections::{BTreeSet, HashMap};
 use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
@@ -27,10 +26,18 @@ pub(crate) trait SidecarRecord: Serialize + DeserializeOwned + Clone {
     fn agent_id(&self) -> &str;
 }
 
-pub(crate) struct ParsedSidecar<R> {
-    pub mtime: SystemTime,
-    pub len: u64,
-    pub record: Option<R>,
+struct ParsedSidecar<R> {
+    mtime: SystemTime,
+    len: u64,
+    record: Option<R>,
+}
+
+pub(crate) struct ParseCache<R>(std::cell::RefCell<HashMap<PathBuf, ParsedSidecar<R>>>);
+
+impl<R> Default for ParseCache<R> {
+    fn default() -> Self {
+        Self(std::cell::RefCell::new(HashMap::new()))
+    }
 }
 
 pub(crate) fn path(dir: &Path, prefix: &str, kind: &str, agent_id: &str) -> PathBuf {
@@ -42,18 +49,18 @@ pub(crate) fn path(dir: &Path, prefix: &str, kind: &str, agent_id: &str) -> Path
     dir.join(format!("{prefix}.{}.json", &digest[..32]))
 }
 
-pub(crate) fn lock_path(dir: &Path, prefix: &str, kind: &str, agent_id: &str) -> PathBuf {
+fn lock_path(dir: &Path, prefix: &str, kind: &str, agent_id: &str) -> PathBuf {
     path(dir, prefix, kind, agent_id).with_extension("lock")
 }
 
 /// Per-record advisory lock shared by sidecar writers that need an atomic
 /// read-modify-write across independent CLI processes.
-pub(crate) struct RecordLock {
+struct RecordLock {
     file: File,
 }
 
 impl RecordLock {
-    pub(crate) fn acquire(
+    fn acquire(
         dir: &Path,
         prefix: &str,
         kind: &str,
@@ -86,10 +93,7 @@ impl Drop for RecordLock {
     }
 }
 
-pub(crate) fn write_record<R: SidecarRecord>(
-    dir: &Path,
-    record: &R,
-) -> Result<(), atomic::AtomicErr> {
+fn write_record<R: SidecarRecord>(dir: &Path, record: &R) -> Result<(), atomic::AtomicErr> {
     atomic::write_temp_then_rename_cache(
         &path(dir, R::FILE_PREFIX, record.kind(), record.agent_id()),
         record,
@@ -104,27 +108,50 @@ pub(crate) fn read_one<R: SidecarRecord>(dir: &Path, kind: &str, agent_id: &str)
     (record.kind() == kind && record.agent_id() == agent_id).then_some(record)
 }
 
-pub(crate) fn remove<R: SidecarRecord>(
+/// Mutate one record against its latest published bytes under the canonical
+/// per-record lock. Missing, malformed, or key-mismatched bytes use `default`;
+/// returning `false` leaves the file untouched.
+pub(crate) fn update<R: SidecarRecord>(
     dir: &Path,
     kind: &str,
     agent_id: &str,
-) -> std::io::Result<()> {
-    match fs::remove_file(path(dir, R::FILE_PREFIX, kind, agent_id)) {
+    default: impl FnOnce() -> R,
+    apply: impl FnOnce(&mut R, bool) -> bool,
+) -> Result<bool, atomic::AtomicErr> {
+    let _lock = RecordLock::acquire(dir, R::FILE_PREFIX, kind, agent_id)?;
+    let prior = read_one(dir, kind, agent_id);
+    let existed = prior.is_some();
+    let mut record = prior.unwrap_or_else(default);
+    if !apply(&mut record, existed) {
+        return Ok(false);
+    }
+    atomic::write_temp_then_rename_cache(&path(dir, R::FILE_PREFIX, kind, agent_id), &record)?;
+    Ok(true)
+}
+
+pub(crate) fn remove_locked<R: SidecarRecord>(
+    dir: &Path,
+    kind: &str,
+    agent_id: &str,
+) -> Result<(), atomic::AtomicErr> {
+    let _lock = RecordLock::acquire(dir, R::FILE_PREFIX, kind, agent_id)?;
+    let record_path = path(dir, R::FILE_PREFIX, kind, agent_id);
+    match fs::remove_file(&record_path) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(err) => Err(err),
+        Err(source) => Err(atomic::AtomicErr::Io {
+            path: record_path,
+            source,
+        }),
     }
 }
 
-pub(crate) fn read_all<R: SidecarRecord>(
-    dir: &Path,
-    cache: &RefCell<HashMap<PathBuf, ParsedSidecar<R>>>,
-) -> Vec<R> {
+pub(crate) fn read_all<R: SidecarRecord>(dir: &Path, cache: &ParseCache<R>) -> Vec<R> {
     let Ok(entries) = fs::read_dir(dir) else {
         return Vec::new();
     };
     let mut out = Vec::new();
-    let mut cache = cache.borrow_mut();
+    let mut cache = cache.0.borrow_mut();
     let mut seen: BTreeSet<PathBuf> = BTreeSet::new();
     for entry in entries.flatten() {
         let path = entry.path();
@@ -159,6 +186,56 @@ pub(crate) fn read_all<R: SidecarRecord>(
     out
 }
 
+/// Read only requested live identities, deduplicating their canonical paths.
+/// Each unchanged `(mtime, len)` serves the per-thread cached parse, including
+/// cached failures; dropped keys and vanished files leave no cache entry.
+pub(crate) fn read_for_keys<'a, R: SidecarRecord>(
+    dir: &Path,
+    keys: impl IntoIterator<Item = (&'a str, &'a str)>,
+    cache: &ParseCache<R>,
+) -> Vec<R> {
+    let mut seen = BTreeSet::new();
+    let mut cache = cache.0.borrow_mut();
+    let records = keys
+        .into_iter()
+        .filter_map(|(kind, agent_id)| {
+            let record_path = path(dir, R::FILE_PREFIX, kind, agent_id);
+            if !seen.insert(record_path.clone()) {
+                return None;
+            }
+            let Ok(meta) = fs::metadata(&record_path) else {
+                cache.remove(&record_path);
+                return None;
+            };
+            let Ok(mtime) = meta.modified() else {
+                cache.remove(&record_path);
+                return None;
+            };
+            let len = meta.len();
+            let record = match cache.get(&record_path) {
+                Some(parsed) if parsed.mtime == mtime && parsed.len == len => parsed.record.clone(),
+                _ => {
+                    let record = fs::read(&record_path)
+                        .ok()
+                        .and_then(|bytes| serde_json::from_slice(&bytes).ok());
+                    cache.insert(
+                        record_path,
+                        ParsedSidecar {
+                            mtime,
+                            len,
+                            record: record.clone(),
+                        },
+                    );
+                    record
+                }
+            }?;
+            (record.kind() == kind && record.agent_id() == agent_id).then_some(record)
+        })
+        .collect();
+    cache.retain(|path, _| seen.contains(path));
+    records
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -166,8 +243,7 @@ mod tests {
     use tempfile::tempdir;
 
     thread_local! {
-        static TEST_PARSE_CACHE: RefCell<HashMap<PathBuf, ParsedSidecar<TestRecord>>> =
-            RefCell::new(HashMap::new());
+        static TEST_PARSE_CACHE: ParseCache<TestRecord> = ParseCache::default();
     }
 
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -201,6 +277,13 @@ mod tests {
 
     fn read_all_test(dir: &Path) -> Vec<TestRecord> {
         TEST_PARSE_CACHE.with(|cache| read_all(dir, cache))
+    }
+
+    fn read_keys_test<'a>(
+        dir: &Path,
+        keys: impl IntoIterator<Item = (&'a str, &'a str)>,
+    ) -> Vec<TestRecord> {
+        TEST_PARSE_CACHE.with(|cache| read_for_keys(dir, keys, cache))
     }
 
     #[test]
@@ -268,14 +351,14 @@ mod tests {
         write_record(dir.path(), &record("sess-1", 1_700_000_000)).unwrap();
         write_record(dir.path(), &record("sess-2", 1_700_000_000)).unwrap();
 
-        remove::<TestRecord>(dir.path(), "codex", "sess-1").unwrap();
+        remove_locked::<TestRecord>(dir.path(), "codex", "sess-1").unwrap();
 
         let ids: Vec<_> = read_all_test(dir.path())
             .into_iter()
             .map(|record| record.agent_id)
             .collect();
         assert_eq!(ids, vec!["sess-2".to_owned()]);
-        remove::<TestRecord>(dir.path(), "codex", "sess-1").unwrap();
+        remove_locked::<TestRecord>(dir.path(), "codex", "sess-1").unwrap();
     }
 
     #[test]
@@ -306,6 +389,155 @@ mod tests {
             read_all_test(dir.path())[0].note,
             "cached",
             "same (mtime, len) still serves the cached parse"
+        );
+    }
+
+    #[test]
+    fn locked_update_creates_defaults_skips_no_ops_and_reads_latest_bytes() {
+        let dir = tempdir().unwrap();
+        assert!(
+            !update(
+                dir.path(),
+                "codex",
+                "sess-1",
+                || record("sess-1", 1),
+                |_, existed| {
+                    assert!(!existed);
+                    false
+                },
+            )
+            .unwrap()
+        );
+        assert!(!path(dir.path(), "test", "codex", "sess-1").exists());
+
+        assert!(
+            update(
+                dir.path(),
+                "codex",
+                "sess-1",
+                || record("sess-1", 1),
+                |record, existed| {
+                    assert!(!existed);
+                    record.note = "created".to_owned();
+                    true
+                },
+            )
+            .unwrap()
+        );
+        assert_eq!(
+            read_one::<TestRecord>(dir.path(), "codex", "sess-1")
+                .unwrap()
+                .note,
+            "created"
+        );
+
+        assert_eq!(read_all_test(dir.path())[0].note, "created");
+        let record_path = path(dir.path(), "test", "codex", "sess-1");
+        let mut latest = read_one::<TestRecord>(dir.path(), "codex", "sess-1").unwrap();
+        latest.note = "direct!".to_owned();
+        std::fs::write(&record_path, serde_json::to_vec(&latest).unwrap()).unwrap();
+        assert!(
+            update(
+                dir.path(),
+                "codex",
+                "sess-1",
+                || record("sess-1", 2),
+                |record, existed| {
+                    assert!(existed);
+                    record.note.push_str(" updated");
+                    true
+                },
+            )
+            .unwrap()
+        );
+        assert_eq!(
+            read_one::<TestRecord>(dir.path(), "codex", "sess-1")
+                .unwrap()
+                .note,
+            "direct! updated"
+        );
+    }
+
+    #[test]
+    fn keyed_reads_dedupe_validate_and_evict_dead_keys() {
+        let dir = tempdir().unwrap();
+        write_record(dir.path(), &record("sess-1", 1)).unwrap();
+        write_record(dir.path(), &record("sess-2", 2)).unwrap();
+        assert_eq!(
+            read_keys_test(
+                dir.path(),
+                [
+                    ("codex", "sess-1"),
+                    ("codex", "sess-1"),
+                    ("codex", "sess-2"),
+                ],
+            )
+            .len(),
+            2
+        );
+
+        let wrong_path = path(dir.path(), "test", "codex", "wrong");
+        std::fs::write(
+            &wrong_path,
+            serde_json::to_vec(&record("different", 3)).unwrap(),
+        )
+        .unwrap();
+        assert!(read_keys_test(dir.path(), [("codex", "wrong")]).is_empty());
+
+        read_keys_test(dir.path(), [("codex", "sess-1"), ("codex", "sess-2")]);
+        read_keys_test(dir.path(), [("codex", "sess-1")]);
+        let sess_2_path = path(dir.path(), "test", "codex", "sess-2");
+        std::fs::write(&sess_2_path, b"malformed").unwrap();
+        assert!(
+            read_keys_test(dir.path(), [("codex", "sess-2")]).is_empty(),
+            "a dropped key must not retain its prior cached parse"
+        );
+    }
+
+    #[test]
+    fn keyed_reads_cache_success_and_failure_at_the_same_stamp() {
+        let dir = tempdir().unwrap();
+        write_record(dir.path(), &record("sess-1", 1)).unwrap();
+        let record_path = path(dir.path(), "test", "codex", "sess-1");
+        assert_eq!(read_keys_test(dir.path(), [("codex", "sess-1")]).len(), 1);
+        let original = std::fs::read(&record_path).unwrap();
+        let mtime = std::fs::metadata(&record_path).unwrap().modified().unwrap();
+        let swapped = String::from_utf8(original)
+            .unwrap()
+            .replace("cached", "direct");
+        std::fs::write(&record_path, swapped).unwrap();
+        File::options()
+            .write(true)
+            .open(&record_path)
+            .unwrap()
+            .set_modified(mtime)
+            .unwrap();
+        assert_eq!(
+            read_keys_test(dir.path(), [("codex", "sess-1")])[0].note,
+            "cached",
+            "same-stamp success serves the cached parse"
+        );
+
+        let malformed_path = path(dir.path(), "test", "codex", "sess-bad");
+        let valid = serde_json::to_vec(&record("sess-bad", 2)).unwrap();
+        let mut malformed = valid.clone();
+        malformed[0] = b'!';
+        std::fs::write(&malformed_path, &malformed).unwrap();
+        let mtime = std::fs::metadata(&malformed_path)
+            .unwrap()
+            .modified()
+            .unwrap();
+        assert!(read_keys_test(dir.path(), [("codex", "sess-bad")]).is_empty());
+        std::fs::write(&malformed_path, valid).unwrap();
+        File::options()
+            .write(true)
+            .open(&malformed_path)
+            .unwrap()
+            .set_modified(mtime)
+            .unwrap();
+        assert!(
+            read_keys_test(dir.path(), [("codex", "sess-bad")]).is_empty(),
+            "same-stamp malformed bytes stay negative-cached"
         );
     }
 }

--- a/crates/rimz/src/store/sidecar.rs
+++ b/crates/rimz/src/store/sidecar.rs
@@ -93,6 +93,7 @@ impl Drop for RecordLock {
     }
 }
 
+#[cfg(test)]
 fn write_record<R: SidecarRecord>(dir: &Path, record: &R) -> Result<(), atomic::AtomicErr> {
     atomic::write_temp_then_rename_cache(
         &path(dir, R::FILE_PREFIX, record.kind(), record.agent_id()),

--- a/crates/rimz/src/store/snapshot/assemble.rs
+++ b/crates/rimz/src/store/snapshot/assemble.rs
@@ -78,10 +78,11 @@ fn assemble_snapshot(
     snapshot.fenced_sessions = ended;
     snapshot.fenced_sessions.extend(expelled);
     snapshot.reap_stale_sessions();
-    snapshot.display_name = display_name_for(paths);
+    let identity = WorkspaceSnapshotIdentity::from_paths(paths);
+    snapshot.display_name = identity.display_name;
     let mut snapshot = snapshot
-        .with_root_class(root_class_for(paths))
-        .with_project_root(project_root_for(paths));
+        .with_root_class(identity.root_class)
+        .with_project_root(identity.project_root);
     // Stamp the extent the fold consumed. The freshness gate compares it
     // against the live log length, so a racing append can never pass a
     // stale rollup off as current.
@@ -154,51 +155,57 @@ thread_local! {
     static LATEST_PARSE_CACHE: ParseCache<SidebarSnapshot> = const { ParseCache::new() };
 }
 
-pub(crate) fn display_name_for(paths: &StatePaths) -> String {
-    let record = match workspace_record::read(&paths.workspace_record) {
-        Ok(record) => record,
-        Err(WorkspaceRecordErr::Io { source, .. })
-            if source.kind() == std::io::ErrorKind::NotFound =>
-        {
-            return paths.workspace_id.as_str().to_owned();
-        }
-        Err(err) => {
-            tracing::debug!(
-                path = %paths.workspace_record.display(),
-                error = %err,
-                "workspace record is unreadable while resolving the display name",
-            );
-            return paths.workspace_id.as_str().to_owned();
-        }
-    };
-    let root = crate::worktree::normalize_path_lexical(&record.project_root);
-    let Some(name) = root
-        .file_name()
-        .and_then(|name| name.to_str())
-        .filter(|name| !name.is_empty())
-    else {
-        tracing::debug!(
-            root = %root.display(),
-            "workspace project root has no usable display name",
-        );
-        return paths.workspace_id.as_str().to_owned();
-    };
-    name.to_owned()
+struct WorkspaceSnapshotIdentity {
+    display_name: String,
+    project_root: Option<PathBuf>,
+    root_class: RootClass,
 }
 
-pub(crate) fn project_root_for(paths: &StatePaths) -> Option<PathBuf> {
-    workspace_record::read(&paths.workspace_record)
-        .ok()
-        .map(|record| record.project_root)
-}
+impl WorkspaceSnapshotIdentity {
+    fn fallback(paths: &StatePaths) -> Self {
+        Self {
+            display_name: paths.workspace_id.as_str().to_owned(),
+            project_root: None,
+            root_class: RootClass::Repo,
+        }
+    }
 
-/// The room root's class from the workspace record, defaulting to `Repo` (the
-/// prior grouping) when the record is missing or pre-dates the field.
-pub(crate) fn root_class_for(paths: &StatePaths) -> RootClass {
-    workspace_record::read(&paths.workspace_record)
-        .ok()
-        .map(|record| record.root_class)
-        .unwrap_or(RootClass::Repo)
+    fn from_paths(paths: &StatePaths) -> Self {
+        let record = match workspace_record::read(&paths.workspace_record) {
+            Ok(record) => record,
+            Err(WorkspaceRecordErr::Io { source, .. })
+                if source.kind() == std::io::ErrorKind::NotFound =>
+            {
+                return Self::fallback(paths);
+            }
+            Err(err) => {
+                tracing::debug!(
+                    path = %paths.workspace_record.display(),
+                    error = %err,
+                    "workspace record is unreadable while resolving snapshot identity",
+                );
+                return Self::fallback(paths);
+            }
+        };
+        let root = crate::worktree::normalize_path_lexical(&record.project_root);
+        let display_name = root
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| {
+                tracing::debug!(
+                    root = %root.display(),
+                    "workspace project root has no usable display name",
+                );
+                paths.workspace_id.as_str().to_owned()
+            });
+        Self {
+            display_name,
+            project_root: Some(record.project_root),
+            root_class: record.root_class,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -212,7 +219,7 @@ mod tests {
     use crate::ids::{AgentKind, AgentSessionId, WorkspaceId};
     use crate::store::event::EventEnvelope;
 
-    fn write_workspace_record(paths: &StatePaths, project_root: PathBuf) {
+    fn write_workspace_record(paths: &StatePaths, project_root: PathBuf, root_class: RootClass) {
         workspace_record::write(
             paths,
             &workspace_record::WorkspaceRecord {
@@ -220,7 +227,7 @@ mod tests {
                 project_root,
                 worktree_root: None,
                 session_name: "rimz-legacy".to_owned(),
-                root_class: RootClass::Repo,
+                root_class,
                 rimz_bin: None,
                 rimz_build: None,
                 updated_at: Timestamp::UNIX_EPOCH,
@@ -235,9 +242,16 @@ mod tests {
         let workspace = WorkspaceId::from_project_root(dir.path());
         let paths = StatePaths::under(workspace, dir.path()).expect("state paths");
         paths.ensure_dirs().expect("state dirs");
-        write_workspace_record(&paths, PathBuf::from("/srv/projects/rimz/child/.."));
+        write_workspace_record(
+            &paths,
+            PathBuf::from("/srv/projects/rimz/child/.."),
+            RootClass::Repo,
+        );
 
-        assert_eq!(display_name_for(&paths), "rimz");
+        assert_eq!(
+            WorkspaceSnapshotIdentity::from_paths(&paths).display_name,
+            "rimz"
+        );
     }
 
     #[test]
@@ -246,9 +260,46 @@ mod tests {
         let workspace = WorkspaceId::from_project_root(dir.path());
         let paths = StatePaths::under(workspace.clone(), dir.path()).expect("state paths");
         paths.ensure_dirs().expect("state dirs");
-        write_workspace_record(&paths, PathBuf::from("/tmp/.."));
+        write_workspace_record(&paths, PathBuf::from("/tmp/.."), RootClass::Directory);
 
-        assert_eq!(display_name_for(&paths), workspace.as_str());
+        let identity = WorkspaceSnapshotIdentity::from_paths(&paths);
+        assert_eq!(identity.display_name, workspace.as_str());
+        assert_eq!(identity.project_root, Some(PathBuf::from("/tmp/..")));
+        assert_eq!(identity.root_class, RootClass::Directory);
+    }
+
+    #[test]
+    fn build_applies_workspace_identity_from_one_record() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let workspace = WorkspaceId::from_project_root(dir.path());
+        let paths = StatePaths::under(workspace, dir.path()).expect("state paths");
+        paths.ensure_dirs().expect("state dirs");
+        let project_root = PathBuf::from("/srv/projects/identity");
+        write_workspace_record(&paths, project_root.clone(), RootClass::Marker);
+
+        let snapshot = build_from(&paths).expect("build snapshot");
+
+        assert_eq!(snapshot.display_name, "identity");
+        assert_eq!(snapshot.project_root, Some(project_root));
+        assert_eq!(snapshot.root_class, RootClass::Marker);
+    }
+
+    #[test]
+    fn missing_or_malformed_workspace_record_uses_identity_fallback() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let workspace = WorkspaceId::from_project_root(dir.path());
+        let paths = StatePaths::under(workspace.clone(), dir.path()).expect("state paths");
+        paths.ensure_dirs().expect("state dirs");
+
+        for corrupt in [false, true] {
+            if corrupt {
+                std::fs::write(&paths.workspace_record, b"not json").expect("corrupt record");
+            }
+            let identity = WorkspaceSnapshotIdentity::from_paths(&paths);
+            assert_eq!(identity.display_name, workspace.as_str());
+            assert_eq!(identity.project_root, None);
+            assert_eq!(identity.root_class, RootClass::Repo);
+        }
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/rimz/src/store/snapshot/assemble.rs
+++ b/crates/rimz/src/store/snapshot/assemble.rs
@@ -182,7 +182,7 @@ impl WorkspaceSnapshotIdentity {
                 tracing::debug!(
                     path = %paths.workspace_record.display(),
                     error = %err,
-                    "workspace record is unreadable while resolving snapshot identity",
+                    "workspace record is unreadable while resolving the display name",
                 );
                 return Self::fallback(paths);
             }

--- a/crates/rimz/src/store/subagent_context.rs
+++ b/crates/rimz/src/store/subagent_context.rs
@@ -13,10 +13,7 @@
 //! sidebar renderer reads this data only through the snapshot JSON, never this
 //! module, so "sidebar is read-only on the store" holds.
 
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::path::PathBuf;
-
+use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
 use crate::agents::context::{SubagentContext, SubagentUsageCursor};
@@ -77,23 +74,32 @@ pub fn update(
     agent_id: &str,
     apply: impl FnOnce(Option<&SubagentContextRecord>) -> (SubagentContext, Option<SubagentUsageCursor>),
 ) -> Result<(), atomic::AtomicErr> {
-    let _lock = sidecar::RecordLock::acquire(
+    sidecar::update(
         &runtime.subagent_context_dir,
-        <SubagentContextRecord as sidecar::SidecarRecord>::FILE_PREFIX,
         kind,
         agent_id,
-    )?;
-    let prior = sidecar::read_one(&runtime.subagent_context_dir, kind, agent_id);
-    let (context, usage_cursor) = apply(prior.as_ref());
-    sidecar::write_record(
-        &runtime.subagent_context_dir,
-        &SubagentContextRecord {
+        || SubagentContextRecord {
             kind: AgentKind::new_unchecked(kind),
             agent_id: agent_id.into(),
-            context,
-            usage_cursor,
+            context: SubagentContext {
+                agent_type: None,
+                model: None,
+                description: None,
+                token_count: None,
+                cost_usd: None,
+                started_at: None,
+                observed_at: Timestamp::now(),
+            },
+            usage_cursor: None,
+        },
+        |record, existed| {
+            let (context, usage_cursor) = apply(existed.then_some(&*record));
+            record.context = context;
+            record.usage_cursor = usage_cursor;
+            true
         },
     )
+    .map(|_| ())
 }
 
 thread_local! {
@@ -101,8 +107,8 @@ thread_local! {
     /// freshly-written temp file, so `(mtime, len)` validates content; the
     /// long-lived consumer fetch thread re-reads these sidecars on every
     /// wakeup, and this caps its steady-state cost at one stat per file.
-    static SUBAGENT_PARSE_CACHE: RefCell<HashMap<PathBuf, sidecar::ParsedSidecar<SubagentContextRecord>>> =
-        RefCell::new(HashMap::new());
+    static SUBAGENT_PARSE_CACHE: sidecar::ParseCache<SubagentContextRecord> =
+        sidecar::ParseCache::default();
 }
 
 /// Read every child's context sidecar. Tolerant: an unreadable or malformed

--- a/crates/rimz/src/store/writer.rs
+++ b/crates/rimz/src/store/writer.rs
@@ -29,10 +29,7 @@ mod queue;
 mod reap;
 mod reset;
 
-pub use lifecycle::{
-    AgentLifecycleIntent, AgentLifecycleReceipt, DEFAULT_EVENT_LOG_ROTATE_BYTES,
-    DerivedLifecycleKind, DerivedLifecycleOutcome, LifecycleAppendOutcome,
-};
+pub use lifecycle::{AgentLifecycleIntent, AgentLifecycleReceipt, DEFAULT_EVENT_LOG_ROTATE_BYTES};
 pub(crate) use queue::DeliverySweepUpdate;
 pub use queue::{DeliveryAck, DeliveryFailureDisposition, EditOutcome, MessageEdit};
 

--- a/crates/rimz/src/store/writer/lifecycle.rs
+++ b/crates/rimz/src/store/writer/lifecycle.rs
@@ -24,41 +24,19 @@ pub struct AgentLifecycleIntent<'a> {
     pub spawned_subagents: &'a [SpawnedSubagent],
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum LifecycleAppendOutcome {
-    Suppressed,
-    Appended,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum DerivedLifecycleKind {
-    Adoption,
-    Reconciliation,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct DerivedLifecycleOutcome {
-    pub kind: DerivedLifecycleKind,
-    pub agent_id: AgentSessionId,
-    pub parent_agent_id: Option<AgentSessionId>,
-    pub event_name: &'static str,
-    pub signal: LifecycleSignal,
-    pub event_id: EventId,
-    pub agent_name: Option<String>,
-    pub prior_status: Option<AgentStatus>,
-    pub transition: Transition,
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AgentLifecycleReceipt {
     pub prior_status: Option<AgentStatus>,
     pub transition: Option<Transition>,
     pub waiting_cleared: bool,
-    pub append: LifecycleAppendOutcome,
     pub primary_event_id: Option<EventId>,
-    pub derived: Vec<DerivedLifecycleOutcome>,
     pub events: Vec<LifecycleEvent>,
     pub rotation_due: bool,
+}
+
+struct StagedLifecycleEvent {
+    envelope: EventEnvelope,
+    event: Option<LifecycleEvent>,
 }
 
 impl Store {
@@ -86,17 +64,13 @@ impl Store {
                 .and_then(|agent_id| find_agent(&agents, &intent.agent_kind, agent_id))
                 .map(|agent| agent.status);
             let transition = lifecycle_transition(&agents, &intent.agent_kind, intent.observation);
-            let append = if append_lifecycle_event(
+            let append_primary = append_lifecycle_event(
                 &intent.observation.signal,
                 transition,
                 intent.observation.parent_agent_id.is_some(),
-            ) {
-                LifecycleAppendOutcome::Appended
-            } else {
-                LifecycleAppendOutcome::Suppressed
-            };
-            let mut envelopes = Vec::new();
-            let primary_event_id = if append == LifecycleAppendOutcome::Appended {
+            );
+            let mut staged = Vec::new();
+            let primary_event_id = if append_primary {
                 let observation = event_lifecycle_observation(intent.observation);
                 let envelope = EventEnvelope::agent_lifecycle(
                     self.inner.paths.workspace_id.clone(),
@@ -106,28 +80,43 @@ impl Store {
                     &observation,
                 );
                 let event_id = envelope.event_id.clone();
-                envelopes.push(envelope);
+                let event = intent.observation.agent_id.as_ref().zip(transition).map(
+                    |(agent_id, transition)| {
+                        LifecycleEvent::new(
+                            event_id.clone(),
+                            envelope.timestamp,
+                            envelope.workspace_id.clone(),
+                            intent.agent_kind.clone(),
+                            agent_id.clone(),
+                            intent.observation.agent_name.clone(),
+                            intent.observation.parent_agent_id.clone(),
+                            intent.observation.signal.clone(),
+                            prior_status,
+                            transition,
+                        )
+                    },
+                );
+                staged.push(StagedLifecycleEvent { envelope, event });
                 Some(event_id)
             } else {
                 None
             };
-            let derived = derive_lifecycle_events(
+            derive_lifecycle_events(
                 &self.inner.paths.workspace_id,
                 &intent,
                 &agents,
                 transition,
-                &mut envelopes,
+                &mut staged,
             );
+            let envelopes = staged
+                .iter()
+                .map(|staged| staged.envelope.clone())
+                .collect::<Vec<_>>();
             txn.append_batch(&envelopes)?;
-
-            let events = lifecycle_events_from_commit(
-                &intent,
-                prior_status,
-                transition,
-                primary_event_id.as_ref(),
-                &derived,
-                &envelopes,
-            );
+            let events = staged
+                .into_iter()
+                .filter_map(|staged| staged.event)
+                .collect();
 
             let waiting_cleared = transition.is_some_and(|transition| transition.waiting_cleared);
             if envelopes.is_empty() {
@@ -135,9 +124,7 @@ impl Store {
                     prior_status,
                     transition,
                     waiting_cleared,
-                    append,
                     primary_event_id,
-                    derived,
                     events,
                     rotation_due: false,
                 });
@@ -147,9 +134,7 @@ impl Store {
                     prior_status,
                     transition,
                     waiting_cleared,
-                    append,
                     primary_event_id,
-                    derived,
                     events,
                     rotation_due: false,
                 });
@@ -164,9 +149,7 @@ impl Store {
                 prior_status,
                 transition,
                 waiting_cleared,
-                append,
                 primary_event_id,
-                derived,
                 events,
                 rotation_due,
             })
@@ -198,9 +181,8 @@ fn derive_lifecycle_events(
     intent: &AgentLifecycleIntent<'_>,
     agents: &[AgentState],
     primary_transition: Option<Transition>,
-    envelopes: &mut Vec<EventEnvelope>,
-) -> Vec<DerivedLifecycleOutcome> {
-    let mut outcomes = Vec::new();
+    staged: &mut Vec<StagedLifecycleEvent>,
+) {
     if matches!(
         intent.observation.signal,
         LifecycleSignal::SubagentStarted | LifecycleSignal::SubagentStopped { .. }
@@ -220,8 +202,7 @@ fn derive_lifecycle_events(
             intent.observation.clone(),
             intent.observation.signal.clone(),
             primary_transition,
-            envelopes,
-            &mut outcomes,
+            staged,
         );
     }
 
@@ -247,15 +228,7 @@ fn derive_lifecycle_events(
             observation.usage.total_tokens = child.total_tokens;
             observation.pane_id = intent.observation.pane_id.clone();
             if child_state.is_some_and(|state| state.parent_agent_id.is_some()) {
-                append_reconciliation(
-                    workspace_id,
-                    intent,
-                    agents,
-                    parent_id,
-                    observation,
-                    envelopes,
-                    &mut outcomes,
-                );
+                append_reconciliation(workspace_id, intent, agents, parent_id, observation, staged);
             } else {
                 append_adoption(
                     workspace_id,
@@ -265,63 +238,11 @@ fn derive_lifecycle_events(
                     observation,
                     LifecycleSignal::SubagentStopped { errored },
                     None,
-                    envelopes,
-                    &mut outcomes,
+                    staged,
                 );
             }
         }
     }
-    outcomes
-}
-
-fn lifecycle_events_from_commit(
-    intent: &AgentLifecycleIntent<'_>,
-    prior_status: Option<AgentStatus>,
-    transition: Option<Transition>,
-    primary_event_id: Option<&EventId>,
-    derived: &[DerivedLifecycleOutcome],
-    envelopes: &[EventEnvelope],
-) -> Vec<LifecycleEvent> {
-    let mut events = Vec::with_capacity(envelopes.len());
-    if let (Some(event_id), Some(agent_id), Some(transition)) = (
-        primary_event_id,
-        intent.observation.agent_id.as_ref(),
-        transition,
-    ) && let Some(envelope) = envelopes
-        .iter()
-        .find(|envelope| envelope.event_id == *event_id)
-    {
-        events.push(LifecycleEvent::new(
-            envelope.event_id.clone(),
-            envelope.timestamp,
-            envelope.workspace_id.clone(),
-            intent.agent_kind.clone(),
-            agent_id.clone(),
-            intent.observation.agent_name.clone(),
-            intent.observation.parent_agent_id.clone(),
-            intent.observation.signal.clone(),
-            prior_status,
-            transition,
-        ));
-    }
-    events.extend(derived.iter().filter_map(|derived| {
-        let envelope = envelopes
-            .iter()
-            .find(|envelope| envelope.event_id == derived.event_id)?;
-        Some(LifecycleEvent::new(
-            envelope.event_id.clone(),
-            envelope.timestamp,
-            envelope.workspace_id.clone(),
-            intent.agent_kind.clone(),
-            derived.agent_id.clone(),
-            derived.agent_name.clone(),
-            derived.parent_agent_id.clone(),
-            derived.signal.clone(),
-            derived.prior_status,
-            derived.transition,
-        ))
-    }));
-    events
 }
 
 fn find_agent<'a>(
@@ -353,8 +274,7 @@ fn append_adoption(
     mut observation: AgentLifecycleObservation,
     signal: LifecycleSignal,
     primary_transition: Option<Transition>,
-    envelopes: &mut Vec<EventEnvelope>,
-    outcomes: &mut Vec<DerivedLifecycleOutcome>,
+    staged: &mut Vec<StagedLifecycleEvent>,
 ) {
     let Some(child_id) = observation.agent_id.clone() else {
         return;
@@ -387,11 +307,9 @@ fn append_adoption(
         intent,
         "SubagentAdopted",
         observation,
-        DerivedLifecycleKind::Adoption,
         prior_status,
         transition,
-        envelopes,
-        outcomes,
+        staged,
     );
 }
 
@@ -401,8 +319,7 @@ fn append_reconciliation(
     agents: &[AgentState],
     parent_id: &AgentSessionId,
     mut observation: AgentLifecycleObservation,
-    envelopes: &mut Vec<EventEnvelope>,
-    outcomes: &mut Vec<DerivedLifecycleOutcome>,
+    staged: &mut Vec<StagedLifecycleEvent>,
 ) {
     let Some(child_id) = observation.agent_id.clone() else {
         return;
@@ -449,11 +366,9 @@ fn append_reconciliation(
         intent,
         "SubagentReconciled",
         observation,
-        DerivedLifecycleKind::Reconciliation,
         prior_status,
         transition,
-        envelopes,
-        outcomes,
+        staged,
     );
 }
 
@@ -463,11 +378,9 @@ fn push_derived(
     intent: &AgentLifecycleIntent<'_>,
     event_name: &'static str,
     observation: AgentLifecycleObservation,
-    kind: DerivedLifecycleKind,
     prior_status: Option<AgentStatus>,
     transition: Transition,
-    envelopes: &mut Vec<EventEnvelope>,
-    outcomes: &mut Vec<DerivedLifecycleOutcome>,
+    staged: &mut Vec<StagedLifecycleEvent>,
 ) {
     let agent_id = observation
         .agent_id
@@ -483,18 +396,21 @@ fn push_derived(
         event_name,
         &observation,
     );
-    let event_id = envelope.event_id.clone();
-    envelopes.push(envelope);
-    outcomes.push(DerivedLifecycleOutcome {
-        kind,
+    let event = LifecycleEvent::new(
+        envelope.event_id.clone(),
+        envelope.timestamp,
+        envelope.workspace_id.clone(),
+        intent.agent_kind.clone(),
         agent_id,
-        parent_agent_id,
-        event_name,
-        signal,
-        event_id,
         agent_name,
+        parent_agent_id,
+        signal,
         prior_status,
         transition,
+    );
+    staged.push(StagedLifecycleEvent {
+        envelope,
+        event: Some(event),
     });
 }
 
@@ -693,7 +609,7 @@ mod tests {
     }
 
     #[test]
-    fn lifecycle_append_outcomes_cover_suppressed_and_appended() {
+    fn lifecycle_receipt_carries_appended_event_and_suppressed_diagnostics() {
         let (_dir, store) = test_store();
         let started = observation(LifecycleSignal::TurnStarted);
         let appended = store
@@ -705,7 +621,10 @@ mod tests {
                 spawned_subagents: &[],
             })
             .expect("append lifecycle event");
-        assert_eq!(appended.append, LifecycleAppendOutcome::Appended);
+        assert_eq!(
+            appended.primary_event_id.as_ref(),
+            Some(&appended.events[0].event_id)
+        );
         assert_eq!(appended.events.len(), 1);
         assert_eq!(appended.events[0].signal, LifecycleSignal::TurnStarted);
 
@@ -727,8 +646,10 @@ mod tests {
                 spawned_subagents: &[],
             })
             .expect("suppress proof-only event");
-        assert_eq!(suppressed.append, LifecycleAppendOutcome::Suppressed);
+        assert!(suppressed.primary_event_id.is_none());
         assert!(suppressed.events.is_empty());
+        assert_eq!(suppressed.prior_status, Some(AgentStatus::Running));
+        assert!(suppressed.transition.is_some());
         assert_eq!(
             std::fs::metadata(&store.paths().events_log)
                 .map(|meta| meta.len())
@@ -742,6 +663,8 @@ mod tests {
             panic!("agent lifecycle event")
         };
         assert_eq!(payload.event_name.as_deref(), Some("UserPromptSubmit"));
+        assert_eq!(appended.events[0].event_id, events[0].event_id);
+        assert_eq!(appended.events[0].at, events[0].timestamp);
     }
 
     #[test]
@@ -790,7 +713,7 @@ mod tests {
 
         assert_eq!(receipt.prior_status, Some(AgentStatus::Waiting));
         assert!(receipt.waiting_cleared);
-        assert_eq!(receipt.append, LifecycleAppendOutcome::Appended);
+        assert!(receipt.primary_event_id.is_some());
         assert_eq!(
             store.snapshot_cached().unwrap().agents[0].status,
             AgentStatus::Running
@@ -844,14 +767,13 @@ mod tests {
         observed.task = Some("adopt me".to_owned());
         observed.pane_id = Some(pane.clone());
         let receipt = append("SubagentStart", &observed);
-        assert_eq!(receipt.derived.len(), 1);
-        assert_eq!(receipt.derived[0].kind, DerivedLifecycleKind::Adoption);
         assert_eq!(receipt.events.len(), 2);
         assert_eq!(receipt.events[0].prior_status, Some(AgentStatus::Idle));
         assert_eq!(receipt.events[1].prior_status, Some(AgentStatus::Running));
         assert_eq!(receipt.events[1].parent_agent_id.as_deref(), Some("root"));
         let events = store.read_events().unwrap();
-        let names = events[events.len() - 2..]
+        let appended = &events[events.len() - 2..];
+        let names = appended
             .iter()
             .map(|event| match event.kind() {
                 EventKind::AgentLifecycle(payload) => payload.event_name.unwrap_or_default(),
@@ -859,6 +781,10 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(names, ["SubagentStart", "SubagentAdopted"]);
+        for (event, envelope) in receipt.events.iter().zip(appended) {
+            assert_eq!(event.event_id, envelope.event_id);
+            assert_eq!(event.at, envelope.timestamp);
+        }
         assert_eq!(
             store
                 .snapshot_cached()
@@ -869,7 +795,7 @@ mod tests {
                 .and_then(|state| state.parent_agent_id.as_deref()),
             Some("root")
         );
-        assert!(append("SubagentStart", &observed).derived.is_empty());
+        assert_eq!(append("SubagentStart", &observed).events.len(), 1);
 
         let mut foreign = AgentLifecycleObservation::new(
             Some(AgentSessionId::from("foreign")),
@@ -881,7 +807,7 @@ mod tests {
         foreign.parent_agent_id = Some(AgentSessionId::from("nested"));
         foreign.task = Some("wrong pane".to_owned());
         foreign.pane_id = Some(pane);
-        assert!(append("SubagentStart", &foreign).derived.is_empty());
+        assert_eq!(append("SubagentStart", &foreign).events.len(), 1);
         assert_eq!(
             store
                 .snapshot_cached()
@@ -961,7 +887,15 @@ mod tests {
                     spawned_subagents: std::slice::from_ref(&facts),
                 })
                 .unwrap();
-            assert_eq!(receipt.derived.len(), expected);
+            assert_eq!(receipt.events.len(), expected);
+            if let Some(event) = receipt.events.first() {
+                assert!(matches!(
+                    event.transition,
+                    crate::agents::LifecycleTransition::Normal
+                ));
+                assert!(event.prior_status.is_some());
+                assert_eq!(event.status, AgentStatus::Success);
+            }
         }
         let state = store
             .snapshot_cached()

--- a/crates/rimz/src/store/writer/reset.rs
+++ b/crates/rimz/src/store/writer/reset.rs
@@ -134,16 +134,11 @@ impl Store {
     /// this method terminal-wakes any surviving waiters and makes the store
     /// match that product boundary.
     #[must_use = "durability barrier; check the result"]
-    pub fn reset_records(&self, session_name: &str, hard: bool) -> Result<ResetRecordsOutcome> {
-        self.reset_records_with(session_name, hard, event_log::rotate)
+    pub fn reset_records(&self, hard: bool) -> Result<ResetRecordsOutcome> {
+        self.reset_records_with(hard, event_log::rotate)
     }
 
-    fn reset_records_with<F>(
-        &self,
-        _session_name: &str,
-        hard: bool,
-        rotate: F,
-    ) -> Result<ResetRecordsOutcome>
+    fn reset_records_with<F>(&self, hard: bool, rotate: F) -> Result<ResetRecordsOutcome>
     where
         F: FnOnce(&Path, &Path, u64) -> event_log::Result<event_log::RotationOutcome>,
     {
@@ -190,9 +185,7 @@ impl Store {
                 &self.inner.paths.root,
             ))?;
 
-            if hard {
-                remove_file_if_exists(&self.inner.paths.latest_snapshot)?;
-            } else {
+            if !hard {
                 snapshot::rebuild(&self.inner.paths)?;
             }
 
@@ -250,7 +243,7 @@ mod tests {
 
         let rotate_called = Cell::new(false);
         store
-            .reset_records_with("rimz-test", false, |events_log, archive_dir, min_bytes| {
+            .reset_records_with(false, |events_log, archive_dir, min_bytes| {
                 rotate_called.set(true);
                 assert!(
                     paths.agents_carryover.exists(),

--- a/crates/rimz/tests/integration/resume.rs
+++ b/crates/rimz/tests/integration/resume.rs
@@ -295,9 +295,7 @@ fn soft_reset_preserves_dead_paneless_resume_identity() {
         ))
         .expect("retire pane stamps");
 
-    h.store
-        .reset_records("rimz-test", false)
-        .expect("soft reset");
+    h.store.reset_records(false).expect("soft reset");
     let projection = h
         .store
         .runtime_projection(rimz::RuntimeScope::Audit)

--- a/crates/rimz/tests/integration/store/write_path.rs
+++ b/crates/rimz/tests/integration/store/write_path.rs
@@ -399,9 +399,7 @@ fn soft_reset_keeps_closed_identity_and_hard_reset_forgets_it() {
         ))
         .expect("append dead-owner lifecycle");
 
-    h.store
-        .reset_records("rimz-test", false)
-        .expect("soft reset");
+    h.store.reset_records(false).expect("soft reset");
     let after_soft = h
         .store
         .runtime_projection(RuntimeScope::Audit)
@@ -414,9 +412,7 @@ fn soft_reset_keeps_closed_identity_and_hard_reset_forgets_it() {
         "soft reset preserves resumable identity"
     );
 
-    h.store
-        .reset_records("rimz-test", true)
-        .expect("hard reset");
+    h.store.reset_records(true).expect("hard reset");
     let after_hard = h
         .store
         .runtime_projection(RuntimeScope::Audit)


### PR DESCRIPTION
## Context

`crates/rimz/src/store/` had accumulated parallel representations of the same facts. Commit `df91d45ce` made the versioned `LifecycleEvent` the canonical reactor/stream shape but left `LifecycleAppendOutcome`, `DerivedLifecycleKind`, and `DerivedLifecycleOutcome` beside it, so every lifecycle commit built two models of one append and rematched them by event ID afterwards. Three runtime-sidecar modules (`active_time`, `agent_context`, `subagent_context`) each hand-rolled their own flock-read-merge-publish choreography, and `active_time` carried a private duplicate of the shared `RecordLock` introduced before `0b7f6c22c` landed the shared one. Snapshot assembly read `workspace.json` three separate times for three fields of one identity. Reset still took a `session_name` that commit `46a127b5f` stopped using, and deleted `latest.json` twice on a hard reset.

This is a behavior-preserving refactor pass: structure changes, observable behavior does not. On-disk names and shapes, durability classes, lock ordering, event ordering and identity and timestamps, cache stale-serve rules, diagnostics, and wake/publish/reap behavior all stay as they were.

## Design choices

- **One `Store` handle, unchanged.** Splitting durable and runtime handles, or moving snapshot view code into the sidebar, adds surface or moves code sideways without reducing what a reader holds. `Store::commit` stays the sole workspace write transaction seam and `QueueTxn` stays the owner of live-queue/history/event ordering; recent commits `2fb9736aa`, `9bedcad9b`, and `128e5f450` deliberately converged those paths and this pass keeps their shape.
- **No new service or trait layer for sidecars.** The existing `SidecarRecord` trait and the existing cache-class rename primitive were enough; `sidecar` absorbed the choreography as plain functions rather than growing an abstraction.
- **`agent_activity` left alone.** Its older custom short-filename scheme is outside the selected sidecar change, and generalizing it here would have grown the blast radius.
- **Broad directory scans kept for agent/subagent context.** Only the already-keyed active-time read moved to shared keyed caching; converting the other two would be a behavior change, not a refactor.
- **No actor and no embedded DB.** Every writer is a short-lived CLI process, so `workspace.lock` remains the only cross-process serialization.

## Implementation

Four ordered refactors across six atomic commits.

**Canonical lifecycle events.** Each durable `EventEnvelope` is now staged beside the `LifecycleEvent` it projects, the envelopes append as one batch, and the receipt returns canonical events in append order. `LifecycleAppendOutcome`, `DerivedLifecycleKind`, `DerivedLifecycleOutcome`, `lifecycle_events_from_commit`, the event-ID rematching, and the re-exports through `store/writer.rs` and `store/mod.rs` are gone. Derived-transition logging in `cli/hooks/lifecycle/observe.rs` now reads canonical receipt events and excludes the primary by `primary_event_id`. The receipt keeps `prior_status`, `transition`, `waiting_cleared`, `primary_event_id`, `events`, and `rotation_due`, so suppressed-primary diagnostics survive.

**Sidecar transactions centralized.** `store::sidecar` now owns per-record flock acquisition, latest-byte read-modify-write (`update`), cache-class publication, locked removal (`remove_locked`), the parse-cache representation (`ParseCache`), and stat-gated keyed reads (`read_for_keys`). `lock_path`, `RecordLock`, and `ParsedSidecar` are private behind that interface, and the fixture writer is scoped to tests. `active_time`, `agent_context`, and `subagent_context` retain only their payload defaults and merge rules; `active_time`'s duplicate `RecordLock` and its hand-rolled keyed cache scan are deleted.

**Workspace identity assembled once.** `display_name_for`, `project_root_for`, and `root_class_for` collapse into one private `WorkspaceSnapshotIdentity` built from a single `workspace_record::read`. Display name, project root, and root class now come from one generation of the record instead of three independent reads.

**Reset vestiges removed.** `reset_records` and `reset_records_with` take `hard` only; `room/birth.rs` and the reset/resume/write-path tests drop the argument. The redundant second `latest.json` removal is gone — the original early removal under both the workspace and publish locks is retained.

### Behavior preservation

Verified against the code rather than the plan, per seam:

- The primary `LifecycleEvent`'s inputs are all fixed before `derive_lifecycle_events` runs, and `append_batch` takes its slice immutably, so building the event earlier changes nothing. The new gate `append_primary && agent_id.is_some() && transition.is_some()` is identical to the old triple-`Some` guard plus its always-successful envelope lookup, and `staged` preserves the primary-then-derived order.
- The `observe.rs` filter yields exactly the old `derived` set, and `LifecycleEvent::new` plus `From<TransitionKind> for LifecycleTransition` map every logged field, level, target, and message string 1:1 with the old derived-path call.
- `sidecar::update` reproduces the old per-module sequence exactly. Its one structural difference — the write path is computed from the requested key rather than from the record's own fields — is inert: no `apply` closure in the tree mutates `record.kind` or `record.agent_id`.
- The identity projection reproduces the old three-read fallback matrix branch for branch, including the single debug record on an unreadable file and the silent fallback on a missing one.
- Nothing between the retained early `latest.json` removal and the deleted one recreates the file: `ensure_dirs` only creates `snapshots/`, `runs/`, and `locks/`, and the two intervening calls remove `diag.log` and the diag frames directory.

### Verification

`cargo xtask gate` passes (`fmt`, `invariants`, `docs-links`, `lint`, `test`). Focused runs: `store::writer::lifecycle` 10 passed, `cli::hooks::lifecycle` 18, `store::sidecar` 9, `store::active_time` 11, `store::agent_context` 21, `store::subagent_context` 6, `store::snapshot::assemble` 9, `reset` 93, `store::write_path` 12.

New tests pin the preserved behavior rather than the new structure: canonical event IDs and timestamps matching their appended envelopes, suppressed-primary diagnostics, sidecar no-op updates and default creation and latest-byte read-modify-write, keyed dedupe and key validation and malformed negative caching and same-stamp cache hits and dead-key eviction, and one assertion that a valid non-default project root, root class, and display name all land together.

Production code drops 116 lines (+296/-412 outside test hunks); the added preservation tests (+238/-21) make the raw total grow by 101.

## Advisories

Neither gates the merge.

- `store/writer/lifecycle.rs` clones every `EventEnvelope` out of the staged vector purely to hand `append_batch` a slice, and `writer.rs` then clones the slice again via `extend_from_slice`. `EventEnvelope` carries a `Box<RawValue>` payload plus six `String` fields, so this doubles per-append envelope copying on a path that runs on every agent lifecycle hook. An `unzip` over the staged pairs removes the extra clone.
- `subagent_context::update` builds a full default record whose context — including a `Timestamp::now()` read — and usage cursor are unconditionally overwritten before any write; only `kind` and `agent_id` survive. It is unobservable but reads as if the placeholder matters. The cause is `sidecar::update`'s `default: impl FnOnce() -> R` shape being slightly wrong for a caller that replaces the whole payload, which is not worth reshaping for one caller.

Known weak spot, unchanged by this pass: a same `(mtime, len)` stamp intentionally serves the cached parse — success or failure — even if the bytes changed. Tests pin that stale-serve behavior; filesystems with coarse mtime granularity remain the boundary to scrutinize.

Out of scope: broad `cargo xtask test resume` reproduces a live-tmux failure at `tests/integration/backend/tmux/agent_lifecycle.rs:371` (`attached live pane`) after all retries. Nothing in this branch reaches mux or pane discovery, and `gate` excludes live-backend tiers by design. Run the live tier on a healthy backend if that tier is required.
