### PR TITLE
refactor(sidebar): deepen pet, cache, and supervisor ownership

### DIFF
--- a/crates/rimz/src/sidebar/agent_projection.rs
+++ b/crates/rimz/src/sidebar/agent_projection.rs
@@ -297,7 +297,8 @@ pub fn read_published(
     panes: &[PaneRef],
 ) -> AgentProjection {
     let inputs = LocalSessionInputs::from_panes(panes);
-    let Some(published) = read_cache(&runtime.agent_projection_path())
+    let Some(published) = AGENT_PROJECTION_PARSE_CACHE
+        .with(|cache| cache.read_stamped_json(&runtime.agent_projection_path()))
         .filter(|published| published.session_name == session_name)
     else {
         return AgentProjection::default();
@@ -348,21 +349,6 @@ fn publish_if_changed(
     crate::store::atomic::write_temp_then_rename_cache(path, published)?;
     on_changed();
     Ok(true)
-}
-
-fn read_cache(path: &Path) -> Option<Arc<AgentProjectionPublication>> {
-    let metadata = std::fs::metadata(path).ok()?;
-    let modified = metadata.modified().ok()?;
-    let len = metadata.len();
-    if let Some(cached) = AGENT_PROJECTION_PARSE_CACHE.with(|cache| cache.get(path, modified, len))
-    {
-        return Some(cached);
-    }
-    let parsed = Arc::new(serde_json::from_slice(&std::fs::read(path).ok()?).ok()?);
-    AGENT_PROJECTION_PARSE_CACHE.with(|cache| {
-        cache.store(path, modified, len, Arc::clone(&parsed));
-    });
-    Some(parsed)
 }
 
 #[cfg(test)]
@@ -531,8 +517,12 @@ mod tests {
         };
         publish_if_changed(&path, &publication, || {}).unwrap();
 
-        let first = read_cache(&path).unwrap();
-        let second = read_cache(&path).unwrap();
+        let first = AGENT_PROJECTION_PARSE_CACHE
+            .with(|cache| cache.read_stamped_json(&path))
+            .unwrap();
+        let second = AGENT_PROJECTION_PARSE_CACHE
+            .with(|cache| cache.read_stamped_json(&path))
+            .unwrap();
         assert!(Arc::ptr_eq(&first, &second));
     }
 

--- a/crates/rimz/src/sidebar/agent_projection.rs
+++ b/crates/rimz/src/sidebar/agent_projection.rs
@@ -5,7 +5,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::time::UNIX_EPOCH;
 
 use serde::{Deserialize, Serialize};
@@ -354,6 +354,7 @@ fn publish_if_changed(
 #[cfg(test)]
 mod tests {
     use std::cell::Cell;
+    use std::sync::Arc;
 
     use jiff::Timestamp;
 

--- a/crates/rimz/src/sidebar/workspace_projection.rs
+++ b/crates/rimz/src/sidebar/workspace_projection.rs
@@ -150,22 +150,8 @@ pub fn workspace_projection_path(runtime: &RuntimePaths) -> PathBuf {
 pub fn read_workspace_projection(
     runtime: &RuntimePaths,
 ) -> Option<Arc<PublishedWorkspaceProjection>> {
-    read_cached_projection(&workspace_projection_path(runtime))
-}
-
-fn read_cached_projection(path: &Path) -> Option<Arc<PublishedWorkspaceProjection>> {
-    let stamped = StampedPath::of(path);
-    if let Some(projection) =
-        WORKSPACE_PROJECTION_PARSE_CACHE.with(|cache| cache.get_stamped(&stamped))
-    {
-        return Some(projection);
-    }
-    let bytes = std::fs::read(path).ok()?;
-    let projection = Arc::new(serde_json::from_slice(&bytes).ok()?);
-    WORKSPACE_PROJECTION_PARSE_CACHE.with(|cache| {
-        cache.store_stamped(&stamped, Arc::clone(&projection));
-    });
-    Some(projection)
+    WORKSPACE_PROJECTION_PARSE_CACHE
+        .with(|cache| cache.read_stamped_json(&workspace_projection_path(runtime)))
 }
 
 #[derive(Deserialize)]
@@ -177,18 +163,7 @@ struct LatestExtent {
 }
 
 fn read_latest_extent(path: &Path) -> Option<LogExtent> {
-    let stamped = StampedPath::of(path);
-    let latest = match LATEST_EXTENT_PARSE_CACHE.with(|cache| cache.get_stamped(&stamped)) {
-        Some(latest) => latest,
-        None => {
-            let bytes = std::fs::read(path).ok()?;
-            let latest = Arc::new(serde_json::from_slice::<LatestExtent>(&bytes).ok()?);
-            LATEST_EXTENT_PARSE_CACHE.with(|cache| {
-                cache.store_stamped(&stamped, Arc::clone(&latest));
-            });
-            latest
-        }
-    };
+    let latest = LATEST_EXTENT_PARSE_CACHE.with(|cache| cache.read_stamped_json(path))?;
     (latest.snapshot_version == crate::store::snapshot::SNAPSHOT_VERSION)
         .then_some(latest.reflects_log)
         .flatten()

--- a/crates/rimz/src/sidebar_pane/pets/mod.rs
+++ b/crates/rimz/src/sidebar_pane/pets/mod.rs
@@ -117,26 +117,63 @@ pub fn dashboard_pet_size(tier: PetRenderTier) -> PetGridSize {
 
 #[derive(Default)]
 pub(crate) struct PetAssets {
-    loaded: Option<LoadedPet>,
-    loading: Option<LoadingPet>,
-    failed: Option<FailedPet>,
+    load_state: PetLoadState,
     previous_action: Option<PetAction>,
     jump_started_phase: Option<u64>,
     previous_unread_rows: BTreeSet<String>,
     caption: Option<String>,
 }
 
-struct LoadingPet {
-    id: String,
-    key: PreparationKey,
-    receiver: Receiver<LoadResult>,
+#[derive(Default)]
+enum PetLoadState {
+    #[default]
+    Empty,
+    Loading {
+        request: PetLoadRequest,
+        receiver: Receiver<LoadResult>,
+    },
+    Loaded {
+        request: PetLoadRequest,
+        asset: LoadedPetAsset,
+    },
+    Failed {
+        request: PetLoadRequest,
+        failed_at_phase: u64,
+        retry_receiver: Option<Receiver<LoadResult>>,
+    },
 }
 
-struct FailedPet {
+impl PetLoadState {
+    fn request(&self) -> Option<&PetLoadRequest> {
+        match self {
+            Self::Empty => None,
+            Self::Loading { request, .. }
+            | Self::Loaded { request, .. }
+            | Self::Failed { request, .. } => Some(request),
+        }
+    }
+
+    fn matches(&self, pet_id: &str, key: PreparationKey) -> bool {
+        self.request()
+            .is_some_and(|request| request.id == pet_id && request.key == key)
+    }
+
+    fn is_loading(&self) -> bool {
+        matches!(
+            self,
+            Self::Loading { .. }
+                | Self::Failed {
+                    retry_receiver: Some(_),
+                    ..
+                }
+        )
+    }
+}
+
+#[derive(Clone)]
+struct PetLoadRequest {
     id: String,
     key: PreparationKey,
-    caption: String,
-    failed_at_phase: u64,
 }
 
 /// Wall-clock span, in milliseconds, before a failed asset load is retried. A
@@ -161,12 +198,6 @@ fn phase_elapsed(started_phase: u64, phase: u64, refresh_ms: u16) -> std::time::
             .saturating_sub(started_phase)
             .saturating_mul(u64::from(refresh_ms.max(1))),
     )
-}
-
-struct LoadedPet {
-    id: String,
-    key: PreparationKey,
-    asset: LoadedPetAsset,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -229,15 +260,17 @@ impl PetAssets {
             data: vec![255, 0, 0, 255],
         };
         Self {
-            loaded: Some(LoadedPet {
-                id: pet_id.to_owned(),
-                key: PreparationKey::new(
-                    PetRenderTier::Pixel,
-                    DASHBOARD_PIXEL_PET,
-                    CellAspect::NEUTRAL,
-                ),
+            load_state: PetLoadState::Loaded {
+                request: PetLoadRequest {
+                    id: pet_id.to_owned(),
+                    key: PreparationKey::new(
+                        PetRenderTier::Pixel,
+                        DASHBOARD_PIXEL_PET,
+                        CellAspect::NEUTRAL,
+                    ),
+                },
                 asset: LoadedPetAsset::Pixel(vec![frame; catalog::FRAME_COUNT]),
-            }),
+            },
             ..Self::default()
         }
     }
@@ -259,9 +292,7 @@ impl PetAssets {
     /// `observe_unread_rows` call in the serve loop, so it is left untouched
     /// here; the full-teardown disabled path clears it on its own.
     fn reset_runtime_state(&mut self) {
-        self.loaded = None;
-        self.loading = None;
-        self.failed = None;
+        self.load_state = PetLoadState::Empty;
         self.previous_action = None;
         self.jump_started_phase = None;
         self.caption = None;
@@ -307,16 +338,12 @@ impl PetAssets {
         }
         self.observe_action(action, config.voice, phase);
 
-        let loading = preparation.is_some_and(|key| {
-            self.loading
-                .as_ref()
-                .is_some_and(|loading| loading.id == id && loading.key == key)
-        });
-        let unavailable_caption = self
-            .failed
-            .as_ref()
-            .filter(|failed| failed.id == id)
-            .map(|failed| failed.caption.clone());
+        let loading = preparation
+            .is_some_and(|key| self.load_state.matches(id, key) && self.load_state.is_loading());
+        let unavailable = matches!(
+            &self.load_state,
+            PetLoadState::Failed { request, .. } if request.id == id
+        );
         let body = preparation.and_then(|key| {
             let (sprite_index, track) = self.loaded_sprite(LoadedSpriteRequest {
                 pet_id: id,
@@ -351,7 +378,8 @@ impl PetAssets {
         };
         Some(PetView {
             body,
-            caption: unavailable_caption
+            caption: unavailable
+                .then(|| "pet unavailable".to_owned())
                 .or_else(|| self.caption.clone())
                 .or_else(|| loading.then(|| "fetching pet...".to_owned())),
             frame_interval,
@@ -359,11 +387,13 @@ impl PetAssets {
     }
 
     pub(crate) fn pixel_frame(&self, pet_id: &str, sprite_index: usize) -> Option<&RgbaImage> {
-        let loaded = self.loaded.as_ref()?;
-        if loaded.id != pet_id {
+        let PetLoadState::Loaded { request, asset } = &self.load_state else {
+            return None;
+        };
+        if request.id != pet_id {
             return None;
         }
-        match &loaded.asset {
+        match asset {
             LoadedPetAsset::Pixel(frames) => frames.get(sprite_index),
             LoadedPetAsset::Cell(_) => None,
         }
@@ -382,57 +412,54 @@ impl PetAssets {
         }
         self.previous_action = Some(action);
     }
+
     fn poll_loader(&mut self, phase: u64) {
-        let Some(loading) = &self.loading else {
-            return;
+        let (request, result) = match &self.load_state {
+            PetLoadState::Loading { request, receiver }
+            | PetLoadState::Failed {
+                request,
+                retry_receiver: Some(receiver),
+                ..
+            } => {
+                let result = match receiver.try_recv() {
+                    Ok(result) => result,
+                    Err(TryRecvError::Empty) => return,
+                    Err(TryRecvError::Disconnected) => Err("pet loader stopped".to_owned()),
+                };
+                (request.clone(), result)
+            }
+            PetLoadState::Empty
+            | PetLoadState::Loaded { .. }
+            | PetLoadState::Failed {
+                retry_receiver: None,
+                ..
+            } => return,
         };
-        let result = match loading.receiver.try_recv() {
-            Ok(result) => result,
-            Err(TryRecvError::Empty) => return,
-            Err(TryRecvError::Disconnected) => Err("pet loader stopped".to_owned()),
-        };
-        let id = loading.id.clone();
-        let key = loading.key;
-        self.loading = None;
         match result {
             Ok(asset) => {
-                self.loaded = Some(LoadedPet { id, key, asset });
-                self.failed = None;
+                self.load_state = PetLoadState::Loaded { request, asset };
             }
             Err(err) => {
-                tracing::debug!(pet = %id, error = %err, "pet asset unavailable");
-                self.loaded = None;
+                tracing::debug!(pet = %request.id, error = %err, "pet asset unavailable");
                 self.jump_started_phase = None;
-                self.failed = Some(FailedPet {
-                    id,
-                    key,
-                    caption: "pet unavailable".to_owned(),
+                self.load_state = PetLoadState::Failed {
+                    request,
                     failed_at_phase: phase,
-                });
+                    retry_receiver: None,
+                };
             }
         }
     }
 
     fn clear_mismatched_pet(&mut self, pet_id: &str, key: Option<PreparationKey>) {
-        if self
-            .loaded
-            .as_ref()
-            .is_some_and(|loaded| loaded.id != pet_id || key.is_some_and(|key| loaded.key != key))
-        {
-            self.loaded = None;
-            self.jump_started_phase = None;
-        }
-        if self.loading.as_ref().is_some_and(|loading| {
-            loading.id != pet_id || key.is_some_and(|key| loading.key != key)
-        }) {
-            self.loading = None;
-        }
-        if self
-            .failed
-            .as_ref()
-            .is_some_and(|failed| failed.id != pet_id || key.is_some_and(|key| failed.key != key))
-        {
-            self.failed = None;
+        let mismatched = self.load_state.request().is_some_and(|request| {
+            request.id != pet_id || key.is_some_and(|key| request.key != key)
+        });
+        if mismatched {
+            if matches!(&self.load_state, PetLoadState::Loaded { .. }) {
+                self.jump_started_phase = None;
+            }
+            self.load_state = PetLoadState::Empty;
         }
     }
 
@@ -445,27 +472,29 @@ impl PetAssets {
     ) {
         let id = source.id();
         let id: &str = id.as_ref();
-        if self
-            .loaded
-            .as_ref()
-            .is_some_and(|loaded| loaded.id == id && loaded.key == key)
-            || self
-                .loading
-                .as_ref()
-                .is_some_and(|loading| loading.id == id && loading.key == key)
+        if self.load_state.matches(id, key)
+            && matches!(
+                &self.load_state,
+                PetLoadState::Loaded { .. } | PetLoadState::Loading { .. }
+            )
         {
             return;
         }
         // A latched failure holds off a fresh attempt until the cooldown
         // elapses, so a transient miss recovers without a per-frame retry storm.
-        if let Some(failed) = self.failed.as_ref()
-            && failed.id == id
-            && failed.key == key
-            && !retry_due(failed.failed_at_phase, phase, refresh_ms)
-        {
-            return;
-        }
-        self.loaded = None;
+        let retrying = match &self.load_state {
+            PetLoadState::Failed {
+                request,
+                failed_at_phase,
+                retry_receiver,
+            } if request.id == id && request.key == key => {
+                if retry_receiver.is_some() || !retry_due(*failed_at_phase, phase, refresh_ms) {
+                    return;
+                }
+                Some(*failed_at_phase)
+            }
+            _ => None,
+        };
         let (sender, receiver) = mpsc::channel();
         let source = source.clone();
         let spawned = thread::Builder::new()
@@ -476,19 +505,28 @@ impl PetAssets {
             });
         match spawned {
             Ok(_) => {
-                self.loading = Some(LoadingPet {
+                let request = PetLoadRequest {
                     id: id.to_owned(),
                     key,
-                    receiver,
-                });
+                };
+                self.load_state = match retrying {
+                    Some(failed_at_phase) => PetLoadState::Failed {
+                        request,
+                        failed_at_phase,
+                        retry_receiver: Some(receiver),
+                    },
+                    None => PetLoadState::Loading { request, receiver },
+                };
             }
             Err(err) => {
-                self.failed = Some(FailedPet {
-                    id: id.to_owned(),
-                    key,
-                    caption: "pet unavailable".to_owned(),
+                self.load_state = PetLoadState::Failed {
+                    request: PetLoadRequest {
+                        id: id.to_owned(),
+                        key,
+                    },
                     failed_at_phase: phase,
-                });
+                    retry_receiver: None,
+                };
                 tracing::debug!(pet = %id, error = %err, "pet asset loader failed");
             }
         }
@@ -500,11 +538,13 @@ impl PetAssets {
         key: PreparationKey,
         sprite_index: usize,
     ) -> Option<PetCellGrid> {
-        let loaded = self.loaded.as_ref()?;
-        if loaded.id != pet_id || loaded.key != key {
+        let PetLoadState::Loaded { request, asset } = &self.load_state else {
+            return None;
+        };
+        if request.id != pet_id || request.key != key {
             return None;
         }
-        match &loaded.asset {
+        match asset {
             LoadedPetAsset::Cell(grids) => grids.get(sprite_index).cloned(),
             LoadedPetAsset::Pixel(_) => None,
         }
@@ -520,8 +560,10 @@ impl PetAssets {
             frame,
         } = request;
         let jump_duration = {
-            let loaded = self.loaded.as_ref()?;
-            if loaded.id != pet_id {
+            let PetLoadState::Loaded { request, .. } = &self.load_state else {
+                return None;
+            };
+            if request.id != pet_id {
                 return None;
             }
             Some(
@@ -539,11 +581,13 @@ impl PetAssets {
             jump_duration,
             unread_triggered: frame.unread_triggered,
         });
-        let loaded = self.loaded.as_ref()?;
-        if loaded.id != pet_id {
+        let PetLoadState::Loaded { request, asset } = &self.load_state else {
+            return None;
+        };
+        if request.id != pet_id {
             return None;
         }
-        let frame_count = match &loaded.asset {
+        let frame_count = match asset {
             LoadedPetAsset::Cell(grids) => grids.len(),
             LoadedPetAsset::Pixel(frames) => frames.len(),
         };

--- a/crates/rimz/src/sidebar_pane/pets/tests.rs
+++ b/crates/rimz/src/sidebar_pane/pets/tests.rs
@@ -70,22 +70,17 @@ fn render_tier_resolves_mode_caps_and_paintability() {
 fn disabled_config_clears_runtime_state() {
     let (_sender, receiver) = mpsc::channel();
     let mut assets = PetAssets {
-        loaded: loaded_cell_assets(None).loaded,
-        loading: Some(LoadingPet {
-            id: "codex".to_owned(),
-            key: cell_key(),
+        load_state: PetLoadState::Loading {
+            request: PetLoadRequest {
+                id: "codex".to_owned(),
+                key: cell_key(),
+            },
             receiver,
-        }),
+        },
         previous_action: Some(PetAction::Running),
         jump_started_phase: Some(1),
         previous_unread_rows: BTreeSet::from(["agent-1".to_owned()]),
         caption: Some("x".to_owned()),
-        failed: Some(FailedPet {
-            id: "codex".to_owned(),
-            key: cell_key(),
-            caption: "pet unavailable".to_owned(),
-            failed_at_phase: 0,
-        }),
     };
     assert!(
         assets
@@ -96,9 +91,7 @@ fn disabled_config_clears_runtime_state() {
     assert_eq!(assets.jump_started_phase, None);
     assert!(assets.previous_unread_rows.is_empty());
     assert_eq!(assets.caption, None);
-    assert!(assets.failed.is_none());
-    assert!(assets.loaded.is_none());
-    assert!(assets.loading.is_none());
+    assert!(matches!(assets.load_state, PetLoadState::Empty));
 }
 
 #[test]
@@ -107,26 +100,29 @@ fn empty_pet_selector_rests_with_no_pet() {
     assets.jump_started_phase = Some(3);
     assets.previous_unread_rows = BTreeSet::from(["agent-1".to_owned()]);
     assets.caption = Some("running".to_owned());
-    assets.failed = Some(FailedPet {
-        id: "codex".to_owned(),
-        key: cell_key(),
-        caption: "pet unavailable".to_owned(),
+    assets.load_state = PetLoadState::Failed {
+        request: PetLoadRequest {
+            id: "codex".to_owned(),
+            key: cell_key(),
+        },
         failed_at_phase: 0,
-    });
+        retry_receiver: None,
+    };
     let view = assets
         .view(&config_for("  "), cell_frame(PetAction::Idle, 0))
         .expect("enabled pets produce a view");
     assert_eq!(view.body, None);
     assert_eq!(view.caption.as_deref(), Some("no pet selected"));
-    assert!(assets.loading.is_none(), "an empty selector loads nothing");
-    assert!(assets.loaded.is_none());
+    assert!(
+        matches!(assets.load_state, PetLoadState::Empty),
+        "an empty selector loads nothing"
+    );
     assert_eq!(assets.previous_action, None);
     assert_eq!(assets.jump_started_phase, None);
     assert_eq!(
         assets.previous_unread_rows,
         BTreeSet::from(["agent-1".to_owned()])
     );
-    assert!(assets.failed.is_none());
 }
 
 #[test]
@@ -147,10 +143,11 @@ fn local_pet_path_begins_loading_under_its_own_id() {
         "a local-path selector uses loading cadence"
     );
     assert!(
-        assets
-            .loading
-            .as_ref()
-            .is_some_and(|loading| loading.id == "/no/such/pet/sheet.webp"),
+        matches!(
+            &assets.load_state,
+            PetLoadState::Loading { request, .. }
+                if request.id == "/no/such/pet/sheet.webp"
+        ),
         "the loader is keyed by the local path"
     );
 }
@@ -168,7 +165,7 @@ fn missing_body_size_does_not_start_asset_loading() {
     assert_eq!(view.body, None);
     assert_eq!(view.frame_interval, None);
     assert_eq!(view.caption.as_deref(), Some("resting"));
-    assert!(assets.loading.is_none());
+    assert!(matches!(assets.load_state, PetLoadState::Empty));
 }
 
 #[test]
@@ -178,11 +175,13 @@ fn failed_loader_settles_without_immediate_retry() {
     sender
         .send(Err("offline".to_owned()))
         .expect("send failure");
-    assets.loading = Some(LoadingPet {
-        id: "codex".to_owned(),
-        key: cell_key(),
+    assets.load_state = PetLoadState::Loading {
+        request: PetLoadRequest {
+            id: "codex".to_owned(),
+            key: cell_key(),
+        },
         receiver,
-    });
+    };
     let config = enabled_config();
 
     let view = assets
@@ -190,14 +189,35 @@ fn failed_loader_settles_without_immediate_retry() {
         .expect("enabled pets produce a view");
     assert_eq!(view.frame_interval, None);
     assert_eq!(view.caption.as_deref(), Some("pet unavailable"));
-    assert!(assets.loading.is_none());
-    assert!(assets.failed.is_some());
+    assert!(matches!(
+        assets.load_state,
+        PetLoadState::Failed {
+            retry_receiver: None,
+            ..
+        }
+    ));
 
     let view = assets
         .view(&config, cell_frame(PetAction::Idle, 1))
         .expect("enabled pets produce a view");
     assert_eq!(view.frame_interval, None);
-    assert!(assets.loading.is_none());
+    assert!(!assets.load_state.is_loading());
+
+    let view = assets
+        .view(&config, cell_frame(PetAction::Idle, 200))
+        .expect("enabled pets produce a view");
+    assert_eq!(
+        view.frame_interval,
+        Some(crate::sidebar::timing::animation_frame(REFRESH_MS))
+    );
+    assert_eq!(view.caption.as_deref(), Some("pet unavailable"));
+    assert!(matches!(
+        assets.load_state,
+        PetLoadState::Failed {
+            retry_receiver: Some(_),
+            ..
+        }
+    ));
 }
 
 #[test]
@@ -327,8 +347,11 @@ fn pixel_view_resolves_sprite_without_cell_grid() {
             .is_some()
     );
     assert!(matches!(
-        assets.loaded.as_ref().expect("loaded").asset,
-        LoadedPetAsset::Pixel(_)
+        assets.load_state,
+        PetLoadState::Loaded {
+            asset: LoadedPetAsset::Pixel(_),
+            ..
+        }
     ));
 }
 
@@ -336,11 +359,13 @@ fn pixel_view_resolves_sprite_without_cell_grid() {
 fn prepared_grids_are_invalidated_on_size_or_aspect_change() {
     let key = cell_key();
     let mut assets = PetAssets {
-        loaded: Some(LoadedPet {
-            id: "codex".to_owned(),
-            key,
+        load_state: PetLoadState::Loaded {
+            request: PetLoadRequest {
+                id: "codex".to_owned(),
+                key,
+            },
             asset: LoadedPetAsset::Cell(vec![vec![]; catalog::FRAME_COUNT]),
-        }),
+        },
         ..PetAssets::default()
     };
 
@@ -352,13 +377,15 @@ fn prepared_grids_are_invalidated_on_size_or_aspect_change() {
             ..key
         }),
     );
-    assert!(assets.loaded.is_none());
+    assert!(matches!(assets.load_state, PetLoadState::Empty));
 
-    assets.loaded = Some(LoadedPet {
-        id: "codex".to_owned(),
-        key,
+    assets.load_state = PetLoadState::Loaded {
+        request: PetLoadRequest {
+            id: "codex".to_owned(),
+            key,
+        },
         asset: LoadedPetAsset::Cell(vec![vec![]; catalog::FRAME_COUNT]),
-    });
+    };
     assets.clear_mismatched_pet(
         "codex",
         Some(PreparationKey {
@@ -366,7 +393,7 @@ fn prepared_grids_are_invalidated_on_size_or_aspect_change() {
             ..key
         }),
     );
-    assert!(assets.loaded.is_none());
+    assert!(matches!(assets.load_state, PetLoadState::Empty));
 }
 
 #[test]
@@ -419,11 +446,13 @@ fn cell_key() -> PreparationKey {
 
 fn loaded_cell_assets(previous_action: Option<PetAction>) -> PetAssets {
     PetAssets {
-        loaded: Some(LoadedPet {
-            id: "codex".to_owned(),
-            key: cell_key(),
+        load_state: PetLoadState::Loaded {
+            request: PetLoadRequest {
+                id: "codex".to_owned(),
+                key: cell_key(),
+            },
             asset: LoadedPetAsset::Cell(vec![vec![]; catalog::FRAME_COUNT]),
-        }),
+        },
         previous_action,
         ..PetAssets::default()
     }
@@ -436,15 +465,17 @@ fn loaded_pixel_assets(previous_action: Option<PetAction>) -> PetAssets {
         data: vec![255, 0, 0, 255],
     };
     PetAssets {
-        loaded: Some(LoadedPet {
-            id: "codex".to_owned(),
-            key: PreparationKey {
-                tier: PetRenderTier::Pixel,
-                size: DASHBOARD_PIXEL_PET,
-                aspect: CellAspect::NEUTRAL,
+        load_state: PetLoadState::Loaded {
+            request: PetLoadRequest {
+                id: "codex".to_owned(),
+                key: PreparationKey {
+                    tier: PetRenderTier::Pixel,
+                    size: DASHBOARD_PIXEL_PET,
+                    aspect: CellAspect::NEUTRAL,
+                },
             },
             asset: LoadedPetAsset::Pixel(vec![frame; catalog::FRAME_COUNT]),
-        }),
+        },
         previous_action,
         ..PetAssets::default()
     }

--- a/crates/rimz/src/sidebar_pane/render/sections/pets.rs
+++ b/crates/rimz/src/sidebar_pane/render/sections/pets.rs
@@ -10,6 +10,15 @@ const CAPTION_GAP: usize = 2;
 /// Below this much room to the sprite's right, the caption stacks underneath
 /// instead of riding alongside.
 const MIN_SIDE_CAPTION: usize = 6;
+/// Dashboard pet captions leave three trailing cells so their right edge lines
+/// up with the sprite body's inner gap.
+const DASHBOARD_CAPTION_RIGHT_PAD: usize = 3;
+
+pub(super) struct DashboardPetColumn {
+    pub(super) width: usize,
+    pub(super) caption: Line<'static>,
+    pub(super) body: Vec<Line<'static>>,
+}
 
 pub(super) fn pet_panel_lines(
     pet: Option<&PetView>,
@@ -30,49 +39,46 @@ pub(super) fn pet_panel_lines(
     vec![centered_caption(fallback, theme, width)]
 }
 
-pub(super) fn dashboard_pet_caption(pet: Option<&PetView>) -> Option<&str> {
-    pet_caption(pet)
-}
-
-pub(super) fn dashboard_pet_grid_lines(
+pub(super) fn dashboard_pet_column(
     pet: Option<&PetView>,
     theme: &Theme,
-    width: usize,
-) -> Vec<Line<'static>> {
-    if let Some(pixel) = theme
-        .pet_body_enabled()
-        .then(|| pet.and_then(|view| pet_pixel(view)))
-        .flatten()
-    {
-        let pixel_style = Style::default().fg(image_id_color(pixel.image_id));
-        let pet_width = usize::from(pixel.size.cols).min(width);
-        let left = width.saturating_sub(pet_width);
-        let mut lines = (0..pixel.size.rows)
-            .map(|row| {
-                let mut spans = Vec::with_capacity(pet_width + usize::from(left > 0));
-                if left > 0 {
-                    spans.push(Span::raw(" ".repeat(left)));
-                }
-                spans
-                    .extend((0..pet_width).map(|col| {
-                        Span::styled(placeholder_cluster(row, col as u16), pixel_style)
-                    }));
-                Line::from(spans)
-            })
-            .collect::<Vec<_>>();
-        lines.push(Line::from(" ".repeat(width)));
-        return lines;
+    dashboard_width: usize,
+) -> Option<DashboardPetColumn> {
+    if !theme.pet_body_enabled() {
+        return None;
     }
-    let Some(grid) = theme
-        .pet_body_enabled()
-        .then(|| pet.and_then(|view| pet_cell_grid(view)))
-        .flatten()
-    else {
-        return Vec::new();
+    let pet = pet?;
+    let (width, mut body) = match pet.body.as_ref()? {
+        PetBody::Pixel(pixel) => {
+            let width = usize::from(pixel.size.cols);
+            let pixel_style = Style::default().fg(image_id_color(pixel.image_id));
+            let lines = (0..pixel.size.rows)
+                .map(|row| {
+                    Line::from(
+                        (0..width)
+                            .map(|col| {
+                                Span::styled(placeholder_cluster(row, col as u16), pixel_style)
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect();
+            (width, lines)
+        }
+        PetBody::Cell(grid) => {
+            let width = grid.iter().map(Vec::len).max().unwrap_or(0);
+            (width, grid_lines(grid, width))
+        }
     };
-    let mut lines = grid_lines(grid, width);
-    lines.push(Line::from(" ".repeat(width)));
-    lines
+    if width == 0 {
+        return None;
+    }
+    body.push(Line::from(" ".repeat(width)));
+    Some(DashboardPetColumn {
+        width,
+        caption: dashboard_caption_line(pet.caption.as_deref(), theme, dashboard_width),
+        body,
+    })
 }
 
 fn pet_caption(pet: Option<&PetView>) -> Option<&str> {
@@ -86,11 +92,25 @@ fn pet_cell_grid(view: &PetView) -> Option<&PetCellGrid> {
     }
 }
 
-fn pet_pixel(view: &PetView) -> Option<&crate::sidebar_pane::pets::PetPixelView> {
-    match view.body.as_ref()? {
-        PetBody::Pixel(pixel) => Some(pixel),
-        PetBody::Cell(_) => None,
+fn dashboard_caption_line(caption: Option<&str>, theme: &Theme, width: usize) -> Line<'static> {
+    let Some(caption) = caption else {
+        return Line::from("");
+    };
+    let caption_w = width.saturating_sub(DASHBOARD_CAPTION_RIGHT_PAD);
+    let clipped = clip(caption, caption_w);
+    let lead = caption_w.saturating_sub(text_width(&clipped));
+    let mut spans = Vec::new();
+    if lead > 0 {
+        spans.push(Span::raw(" ".repeat(lead)));
     }
+    if !clipped.is_empty() {
+        spans.push(Span::styled(clipped, theme.muted()));
+    }
+    let trail = width.saturating_sub(caption_w);
+    if trail > 0 {
+        spans.push(Span::raw(" ".repeat(trail)));
+    }
+    Line::from(spans)
 }
 
 /// The sprite pinned to the right edge, with its caption set to the left,

--- a/crates/rimz/src/sidebar_pane/render/sections/provider.rs
+++ b/crates/rimz/src/sidebar_pane/render/sections/provider.rs
@@ -3,7 +3,7 @@
 
 use crate::agents::{AgentStatus, ExtraCredits, RateLimitWindow};
 use crate::config::{BudgetBarConfig, GlyphRole};
-use crate::sidebar_pane::pets::{PetBody, PetView};
+use crate::sidebar_pane::pets::PetView;
 use crate::{RemoteControlBadge, SidebarProviderPanel, SpendTally, SpendWindow};
 use jiff::{SignedDuration, Timestamp};
 use ratatui::style::{Color, Modifier, Style};
@@ -46,10 +46,6 @@ const PROVIDER_NORMAL_MIN_WIDTH: usize = 40;
 /// Blank cells between the active provider block and the pet column when the
 /// pet rides beside the dashboard.
 const PET_COLUMN_GAP: usize = 1;
-
-/// Pet captions leave three trailing cells so their right edge lines up with the
-/// sprite body's inner gap.
-const PET_CAPTION_RIGHT_PAD: usize = 3;
 
 /// The provider bar's label slot (`5h` / `7d` / `30d` / `ex` / `api`) and value
 /// column, shared by every provider bar so they align front and back. The label
@@ -503,20 +499,17 @@ pub(in crate::sidebar_pane::render) fn dashboard_block(
     ));
 
     if context.mode == DashboardMode::Pet
-        && let Some(pet_w) = pet_column_width(context.theme, context.pet)
-        && pet_w + PET_COLUMN_GAP < context.width
+        && let Some(pet) =
+            super::pets::dashboard_pet_column(context.pet, context.theme, context.width)
+        && pet.width + PET_COLUMN_GAP < context.width
     {
+        let pet_w = pet.width;
         let block_w = context.width.saturating_sub(pet_w + PET_COLUMN_GAP);
-        output.push_inert(provider_pet_caption_line(
-            context.theme,
-            context.pet,
-            context.width,
-        ));
+        output.push_inert(pet.caption);
         let block = provider_block_lines(&context, active, block_w, None);
-        let pet_lines = super::pets::dashboard_pet_grid_lines(context.pet, context.theme, pet_w);
         let footer_rows = usize::from(context.folded_footer.is_some());
         let block_rows = block.len() + footer_rows;
-        let pet_rows = pet_lines.len();
+        let pet_rows = pet.body.len();
         let rows = block_rows.max(pet_rows);
         let footer = context
             .folded_footer
@@ -524,7 +517,7 @@ pub(in crate::sidebar_pane::render) fn dashboard_block(
             .map(|footer| folded_footer_line(footer, block_w));
         output.extend_inert(zip_provider_pet_lines(
             block,
-            pet_lines,
+            pet.body,
             footer,
             ProviderPetZipLayout {
                 pet_top: rows.saturating_sub(pet_rows),
@@ -597,40 +590,6 @@ fn provider_block_lines(
 
 fn folded_footer_line(parts: super::super::chrome::FooterParts, width: usize) -> Line<'static> {
     pin_right(parts.left, vec![parts.help], width)
-}
-
-fn pet_column_width(theme: &Theme, pet: Option<&PetView>) -> Option<usize> {
-    theme
-        .pet_body_enabled()
-        .then(|| {
-            pet.and_then(|view| match view.body.as_ref()? {
-                PetBody::Pixel(pixel) => Some(usize::from(pixel.size.cols)),
-                PetBody::Cell(grid) => grid.iter().map(Vec::len).max(),
-            })
-        })
-        .flatten()
-        .filter(|width| *width > 0)
-}
-
-fn provider_pet_caption_line(theme: &Theme, pet: Option<&PetView>, width: usize) -> Line<'static> {
-    let Some(caption) = super::pets::dashboard_pet_caption(pet) else {
-        return Line::from("");
-    };
-    let caption_w = width.saturating_sub(PET_CAPTION_RIGHT_PAD);
-    let clipped = clip(caption, caption_w);
-    let lead = caption_w.saturating_sub(text_width(&clipped));
-    let mut spans = Vec::new();
-    if lead > 0 {
-        spans.push(Span::raw(" ".repeat(lead)));
-    }
-    if !clipped.is_empty() {
-        spans.push(Span::styled(clipped, theme.muted()));
-    }
-    let trail = width.saturating_sub(caption_w);
-    if trail > 0 {
-        spans.push(Span::raw(" ".repeat(trail)));
-    }
-    Line::from(spans)
 }
 
 struct ProviderPetZipLayout {

--- a/crates/rimz/src/sidebar_pane/supervise.rs
+++ b/crates/rimz/src/sidebar_pane/supervise.rs
@@ -927,12 +927,7 @@ fn request_worker_handoff(
         debug!(error = %err, "sidebar supervisor worker handoff nudge failed");
     }
     if let Some(target) = target {
-        crate::diag::DiagSink::for_workspace(
-            config.workspace_id.clone(),
-            config.session_name.clone(),
-            Some(config.instance_id.clone()),
-        )
-        .emit(DiagEvent::SupervisorConvergence {
+        diag_sink(config).emit(DiagEvent::SupervisorConvergence {
             target_build: target.build.clone(),
         });
     }
@@ -969,12 +964,7 @@ fn record_signal_death(
     exit_code: Option<i32>,
     stderr_excerpt: String,
 ) {
-    let diag = crate::diag::DiagSink::for_workspace(
-        config.workspace_id.clone(),
-        config.session_name.clone(),
-        Some(config.instance_id.clone()),
-    );
-    diag.emit(DiagEvent::RendererSignalDeath {
+    diag_sink(config).emit(DiagEvent::RendererSignalDeath {
         signal,
         exit_code,
         stderr_excerpt: stderr_excerpt.clone(),
@@ -983,12 +973,7 @@ fn record_signal_death(
 }
 
 fn record_orphan_reap(config: &ServeConfig, worker_pid: i32) {
-    crate::diag::DiagSink::for_workspace(
-        config.workspace_id.clone(),
-        config.session_name.clone(),
-        Some(config.instance_id.clone()),
-    )
-    .emit(DiagEvent::RendererOrphanReaped {
+    diag_sink(config).emit(DiagEvent::RendererOrphanReaped {
         pane_id: config
             .own_pane
             .as_ref()
@@ -1011,38 +996,31 @@ fn preflight_supervisor(exe: &Path) -> std::result::Result<(), String> {
 }
 
 fn record_preflight_rejected(config: &ServeConfig, target_build: &str, reason: &str) {
-    crate::diag::DiagSink::for_workspace(
-        config.workspace_id.clone(),
-        config.session_name.clone(),
-        Some(config.instance_id.clone()),
-    )
-    .emit(DiagEvent::SupervisorPreflightRejected {
+    diag_sink(config).emit(DiagEvent::SupervisorPreflightRejected {
         target_build: target_build.to_owned(),
         reason: reason.to_owned(),
     });
 }
 
 fn record_self_close_rejected(config: &ServeConfig, siblings: usize, reason: &str) {
-    crate::diag::DiagSink::for_workspace(
-        config.workspace_id.clone(),
-        config.session_name.clone(),
-        Some(config.instance_id.clone()),
-    )
-    .emit(DiagEvent::SelfCloseRejected {
+    diag_sink(config).emit(DiagEvent::SelfCloseRejected {
         siblings,
         reason: reason.to_owned(),
     });
 }
 
 fn record_confirmed_self_close(config: &ServeConfig) {
+    diag_sink(config).emit_unlimited(DiagEvent::RendererExit {
+        cause: crate::diag::record::RendererExitCause::SelfCloseEmptyTab,
+    });
+}
+
+fn diag_sink(config: &ServeConfig) -> crate::diag::DiagSink {
     crate::diag::DiagSink::for_workspace(
         config.workspace_id.clone(),
         config.session_name.clone(),
         Some(config.instance_id.clone()),
     )
-    .emit_unlimited(DiagEvent::RendererExit {
-        cause: crate::diag::record::RendererExitCause::SelfCloseEmptyTab,
-    });
 }
 
 fn remove_orphan_runtime_files(config: &ServeConfig) {
@@ -1152,32 +1130,17 @@ fn render_program(exe: &std::path::Path) -> String {
 
 #[cfg(feature = "testkit")]
 fn reap_poll_interval() -> Duration {
-    let Some(value) = env::var_os(TEST_REAP_POLL_MS_ENV).filter(|value| !value.is_empty()) else {
-        return REAP_POLL_INTERVAL;
-    };
-    value
-        .to_str()
-        .and_then(|value| value.parse::<u64>().ok())
-        .map(Duration::from_millis)
-        .unwrap_or(REAP_POLL_INTERVAL)
+    duration_override(TEST_REAP_POLL_MS_ENV, REAP_POLL_INTERVAL)
 }
 
 #[cfg(feature = "testkit")]
 fn respawn_delay(delay: Duration) -> Duration {
-    env::var(TEST_RESPAWN_BACKOFF_MS_ENV)
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .map(Duration::from_millis)
-        .unwrap_or(delay)
+    duration_override(TEST_RESPAWN_BACKOFF_MS_ENV, delay)
 }
 
 #[cfg(feature = "testkit")]
 fn record_poll_interval() -> Duration {
-    env::var(TEST_RECORD_POLL_MS_ENV)
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .map(Duration::from_millis)
-        .unwrap_or(RECORD_POLL_INTERVAL)
+    duration_override(TEST_RECORD_POLL_MS_ENV, RECORD_POLL_INTERVAL)
 }
 
 #[cfg(not(feature = "testkit"))]
@@ -1187,11 +1150,7 @@ fn record_poll_interval() -> Duration {
 
 #[cfg(feature = "testkit")]
 fn respawn_stable_run() -> Duration {
-    env::var(TEST_STABLE_RUN_MS_ENV)
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .map(Duration::from_millis)
-        .unwrap_or(RESPAWN_STABLE_RUN)
+    duration_override(TEST_STABLE_RUN_MS_ENV, RESPAWN_STABLE_RUN)
 }
 
 #[cfg(not(feature = "testkit"))]
@@ -1201,11 +1160,7 @@ fn respawn_stable_run() -> Duration {
 
 #[cfg(feature = "testkit")]
 fn worker_handoff_grace() -> Duration {
-    env::var(TEST_HANDOFF_GRACE_MS_ENV)
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .map(Duration::from_millis)
-        .unwrap_or(WORKER_HANDOFF_GRACE)
+    duration_override(TEST_HANDOFF_GRACE_MS_ENV, WORKER_HANDOFF_GRACE)
 }
 
 #[cfg(not(feature = "testkit"))]
@@ -1220,16 +1175,16 @@ fn respawn_delay(delay: Duration) -> Duration {
 
 #[cfg(feature = "testkit")]
 fn pane_probe_interval() -> Duration {
-    let Some(value) =
-        env::var_os(TEST_PANE_PROBE_INTERVAL_MS_ENV).filter(|value| !value.is_empty())
-    else {
-        return PANE_PROBE_INTERVAL;
-    };
-    value
-        .to_str()
-        .and_then(|value| value.parse::<u64>().ok())
+    duration_override(TEST_PANE_PROBE_INTERVAL_MS_ENV, PANE_PROBE_INTERVAL)
+}
+
+#[cfg(feature = "testkit")]
+fn duration_override(name: &str, default: Duration) -> Duration {
+    env::var_os(name)
+        .filter(|value| !value.is_empty())
+        .and_then(|value| value.to_str()?.parse::<u64>().ok())
         .map(Duration::from_millis)
-        .unwrap_or(PANE_PROBE_INTERVAL)
+        .unwrap_or(default)
 }
 
 #[cfg(not(feature = "testkit"))]

--- a/crates/rimz/src/store/parse_cache.rs
+++ b/crates/rimz/src/store/parse_cache.rs
@@ -23,12 +23,13 @@
 //! and is never shared across threads.
 
 use std::cell::RefCell;
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-#[cfg(unix)]
-use std::os::unix::fs::MetadataExt;
+use serde::de::DeserializeOwned;
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub(crate) struct FileStamp {
@@ -151,5 +152,19 @@ impl<T> ParseCache<T> {
             stamp: EntryStamp::File(stamped.stamp),
             value,
         });
+    }
+}
+
+impl<T: DeserializeOwned> ParseCache<T> {
+    /// Read one JSON value under the file identity observed before the read,
+    /// reusing this thread's last parse when that identity still matches.
+    pub(crate) fn read_stamped_json(&self, path: &Path) -> Option<Arc<T>> {
+        let stamped = StampedPath::of(path);
+        if let Some(value) = self.get_stamped(&stamped) {
+            return Some(value);
+        }
+        let value = Arc::new(serde_json::from_slice(&std::fs::read(path).ok()?).ok()?);
+        self.store_stamped(&stamped, Arc::clone(&value));
+        Some(value)
     }
 }


### PR DESCRIPTION
## Context

`crates/rimz/src/sidebar/` and `crates/rimz/src/sidebar_pane/` hold roughly 54k non-test lines, and the churn concentrates at a handful of seams where ownership had drifted shallow — a caller ended up holding choreography or state that the module below it should have owned. This pass takes the four worst and pushes the knowledge down. No observable behavior moves.

- **Pet asset loading** kept its lifecycle in three independent `Option` fields (`loaded`, `loading`, `failed`) although the docs specify exactly one load state. The `(pet id, PreparationKey)` identity check and the sibling-clearing dance were re-derived at every site: reset, view, poll, mismatch invalidation, retry gating, and each of the three asset lookups. The original pet commit introduced the shape; adding off-thread cell preparation later threaded `PreparationKey` through all three slots and multiplied the branches.
- **Dashboard pet rendering** straddled two modules. The provider section opened `PetBody`, computed the sprite's intrinsic width, pulled the caption through a pass-through, and laid the caption out; the pets section separately rendered body lines. Layout sizing, a wide-caption fix, and the pixel tier each accumulated across that seam.
- **Three call sites** repeated the same stat / cache-probe / read / deserialize / store choreography around `ParseCache`, because the cache stopped one step short of the operation every caller actually wanted.
- **The sidebar supervisor** rebuilt the same workspace/session/instance diagnostic sink at six sites and repeated the same millisecond environment parser at six more.

## Design choices

**One exclusive pet load state, whose failed variant can hold a retry.** `PetLoadState` is `Empty | Loading | Loaded | Failed`, each non-empty variant carrying a `PetLoadRequest` of `(id, key)`. `Failed` holds an optional retry receiver instead of transitioning back to `Loading`. That looks less textbook and is deliberate: the old code left `failed` and `loading` set simultaneously during a cooldown retry, so the failure caption outranked the loading caption for the whole retry window. Modelling a retry as a plain `Loading` would surface `"fetching pet..."` where the old code showed `"pet unavailable"`. This encoding preserves both the caption precedence and the loading frame cadence while still reducing three lifecycle slots to one.

Rejected: a separate `Retrying` variant. It duplicates `Failed`'s cooldown latch and forces the caption and cadence sites to match two variants where they now match one.

**The complete pet column behind the pets section.** `dashboard_pet_column` returns intrinsic width, the caption line, and body plus spacer as a single value. The provider section applies the strict-fit rule (`column width + gap < dashboard width`), sizes its own block, and zips. Provider no longer names `PetBody` at all.

Rejected: leaving width in provider and moving only the caption. That keeps the `PetBody` match in two modules — the split that let the layout, caption, and tier changes accumulate across the seam in the first place.

**A typed stamped-JSON read on `ParseCache`, not a verdict cache.** `read_stamped_json` stamps the file, serves this thread's last parse when the identity still matches, and otherwise reads and deserializes under that same stamp. Session name, schema version, and source stamps stay at the callers, per the cache's documented contract that it caches the parse and never a verdict.

Rejected: folding the remaining `(mtime, len)`-keyed `get`/`store` pair into the same helper. Its one caller, `store/snapshot/assemble.rs`, supplies identity from a stat it already holds and mutates the value — re-stamping the projection clock at the read instant — before both returning and caching it. A generic read-parse-store helper cannot express caller-supplied identity plus mutate-before-cache without dragging caller policy into the cache, so the two-variant stamp enum stays.

**Private helpers for the repeated supervisor plumbing.** One `diag_sink(config)` for the six diagnostic records, one `#[cfg(feature = "testkit")] duration_override(name, default)` for the six timer overrides. The `emit` versus `emit_unlimited` choice per record is preserved, as are the non-testkit constant-returning functions and every worker, watchdog, reload, and self-close branch.

## Implementation

Five atomic commits, one per seam plus a lint fix:

- `refactor(pets): make asset loading state exclusive`
- `refactor(sidebar): project complete pet columns together`
- `refactor(store): own stamped JSON reads in parse cache`
- `refactor(sidebar): centralize supervisor support plumbing`
- `refactor(sidebar): scope Arc import to cache test`

Touched production source is down 41 physical lines (281 insertions against 322 deletions across the seven non-test files), and three private top-level types disappear (`LoadedPet`, `LoadingPet`, `FailedPet`).

### Evidence the pass is behavior-preserving

- **No golden moved.** `git diff --stat <merge-base> -- '*.snap'` is empty. Since the pet-column rehome is the one change whose output is a rendered frame, an unchanged golden set is the direct proof for it. The suite covering that seam — cell sprite and caption, pixel placeholder clusters, image-id buffer color, the totals spacer row, totals balanced beside the pet, the three-trailing-cell caption alignment, the no-pet fallback body, dashboard total rows, and the footer folded left of the pet — passes untouched.
- **The pixel body's leading-pad branch was dead.** The old `dashboard_pet_grid_lines` was only ever called with `width` equal to the pixel column's own `cols`, so its `pet_width = cols.min(width)` clamp and `left` pad always resolved to `cols` and `0`. Dropping them is byte-identical, not a narrowing.
- **The pet state audit.** Of the four ways the old three-`Option` model could hold two slots at once, three are unreachable: `ensure_loading` returned early on a matching `loaded`, cleared `loaded` before every spawn, and `clear_mismatched_pet` ran immediately before it on the same `(id, key)`. The single reachable overlap is `loading` plus `failed` for the *same* request, which is the cooldown-retry window, and that is precisely what `Failed { retry_receiver: Some(_) }` encodes. The retry test now pins the frame interval, the caption, and the state shape inside that window.
- **Preserved across the state collapse and checked individually:** the 20-second retry cooldown and its one-in-flight cap, the thread-disconnect failure path, same-pet asset retention when the frame carries no body, stale asset and receiver removal on pet/tier/size/cell-aspect change, pixel preparation ignoring cell aspect, jump reset timing, and the disabled-config-clears-unread versus empty-selector-does-not distinction.
- **Gates:** `cargo xtask gate` passes (fmt, invariants, docs-links, lint, test), `cargo xtask invariants` passes, and the focused suites are green — 735 tests under `sidebar_pane`, 540 under `sidebar::`.

### Deviations from the plan

- The plan asked for the failed state and the loading state to be distinct. They are not quite: `Failed` can own an in-flight retry receiver. The reason is behavior preservation, above, and it is recorded on the blackboard as a decision.
- Routing agent projection through `read_stamped_json` also changed that caller's cache key. It moved from `(path, mtime, len)` to `(path, mtime, len, device, inode)`, the identity workspace projection already used. The plan's contract said cache acceptance would not move, and here it did — in the safe direction only. The new key is strictly narrower, so it can turn a hit into a miss but can never mint a wrong hit; an atomic replacement at equal length inside one mtime tick, which the old key served stale, is now correctly re-parsed. `read_published` still filters the result on `session_name`, so the caller-side validation contract is unchanged either way.
- A fifth commit was needed after `cargo xtask gate` flagged a now-unused production `use std::sync::Arc` in `sidebar/agent_projection.rs`; the import moved into the test module.

## Advisories

- `render/sections/pets.rs:17` — `DashboardPetColumn` mixes two width scales: `width` and `body` are the pet column's intrinsic width, while `caption` is laid out at the full dashboard width and ignores `width`. Both the struct and `dashboard_pet_column` are the only items in that file without a doc comment. One line naming the two scales would close the trap. Left as-is; the sole consumer is three lines away and the `dashboard_width` parameter name telegraphs it.
- `store/parse_cache.rs` now carries two stamping conventions with one caller each. That is justified today (see the rejected alternative above), but if `assemble.rs` ever stops mutating before caching, `EntryStamp` collapses to a single variant and `get`/`store` go with it.
