### PR TITLE
refactor(harness): deepen launch and automation plumbing

### DIFF
--- a/crates/rimz/src/child_process.rs
+++ b/crates/rimz/src/child_process.rs
@@ -2,6 +2,7 @@
 //! fire-and-forget children to the global reaper and supervise foreground
 //! children with event-driven exit and signal waits.
 
+use std::ffi::OsStr;
 use std::io;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
@@ -215,8 +216,8 @@ fn signal_child(pid: u32, signal: ChildSignal) {
     let _ = kill(Pid::from_raw(pid as i32), signal);
 }
 
-/// Build a detached `rimz` helper command, anchored to RimZ-owned shared
-/// disk_usage so a deleted launch CWD cannot ENOENT the spawn.
+/// Build a detached `rimz` command with fresh null stdio, anchored to RimZ-owned
+/// shared disk usage so a deleted launch CWD cannot ENOENT the spawn.
 pub(crate) fn detached_rimz_command(exe: PathBuf, runtime: &RuntimePaths) -> Command {
     let mut cmd = Command::new(exe);
     cmd.current_dir(&runtime.shared_root)
@@ -224,6 +225,40 @@ pub(crate) fn detached_rimz_command(exe: PathBuf, runtime: &RuntimePaths) -> Com
         .stdout(Stdio::null())
         .stderr(Stdio::null());
     cmd
+}
+
+fn detached_rimz_helper_command<I, S>(runtime: &RuntimePaths, args: I) -> Command
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut cmd = detached_rimz_command(crate::proc::rimz_exe(), runtime);
+    cmd.args(args);
+    cmd
+}
+
+/// Spawn one detached RimZ helper. Unit tests compile the exact command but
+/// suppress the subprocess centrally so policy tests cannot leak helpers.
+pub(crate) fn spawn_detached_rimz<I, S>(
+    runtime: &RuntimePaths,
+    args: I,
+    label: &'static str,
+) -> io::Result<()>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let cmd = detached_rimz_helper_command(runtime, args);
+    #[cfg(not(test))]
+    {
+        let mut cmd = cmd;
+        spawn_detached_reaped(&mut cmd, label).map(drop)
+    }
+    #[cfg(test)]
+    {
+        let _ = (cmd, label);
+        Ok(())
+    }
 }
 
 /// Spawn `cmd` detached and hand its `Child` to the global reaper thread so the
@@ -378,9 +413,25 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let workspace = crate::ids::WorkspaceId::from_project_root(dir.path());
         let runtime = RuntimePaths::under(workspace, dir.path()).unwrap();
-        let cmd = detached_rimz_command(std::path::PathBuf::from("/nonexistent/rimz"), &runtime);
+        let cmd = detached_rimz_helper_command(&runtime, ["agents", "auto-continue"]);
 
+        assert_eq!(cmd.get_program(), crate::proc::rimz_exe());
         assert_eq!(cmd.get_current_dir(), Some(runtime.shared_root.as_path()));
+        assert_eq!(
+            cmd.get_args().collect::<Vec<_>>(),
+            [OsStr::new("agents"), OsStr::new("auto-continue")]
+        );
+    }
+
+    #[test]
+    fn detached_rimz_helper_does_not_spawn_in_unit_tests() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = crate::ids::WorkspaceId::from_project_root(dir.path());
+        let mut runtime = RuntimePaths::under(workspace, dir.path()).unwrap();
+        runtime.shared_root = dir.path().join("missing");
+
+        spawn_detached_rimz(&runtime, ["agents", "auto-continue"], "test-helper")
+            .expect("unit-test spawn suppression");
     }
 
     #[test]

--- a/crates/rimz/src/cli/agents_cmd/launch.rs
+++ b/crates/rimz/src/cli/agents_cmd/launch.rs
@@ -276,15 +276,16 @@ pub(super) fn launch_layout(
         |channel| format!("#{channel}"),
     );
     let sidebar = room.sidebar_options(&cwd, Vec::new(), None);
-    let pane_plans = agent_pane_plans(&layout, None, launch_batch.identities(), None)?;
-    let panes = layout_panes_with_names(
+    let panes = compile_layout_panes(
         &layout,
-        LayoutPaneParams {
+        CompileLayoutPanes {
             cwd: &cwd,
             cleanup_worktree: worktree_launch,
             in_place,
+            resume_seeds: None,
+            launch_identities: launch_batch.identities(),
+            fallback_channel: None,
         },
-        &pane_plans,
     )?;
     super::placement::execute(
         backend,
@@ -424,20 +425,16 @@ fn launch_resume_layout(
         |channel| format!("#{channel}"),
     );
     let sidebar = room.sidebar_options(&cwd, Vec::new(), None);
-    let pane_plans = agent_pane_plans(
+    let panes = compile_layout_panes(
         &layout,
-        Some(&plan.seeds),
-        launch_batch.identities(),
-        channel.as_deref(),
-    )?;
-    let panes = layout_panes_with_names(
-        &layout,
-        LayoutPaneParams {
+        CompileLayoutPanes {
             cwd: &cwd,
             cleanup_worktree: false,
             in_place,
+            resume_seeds: Some(&plan.seeds),
+            launch_identities: launch_batch.identities(),
+            fallback_channel: channel.as_deref(),
         },
-        &pane_plans,
     )?;
     if in_place {
         report_cohort_resume(&plan);

--- a/crates/rimz/src/cli/agents_cmd/launch.rs
+++ b/crates/rimz/src/cli/agents_cmd/launch.rs
@@ -278,7 +278,7 @@ pub(super) fn launch_layout(
     let sidebar = room.sidebar_options(&cwd, Vec::new(), None);
     let panes = compile_layout_panes(
         &layout,
-        CompileLayoutPanes {
+        LayoutPaneParams {
             cwd: &cwd,
             cleanup_worktree: worktree_launch,
             in_place,
@@ -427,7 +427,7 @@ fn launch_resume_layout(
     let sidebar = room.sidebar_options(&cwd, Vec::new(), None);
     let panes = compile_layout_panes(
         &layout,
-        CompileLayoutPanes {
+        LayoutPaneParams {
             cwd: &cwd,
             cleanup_worktree: false,
             in_place,

--- a/crates/rimz/src/cli/agents_cmd/mod.rs
+++ b/crates/rimz/src/cli/agents_cmd/mod.rs
@@ -44,9 +44,9 @@ pub(super) use crate::cli::Ctx;
 use crate::cli::supervised;
 use rimz::agents::AgentState;
 use rimz::harness::plan::{
-    LaunchFinalizeOptions, LayoutPaneParams, Placement, ResolvedLaunch, agent_pane_plans,
-    apply_in_place_downgrade, cohort_cells, launch_identity_requests, layout_panes_with_names,
-    mint_launch_id, resolve_fork_placement, resolve_placement, validate_agent_name,
+    CompileLayoutPanes, LaunchFinalizeOptions, Placement, ResolvedLaunch, apply_in_place_downgrade,
+    cohort_cells, compile_layout_panes, launch_identity_requests, mint_launch_id,
+    resolve_fork_placement, resolve_placement, validate_agent_name,
 };
 use rimz::harness::resume::{PostureDegrade, ResumePosture};
 use rimz::harness::run::{PermissionMode, RunRecord, RunStatus};

--- a/crates/rimz/src/cli/agents_cmd/mod.rs
+++ b/crates/rimz/src/cli/agents_cmd/mod.rs
@@ -44,7 +44,7 @@ pub(super) use crate::cli::Ctx;
 use crate::cli::supervised;
 use rimz::agents::AgentState;
 use rimz::harness::plan::{
-    CompileLayoutPanes, LaunchFinalizeOptions, Placement, ResolvedLaunch, apply_in_place_downgrade,
+    LaunchFinalizeOptions, LayoutPaneParams, Placement, ResolvedLaunch, apply_in_place_downgrade,
     cohort_cells, compile_layout_panes, launch_identity_requests, mint_launch_id,
     resolve_fork_placement, resolve_placement, validate_agent_name,
 };

--- a/crates/rimz/src/harness/auto_continue.rs
+++ b/crates/rimz/src/harness/auto_continue.rs
@@ -26,6 +26,7 @@
 //! arm decision is the pure, unit-tested [`resume_park`].
 
 use std::collections::BTreeSet;
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -38,13 +39,13 @@ use crate::agents::{
     AgentCardRef, AgentState, ProviderCapacity, TurnErrorClass, display_turn_error,
     effective_turn_error_class,
 };
-#[cfg(not(test))]
-use crate::child_process::detached_rimz_command;
 use crate::config::{DEFAULT_AUTO_CONTINUE_BACKOFF_SECS, ResumeConfig};
 use crate::ids::{AgentKind, AgentSessionId, MessageId, PaneId};
 use crate::message::{DeliveryGate, MessageBody, MessageRecord, MessageStatus};
 use crate::store::atomic::write_temp_then_rename_cache;
-use crate::store::snapshot::{PaneAgent, ResumeOutcome};
+#[cfg(test)]
+use crate::store::snapshot::PaneAgent;
+use crate::store::snapshot::ResumeOutcome;
 
 /// Minimum gap between auto-continue nudges to one rate-limit-parked agent. One
 /// nudge resumes the turn within a frame, so this mostly bounds the brief window
@@ -380,7 +381,7 @@ fn fire_if_due(agent: &AgentState, path: &Path, ctx: FireContext<'_>) {
     ) {
         return;
     }
-    let Some(pane_id) = live_pane(&ctx.snapshot.agent_panes, &agent.kind, &agent.agent_id) else {
+    let Some(pane_id) = ctx.snapshot.live_agent_pane(&agent.kind, &agent.agent_id) else {
         return;
     };
     let peers = crate::harness::target::addressable_agents(ctx.snapshot);
@@ -563,16 +564,6 @@ fn latest_resume_message<'a>(
         })
 }
 
-/// The live pane bound to one agent this frame, from the producer's pane fold. An
-/// agent with no bound live pane (absent from `agent_panes`) has nothing to type
-/// into.
-fn live_pane(panes: &[PaneAgent], kind: &AgentKind, agent_id: &AgentSessionId) -> Option<PaneId> {
-    panes
-        .iter()
-        .find(|pane| &pane.kind == kind && pane.agent_id.as_ref() == Some(agent_id))
-        .map(|pane| pane.pane_id.clone())
-}
-
 fn read_park(path: &Path) -> Option<ParkRecord> {
     let bytes = std::fs::read(path).ok()?;
     serde_json::from_slice(&bytes).ok()
@@ -599,7 +590,7 @@ fn park_record_path(
 ) -> PathBuf {
     runtime.root.join(format!(
         "auto-continue.{}.json",
-        crate::harness::budget::agent_digest(kind, agent_id)
+        crate::store::sidecar::digest(kind.as_str(), agent_id.as_str())
     ))
 }
 
@@ -638,7 +629,6 @@ pub(crate) fn budget_park_armed(
 /// resume-gated message. Best-effort: a spawn failure is logged without
 /// consuming an attempt; a spawned helper that dies before queueing is still
 /// paced by the durable nudge stamp.
-#[cfg(not(test))]
 fn spawn_auto_continue(
     runtime: &RuntimePaths,
     kind: &AgentKind,
@@ -648,31 +638,29 @@ fn spawn_auto_continue(
     text: &str,
     facts: AutoContinueFacts<'_>,
 ) -> bool {
-    let exe = crate::proc::rimz_exe();
-    let mut cmd = detached_rimz_command(exe, runtime);
-    cmd.args([
-        "agents",
-        "auto-continue",
-        "--workspace-id",
-        runtime.workspace_id.as_str(),
-        "--kind",
-        kind.as_str(),
-        "--agent-id",
-        agent_id.as_str(),
-        "--pane",
-        &pane_id.to_string(),
-        "--text",
-        text,
-        "--reason",
-        facts.reason,
-        "--parked-since",
-        &facts.parked_since.to_string(),
-    ]);
+    let mut args: Vec<OsString> = vec![
+        "agents".into(),
+        "auto-continue".into(),
+        "--workspace-id".into(),
+        runtime.workspace_id.as_str().into(),
+        "--kind".into(),
+        kind.as_str().into(),
+        "--agent-id".into(),
+        agent_id.as_str().into(),
+        "--pane".into(),
+        pane_id.to_string().into(),
+        "--text".into(),
+        text.into(),
+        "--reason".into(),
+        facts.reason.into(),
+        "--parked-since".into(),
+        facts.parked_since.to_string().into(),
+    ];
     if let Some(message_id) = message_id {
-        cmd.args(["--message-id", message_id.as_str()]);
+        args.extend([OsString::from("--message-id"), message_id.as_str().into()]);
     }
     if let Some(label) = facts.label {
-        cmd.args(["--label", label]);
+        args.extend([OsString::from("--label"), label.into()]);
     }
     tracing::info!(
         target: crate::observability::BREADCRUMB_TARGET,
@@ -681,7 +669,9 @@ fn spawn_auto_continue(
         reason = facts.reason,
         "sidebar: auto-continuing parked agent",
     );
-    if let Err(err) = crate::child_process::spawn_detached_reaped(&mut cmd, "agent-auto-continue") {
+    if let Err(err) =
+        crate::child_process::spawn_detached_rimz(runtime, args, "agent-auto-continue")
+    {
         // Best-effort enrichment on a throttled producer path. The CWD anchor
         // clears the gc'd-worktree ENOENT; a bad RIMZ_BIN/PATH is an
         // environment fact, not a RimZ fault. Keep it at debug! so it never
@@ -694,35 +684,6 @@ fn spawn_auto_continue(
         );
         return false;
     }
-    true
-}
-
-#[cfg(test)]
-fn spawn_auto_continue(
-    runtime: &RuntimePaths,
-    kind: &AgentKind,
-    agent_id: &AgentSessionId,
-    pane_id: &PaneId,
-    message_id: Option<&MessageId>,
-    text: &str,
-    facts: AutoContinueFacts<'_>,
-) -> bool {
-    let AutoContinueFacts {
-        reason,
-        parked_since,
-        label,
-    } = facts;
-    let _ = (
-        runtime,
-        kind,
-        agent_id,
-        pane_id,
-        message_id,
-        text,
-        reason,
-        parked_since,
-        label,
-    );
     true
 }
 

--- a/crates/rimz/src/harness/auto_continue/tests.rs
+++ b/crates/rimz/src/harness/auto_continue/tests.rs
@@ -136,6 +136,18 @@ fn park_path(runtime: &RuntimePaths) -> PathBuf {
     park_record_path(runtime, &AgentKind::new_unchecked("claude"), &"sess".into())
 }
 
+#[test]
+fn park_cache_path_preserves_existing_name() {
+    let (_dir, runtime) = temp_runtime();
+
+    assert_eq!(
+        park_path(&runtime)
+            .file_name()
+            .and_then(|name| name.to_str()),
+        Some("auto-continue.4a8d94f232e55a6a0879ba0858b59241.json")
+    );
+}
+
 fn agent(activity: i64) -> AgentState {
     let mut agent = crate::sidebar::test_support::root_agent("claude", "sess", None);
     agent.name = None;

--- a/crates/rimz/src/harness/auto_redeem.rs
+++ b/crates/rimz/src/harness/auto_redeem.rs
@@ -8,6 +8,7 @@
 //! burn-rate cache; atomic replacement plus observation stamps make duplicate
 //! folds idempotent.
 
+use std::ffi::OsString;
 use std::path::Path;
 use std::str::FromStr;
 use std::time::Duration;
@@ -19,8 +20,6 @@ use crate::agents::account::{
     ProviderCapacity, RedemptionCode, ResetCreditResult, prepare_reset_credit_redemption,
 };
 use crate::agents::{AccountUsageSnapshot, RateLimitWindow, ResetCredits};
-#[cfg(not(test))]
-use crate::child_process::detached_rimz_command;
 use crate::config::ResumeConfig;
 use crate::harness::assist_log::AssistWindowReset;
 use crate::store::atomic::write_temp_then_rename_cache;
@@ -588,22 +587,19 @@ fn publish_usage(
     }
 }
 
-#[cfg(not(test))]
 fn spawn_auto_redeem(runtime: &RuntimePaths, reason: RedeemReason, request_id: &str) -> bool {
-    let exe = crate::proc::rimz_exe();
-    let mut cmd = detached_rimz_command(exe, runtime);
-    cmd.args([
-        "agents",
-        "auto-redeem",
-        "--workspace-id",
-        runtime.workspace_id.as_str(),
-        "--kind",
-        CODEX_KIND,
-        "--reason",
-        reason.as_str(),
-        "--request-id",
-        request_id,
-    ]);
+    let args: Vec<OsString> = vec![
+        "agents".into(),
+        "auto-redeem".into(),
+        "--workspace-id".into(),
+        runtime.workspace_id.as_str().into(),
+        "--kind".into(),
+        CODEX_KIND.into(),
+        "--reason".into(),
+        reason.as_str().into(),
+        "--request-id".into(),
+        request_id.into(),
+    ];
     tracing::info!(
         target: crate::observability::BREADCRUMB_TARGET,
         workspace = %runtime.workspace_id,
@@ -611,7 +607,8 @@ fn spawn_auto_redeem(runtime: &RuntimePaths, reason: RedeemReason, request_id: &
         reason = reason.as_str(),
         "sidebar: auto-redeeming reset credit",
     );
-    if let Err(err) = crate::child_process::spawn_detached_reaped(&mut cmd, "agent-auto-redeem") {
+    if let Err(err) = crate::child_process::spawn_detached_rimz(runtime, args, "agent-auto-redeem")
+    {
         tracing::debug!(
             workspace = %runtime.workspace_id,
             tags.operation = "auto_redeem.spawn",
@@ -620,12 +617,6 @@ fn spawn_auto_redeem(runtime: &RuntimePaths, reason: RedeemReason, request_id: &
         );
         return false;
     }
-    true
-}
-
-#[cfg(test)]
-fn spawn_auto_redeem(runtime: &RuntimePaths, reason: RedeemReason, request_id: &str) -> bool {
-    let _ = (runtime, reason, request_id);
     true
 }
 

--- a/crates/rimz/src/harness/budget.rs
+++ b/crates/rimz/src/harness/budget.rs
@@ -9,6 +9,7 @@
 //! graph.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsString;
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -1087,7 +1088,7 @@ fn interrupt_parked_agent(
     if agent.status != AgentStatus::Running || !interrupt_due(last_interrupt, ctx.now) {
         return;
     }
-    let Some(pane_id) = live_pane(ctx.snapshot, agent) else {
+    let Some(pane_id) = ctx.snapshot.live_agent_pane(&agent.kind, &agent.agent_id) else {
         return;
     };
 
@@ -1300,14 +1301,6 @@ fn is_budget_waiving_delivery(message: &MessageRecord) -> bool {
         && message.gate != DeliveryGate::Resume
 }
 
-fn live_pane(snapshot: &SidebarSnapshot, agent: &AgentState) -> Option<PaneId> {
-    snapshot
-        .agent_panes
-        .iter()
-        .find(|pane| pane.kind == agent.kind && pane.agent_id.as_ref() == Some(&agent.agent_id))
-        .map(|pane| pane.pane_id.clone())
-}
-
 fn interrupt_due(last: Option<Timestamp>, now: Timestamp) -> bool {
     last.is_none_or(|last| now.as_second() - last.as_second() >= INTERRUPT_RETRY_SECS)
 }
@@ -1471,30 +1464,29 @@ fn ledger_day_reset(ledger: &BudgetLedger, now: Timestamp, zone: &TimeZone) -> O
         .map(|zoned| zoned.timestamp())
 }
 
-#[cfg(not(test))]
 fn spawn_budget_park(
     runtime: &RuntimePaths,
     agent: &AgentState,
     pane_id: &PaneId,
     at_cost: Option<f64>,
 ) -> bool {
-    let mut cmd = crate::child_process::detached_rimz_command(crate::proc::rimz_exe(), runtime);
-    cmd.args([
-        "agents",
-        "budget-park",
-        "--workspace-id",
-        runtime.workspace_id.as_str(),
-        "--kind",
-        agent.kind.as_str(),
-        "--agent-id",
-        agent.agent_id.as_str(),
-        "--pane",
-        &pane_id.to_string(),
-    ]);
+    let mut args: Vec<OsString> = vec![
+        "agents".into(),
+        "budget-park".into(),
+        "--workspace-id".into(),
+        runtime.workspace_id.as_str().into(),
+        "--kind".into(),
+        agent.kind.as_str().into(),
+        "--agent-id".into(),
+        agent.agent_id.as_str().into(),
+        "--pane".into(),
+        pane_id.to_string().into(),
+    ];
     if let Some(at_cost) = at_cost {
-        cmd.arg("--at-cost").arg(at_cost.to_string());
+        args.extend([OsString::from("--at-cost"), at_cost.to_string().into()]);
     }
-    if let Err(err) = crate::child_process::spawn_detached_reaped(&mut cmd, "agent-budget-park") {
+    if let Err(err) = crate::child_process::spawn_detached_rimz(runtime, args, "agent-budget-park")
+    {
         tracing::debug!(
             workspace = %runtime.workspace_id,
             kind = %agent.kind,
@@ -1508,33 +1500,15 @@ fn spawn_budget_park(
     true
 }
 
-#[cfg(test)]
-fn spawn_budget_park(
-    _runtime: &RuntimePaths,
-    _agent: &AgentState,
-    _pane_id: &PaneId,
-    _at_cost: Option<f64>,
-) -> bool {
-    true
-}
-
 pub fn budget_ledger_path(
     runtime: &RuntimePaths,
     kind: &AgentKind,
     agent_id: &AgentSessionId,
 ) -> PathBuf {
-    runtime
-        .root
-        .join(format!("budget.{}.json", agent_digest(kind, agent_id)))
-}
-
-pub(crate) fn agent_digest(kind: &AgentKind, agent_id: &AgentSessionId) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(kind.as_str().as_bytes());
-    hasher.update([0]);
-    hasher.update(agent_id.as_str().as_bytes());
-    let digest = hex::encode(hasher.finalize());
-    digest[..32].to_owned()
+    runtime.root.join(format!(
+        "budget.{}.json",
+        crate::store::sidecar::digest(kind.as_str(), agent_id.as_str())
+    ))
 }
 
 pub fn read_ledger(

--- a/crates/rimz/src/harness/budget/tests.rs
+++ b/crates/rimz/src/harness/budget/tests.rs
@@ -35,10 +35,22 @@ fn budget_spec_accepts_canonical_forms_and_rejects_bad_values() {
 }
 
 #[test]
-fn agent_digest_preserves_existing_ledger_names() {
+fn budget_cache_path_preserves_existing_name() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let runtime = RuntimePaths::under(
+        crate::ids::WorkspaceId::from_project_root(dir.path()),
+        dir.path(),
+    )
+    .expect("runtime");
     assert_eq!(
-        agent_digest(&AgentKind::new_unchecked("claude"), &"sess".into()),
-        "4a8d94f232e55a6a0879ba0858b59241"
+        budget_ledger_path(
+            &runtime,
+            &AgentKind::new_unchecked("claude"),
+            &"sess".into()
+        )
+        .file_name()
+        .and_then(|name| name.to_str()),
+        Some("budget.4a8d94f232e55a6a0879ba0858b59241.json")
     );
 }
 

--- a/crates/rimz/src/harness/idle_compact.rs
+++ b/crates/rimz/src/harness/idle_compact.rs
@@ -5,6 +5,7 @@
 //! detached `rimz agents idle-compact` helper. The helper owns the durable
 //! message write; this module writes only a disposable pacing record.
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -12,8 +13,6 @@ use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
 use crate::agents::{AgentState, AgentStatus};
-#[cfg(not(test))]
-use crate::child_process::detached_rimz_command;
 use crate::config::{HarnessConfig, IdleCompactMode};
 use crate::ids::{AgentKind, AgentSessionId, PaneId};
 use crate::store::atomic::write_temp_then_rename_cache;
@@ -75,7 +74,7 @@ pub(crate) fn compact_idle_agents(
         ) {
             continue;
         }
-        let Some(pane_id) = live_pane(snapshot, agent) else {
+        let Some(pane_id) = snapshot.live_agent_pane(&agent.kind, &agent.agent_id) else {
             continue;
         };
         let (Some(command), Some(occupied)) = (command, occupied) else {
@@ -171,14 +170,6 @@ fn worktree_pr_open(agent: &AgentState, cache: &crate::sidebar::refresh::pr::PrS
     })
 }
 
-fn live_pane(snapshot: &SidebarSnapshot, agent: &AgentState) -> Option<PaneId> {
-    snapshot
-        .agent_panes
-        .iter()
-        .find(|pane| pane.kind == agent.kind && pane.agent_id.as_ref() == Some(&agent.agent_id))
-        .map(|pane| pane.pane_id.clone())
-}
-
 fn fire_record_path(
     runtime: &RuntimePaths,
     kind: &AgentKind,
@@ -186,7 +177,7 @@ fn fire_record_path(
 ) -> PathBuf {
     runtime.root.join("idle-compact").join(format!(
         "{}.json",
-        crate::harness::budget::agent_digest(kind, agent_id)
+        crate::store::sidecar::digest(kind.as_str(), agent_id.as_str())
     ))
 }
 
@@ -206,7 +197,6 @@ fn write_fire_record(path: &Path, record: &FireRecord) {
     }
 }
 
-#[cfg(not(test))]
 fn spawn_idle_compact(
     runtime: &RuntimePaths,
     kind: &AgentKind,
@@ -216,26 +206,24 @@ fn spawn_idle_compact(
     occupied: u64,
     label: &str,
 ) -> bool {
-    let exe = crate::proc::rimz_exe();
-    let mut cmd = detached_rimz_command(exe, runtime);
-    cmd.args([
-        "agents",
-        "idle-compact",
-        "--workspace-id",
-        runtime.workspace_id.as_str(),
-        "--kind",
-        kind.as_str(),
-        "--agent-id",
-        agent_id.as_str(),
-        "--pane",
-        &pane_id.to_string(),
-        "--command",
-        command,
-        "--occupied-tokens",
-        &occupied.to_string(),
-        "--label",
-        label,
-    ]);
+    let args: Vec<OsString> = vec![
+        "agents".into(),
+        "idle-compact".into(),
+        "--workspace-id".into(),
+        runtime.workspace_id.as_str().into(),
+        "--kind".into(),
+        kind.as_str().into(),
+        "--agent-id".into(),
+        agent_id.as_str().into(),
+        "--pane".into(),
+        pane_id.to_string().into(),
+        "--command".into(),
+        command.into(),
+        "--occupied-tokens".into(),
+        occupied.to_string().into(),
+        "--label".into(),
+        label.into(),
+    ];
     tracing::info!(
         target: crate::observability::BREADCRUMB_TARGET,
         workspace = %runtime.workspace_id,
@@ -243,7 +231,8 @@ fn spawn_idle_compact(
         occupied,
         "sidebar: compacting idle agent",
     );
-    if let Err(err) = crate::child_process::spawn_detached_reaped(&mut cmd, "agent-idle-compact") {
+    if let Err(err) = crate::child_process::spawn_detached_rimz(runtime, args, "agent-idle-compact")
+    {
         tracing::debug!(
             workspace = %runtime.workspace_id,
             tags.operation = "idle_compact.spawn",
@@ -252,20 +241,6 @@ fn spawn_idle_compact(
         );
         return false;
     }
-    true
-}
-
-#[cfg(test)]
-fn spawn_idle_compact(
-    runtime: &RuntimePaths,
-    kind: &AgentKind,
-    agent_id: &AgentSessionId,
-    pane_id: &PaneId,
-    command: &str,
-    occupied: u64,
-    label: &str,
-) -> bool {
-    let _ = (runtime, kind, agent_id, pane_id, command, occupied, label);
     true
 }
 
@@ -292,6 +267,24 @@ mod tests {
         agent.worktree_path = Some("/repo/worktree".to_owned());
         agent.worktree_branch = Some("feat/cache".to_owned());
         agent
+    }
+
+    #[test]
+    fn fire_cache_path_preserves_existing_name() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime = RuntimePaths::under(WorkspaceId::from_project_root(dir.path()), dir.path())
+            .expect("runtime");
+
+        assert_eq!(
+            fire_record_path(
+                &runtime,
+                &AgentKind::new_unchecked("claude"),
+                &"sess".into()
+            )
+            .file_name()
+            .and_then(|name| name.to_str()),
+            Some("4a8d94f232e55a6a0879ba0858b59241.json")
+        );
     }
 
     fn due(agent: &AgentState) -> bool {

--- a/crates/rimz/src/harness/plan.rs
+++ b/crates/rimz/src/harness/plan.rs
@@ -4,7 +4,7 @@
 use std::fmt;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 
 use crate::config::{LaunchPlacement, RoleBinding};
 use crate::harness::budget::BudgetSpec;
@@ -598,28 +598,27 @@ fn index_to_launch_ordinal(index: usize) -> u32 {
     u32::try_from(index).unwrap_or(u32::MAX)
 }
 
-#[derive(Debug)]
-enum AgentPanePlan<'a> {
-    Fresh(&'a AgentLaunchIdentity),
-    Resume {
-        agent: &'a crate::agents::AgentState,
-        fallback_channel: Option<&'a str>,
-    },
+#[derive(Clone, Copy)]
+pub struct CompileLayoutPanes<'a> {
+    pub cwd: &'a Path,
+    pub cleanup_worktree: bool,
+    pub in_place: bool,
+    pub resume_seeds: Option<&'a [CohortSeed]>,
+    pub launch_identities: &'a [AgentLaunchIdentity],
+    pub fallback_channel: Option<&'a str>,
 }
 
-/// Layout-aligned agent pane inputs. Construction validates every count before
-/// pane compilation can reach mux orchestration.
-#[derive(Debug)]
-pub struct AgentPanePlans<'a>(Vec<AgentPanePlan<'a>>);
-
-pub fn agent_pane_plans<'a>(
+/// Compile backend-neutral pane commands for a resolved layout.
+///
+/// This is the single layout-to-pane boundary: it validates launch inputs,
+/// keeps resumed and fresh agents aligned with their cells, and preserves
+/// command cells in layout order.
+pub fn compile_layout_panes(
     layout: &LayoutSpec,
-    resume_seeds: Option<&'a [CohortSeed]>,
-    launch_identities: &'a [AgentLaunchIdentity],
-    fallback_channel: Option<&'a str>,
-) -> Result<AgentPanePlans<'a>> {
+    params: CompileLayoutPanes<'_>,
+) -> Result<LayoutPanes> {
     let agent_count = layout.agent_cells().count();
-    if let Some(seeds) = resume_seeds
+    if let Some(seeds) = params.resume_seeds
         && seeds.len() != agent_count
     {
         bail!(
@@ -627,36 +626,9 @@ pub fn agent_pane_plans<'a>(
             seeds.len()
         );
     }
-    let mut launches = launch_identities.iter();
-    let mut plans = Vec::with_capacity(agent_count);
-    for index in 0..agent_count {
-        match resume_seeds.map(|seeds| &seeds[index]) {
-            Some(CohortSeed::Resume(agent)) => plans.push(AgentPanePlan::Resume {
-                agent,
-                fallback_channel,
-            }),
-            Some(CohortSeed::Fresh) | None => {
-                let Some(launch) = launches.next() else {
-                    bail!("launch plan missing identity for agent cell {index}");
-                };
-                plans.push(AgentPanePlan::Fresh(launch));
-            }
-        }
-    }
-    if launches.next().is_some() {
-        bail!("launch plan has more identities than fresh agent cells");
-    }
-    Ok(AgentPanePlans(plans))
-}
-
-/// Compile backend-neutral pane commands for a resolved layout.
-pub fn layout_panes_with_names(
-    layout: &LayoutSpec,
-    params: LayoutPaneParams<'_>,
-    plans: &AgentPanePlans<'_>,
-) -> Result<LayoutPanes> {
     let rimz_bin = crate::proc::rimz_exe();
     let mut agent_index = 0usize;
+    let mut launches = params.launch_identities.iter();
     let columns = layout
         .columns
         .iter()
@@ -665,25 +637,38 @@ pub fn layout_panes_with_names(
                 .rows
                 .iter()
                 .map(|cell| {
-                    let plan = if matches!(cell, Cell::Agent(_)) {
-                        let plan = plans.0.get(agent_index).with_context(|| {
-                            format!("pane plan missing agent cell {agent_index}")
-                        })?;
-                        agent_index = agent_index.saturating_add(1);
-                        Some(plan)
-                    } else {
-                        None
-                    };
-                    pane_cmd_with_name(
-                        cell,
-                        PaneCmdOptions {
-                            rimz_bin: &rimz_bin,
-                            cwd: params.cwd,
-                            cleanup_worktree: params.cleanup_worktree,
-                            in_place: params.in_place,
-                            plan,
+                    let pane = match cell {
+                        Cell::Command { argv } if argv.is_empty() => PaneCmd {
+                            argv: vec![crate::harness::launch::user_shell_program()],
                         },
-                    )
+                        Cell::Command { argv } => PaneCmd { argv: argv.clone() },
+                        Cell::Agent(cell) => {
+                            let seed = params.resume_seeds.map(|seeds| &seeds[agent_index]);
+                            let pane = match seed {
+                                Some(CohortSeed::Resume(agent)) => PaneCmd {
+                                    // The layout already resolved this cell from its profile or
+                                    // role binding, so the posture to replay is right here.
+                                    argv: crate::harness::resume::resume_command(
+                                        &rimz_bin,
+                                        agent,
+                                        params.fallback_channel,
+                                        &crate::harness::resume::ResumePosture::from_cell(cell),
+                                    ),
+                                },
+                                Some(CohortSeed::Fresh) | None => {
+                                    let Some(launch) = launches.next() else {
+                                        bail!(
+                                            "launch plan missing identity for agent cell {agent_index}"
+                                        );
+                                    };
+                                    fresh_agent_pane(cell, launch, &rimz_bin, params)?
+                                }
+                            };
+                            agent_index = agent_index.saturating_add(1);
+                            pane
+                        }
+                    };
+                    Ok(pane)
                 })
                 .collect::<Result<Vec<_>>>()?;
             Ok(LayoutColumn {
@@ -692,75 +677,42 @@ pub fn layout_panes_with_names(
             })
         })
         .collect::<Result<Vec<_>>>()?;
+    if launches.next().is_some() {
+        bail!("launch plan has more identities than fresh agent cells");
+    }
     Ok(LayoutPanes { columns })
 }
 
-#[derive(Clone, Copy)]
-pub struct LayoutPaneParams<'a> {
-    pub cwd: &'a Path,
-    pub cleanup_worktree: bool,
-    pub in_place: bool,
-}
-
-pub struct PaneCmdOptions<'a> {
-    pub rimz_bin: &'a Path,
-    pub cwd: &'a Path,
-    pub cleanup_worktree: bool,
-    pub in_place: bool,
-    plan: Option<&'a AgentPanePlan<'a>>,
-}
-
-pub fn pane_cmd_with_name(cell: &Cell, options: PaneCmdOptions<'_>) -> Result<PaneCmd> {
-    let argv = match cell {
-        Cell::Command { argv } if argv.is_empty() => {
-            vec![crate::harness::launch::user_shell_program()]
-        }
-        Cell::Command { argv } => argv.clone(),
-        Cell::Agent(cell) => {
-            let plan = options.plan.context("agent cell has no pane plan")?;
-            let launch = match plan {
-                AgentPanePlan::Fresh(launch) => launch,
-                AgentPanePlan::Resume {
-                    agent,
-                    fallback_channel,
-                } => {
-                    // The layout already resolved this cell from its profile or
-                    // role binding, so the posture to replay is right here.
-                    return Ok(PaneCmd {
-                        argv: crate::harness::resume::resume_command(
-                            options.rimz_bin,
-                            agent,
-                            *fallback_channel,
-                            &crate::harness::resume::ResumePosture::from_cell(cell),
-                        ),
-                    });
-                }
-            };
-            validate_agent_name(&launch.name)?;
-            crate::harness::launch::exec_argv(
-                options.rimz_bin,
-                &crate::harness::launch::ExecRequest {
-                    kind: cell.kind.clone(),
-                    action: crate::harness::launch::ExecAction::Launch {
-                        prompt: launch.prompt.clone(),
-                        extra_args: cell.args.clone(),
-                    },
-                    provider_account: crate::harness::launch::ProviderAccountState::Unbound,
-                    run_id: None,
-                    worktree_path: options.cleanup_worktree.then(|| options.cwd.to_path_buf()),
-                    close_pane_on_exit: !options.cleanup_worktree && !options.in_place,
-                    exit_on_run_completion: false,
-                    identity: crate::harness::launch::ExecIdentity {
-                        name: Some(launch.name.clone()),
-                        name_explicit: launch.name_explicit,
-                        launch_id: Some(launch.agent_id.to_string()),
-                        params: launch.launch.clone(),
-                    },
+fn fresh_agent_pane(
+    cell: &AgentCell,
+    launch: &AgentLaunchIdentity,
+    rimz_bin: &Path,
+    params: CompileLayoutPanes<'_>,
+) -> Result<PaneCmd> {
+    validate_agent_name(&launch.name)?;
+    Ok(PaneCmd {
+        argv: crate::harness::launch::exec_argv(
+            rimz_bin,
+            &crate::harness::launch::ExecRequest {
+                kind: cell.kind.clone(),
+                action: crate::harness::launch::ExecAction::Launch {
+                    prompt: launch.prompt.clone(),
+                    extra_args: cell.args.clone(),
                 },
-            )?
-        }
-    };
-    Ok(PaneCmd { argv })
+                provider_account: crate::harness::launch::ProviderAccountState::Unbound,
+                run_id: None,
+                worktree_path: params.cleanup_worktree.then(|| params.cwd.to_path_buf()),
+                close_pane_on_exit: !params.cleanup_worktree && !params.in_place,
+                exit_on_run_completion: false,
+                identity: crate::harness::launch::ExecIdentity {
+                    name: Some(launch.name.clone()),
+                    name_explicit: launch.name_explicit,
+                    launch_id: Some(launch.agent_id.to_string()),
+                    params: launch.launch.clone(),
+                },
+            },
+        )?,
+    })
 }
 
 pub fn validate_agent_name(name: &str) -> Result<()> {

--- a/crates/rimz/src/harness/plan.rs
+++ b/crates/rimz/src/harness/plan.rs
@@ -599,7 +599,7 @@ fn index_to_launch_ordinal(index: usize) -> u32 {
 }
 
 #[derive(Clone, Copy)]
-pub struct CompileLayoutPanes<'a> {
+pub struct LayoutPaneParams<'a> {
     pub cwd: &'a Path,
     pub cleanup_worktree: bool,
     pub in_place: bool,
@@ -615,7 +615,7 @@ pub struct CompileLayoutPanes<'a> {
 /// command cells in layout order.
 pub fn compile_layout_panes(
     layout: &LayoutSpec,
-    params: CompileLayoutPanes<'_>,
+    params: LayoutPaneParams<'_>,
 ) -> Result<LayoutPanes> {
     let agent_count = layout.agent_cells().count();
     if let Some(seeds) = params.resume_seeds
@@ -687,7 +687,7 @@ fn fresh_agent_pane(
     cell: &AgentCell,
     launch: &AgentLaunchIdentity,
     rimz_bin: &Path,
-    params: CompileLayoutPanes<'_>,
+    params: LayoutPaneParams<'_>,
 ) -> Result<PaneCmd> {
     validate_agent_name(&launch.name)?;
     Ok(PaneCmd {

--- a/crates/rimz/src/harness/plan/tests.rs
+++ b/crates/rimz/src/harness/plan/tests.rs
@@ -1160,7 +1160,7 @@ fn layout_panes_put_the_prompt_only_on_the_leader_agent() {
     identities[1].prompt = Some("lead this".to_owned());
     let panes = compile_layout_panes(
         &layout,
-        CompileLayoutPanes {
+        LayoutPaneParams {
             cwd: Path::new("/tmp/project"),
             cleanup_worktree: false,
             in_place: false,
@@ -1220,7 +1220,7 @@ fn mixed_resume_and_fresh_panes_stay_aligned_in_layout_order() {
     let fresh = [fresh];
     let panes = compile_layout_panes(
         &layout,
-        CompileLayoutPanes {
+        LayoutPaneParams {
             cwd: Path::new("/repo"),
             cleanup_worktree: false,
             in_place: false,
@@ -1240,7 +1240,7 @@ fn mixed_resume_and_fresh_panes_stay_aligned_in_layout_order() {
 
     let err = compile_layout_panes(
         &layout,
-        CompileLayoutPanes {
+        LayoutPaneParams {
             cwd: Path::new("/repo"),
             cleanup_worktree: false,
             in_place: false,
@@ -1257,7 +1257,7 @@ fn mixed_resume_and_fresh_panes_stay_aligned_in_layout_order() {
 
     let err = compile_layout_panes(
         &layout,
-        CompileLayoutPanes {
+        LayoutPaneParams {
             cwd: Path::new("/repo"),
             cleanup_worktree: false,
             in_place: false,
@@ -1272,7 +1272,7 @@ fn mixed_resume_and_fresh_panes_stay_aligned_in_layout_order() {
     let surplus = [fresh[0].clone(), fresh[0].clone()];
     let err = compile_layout_panes(
         &layout,
-        CompileLayoutPanes {
+        LayoutPaneParams {
             cwd: Path::new("/repo"),
             cleanup_worktree: false,
             in_place: false,
@@ -1320,7 +1320,7 @@ fn pane_command_stamps_cli_identity_and_close_policy() {
     let launches = [launch];
     let panes = compile_layout_panes(
         &layout,
-        CompileLayoutPanes {
+        LayoutPaneParams {
             cwd: Path::new("/tmp/project"),
             cleanup_worktree: false,
             in_place: false,
@@ -1354,7 +1354,7 @@ fn pane_command_stamps_cli_identity_and_close_policy() {
     for (cleanup_worktree, in_place) in [(false, true), (true, false)] {
         let panes = compile_layout_panes(
             &layout,
-            CompileLayoutPanes {
+            LayoutPaneParams {
                 cwd: Path::new("/tmp/project"),
                 cleanup_worktree,
                 in_place,
@@ -1406,7 +1406,7 @@ fn pane_command_resume_keeps_prior_identity_and_replays_cell_posture() {
     let layout = LayoutSpec::single(cell);
     let panes = compile_layout_panes(
         &layout,
-        CompileLayoutPanes {
+        LayoutPaneParams {
             cwd: Path::new("/tmp/project"),
             cleanup_worktree: false,
             in_place: false,

--- a/crates/rimz/src/harness/plan/tests.rs
+++ b/crates/rimz/src/harness/plan/tests.rs
@@ -1158,15 +1158,16 @@ fn layout_panes_put_the_prompt_only_on_the_leader_agent() {
     };
     let mut identities = [identity("claude", "first"), identity("codex", "leader")];
     identities[1].prompt = Some("lead this".to_owned());
-    let plans = agent_pane_plans(&layout, None, &identities, None).expect("pane plans");
-    let panes = layout_panes_with_names(
+    let panes = compile_layout_panes(
         &layout,
-        LayoutPaneParams {
+        CompileLayoutPanes {
             cwd: Path::new("/tmp/project"),
             cleanup_worktree: false,
             in_place: false,
+            resume_seeds: None,
+            launch_identities: &identities,
+            fallback_channel: None,
         },
-        &plans,
     )
     .unwrap();
 
@@ -1178,6 +1179,10 @@ fn layout_panes_put_the_prompt_only_on_the_leader_agent() {
         &panes.columns[1].panes[1].argv,
         RequestField::Prompt,
         "lead this",
+    );
+    assert_eq!(
+        panes.columns[1].panes[0].argv,
+        [crate::harness::launch::user_shell_program()]
     );
 }
 
@@ -1213,16 +1218,16 @@ fn mixed_resume_and_fresh_panes_stay_aligned_in_layout_order() {
     };
 
     let fresh = [fresh];
-    let plans =
-        agent_pane_plans(&layout, Some(&seeds), &fresh, Some("fallback")).expect("pane plans");
-    let panes = layout_panes_with_names(
+    let panes = compile_layout_panes(
         &layout,
-        LayoutPaneParams {
+        CompileLayoutPanes {
             cwd: Path::new("/repo"),
             cleanup_worktree: false,
             in_place: false,
+            resume_seeds: Some(&seeds),
+            launch_identities: &fresh,
+            fallback_channel: Some("fallback"),
         },
-        &plans,
     )
     .expect("mixed panes");
 
@@ -1233,16 +1238,53 @@ fn mixed_resume_and_fresh_panes_stay_aligned_in_layout_order() {
     assert_request_field(&panes[2].argv, RequestField::Name, "bright-river");
     assert_request_field(&panes[2].argv, RequestField::Prompt, "fresh prompt");
 
-    let err = agent_pane_plans(
+    let err = compile_layout_panes(
         &layout,
-        Some(&[CohortSeed::Fresh, CohortSeed::Fresh]),
-        &[],
-        None,
+        CompileLayoutPanes {
+            cwd: Path::new("/repo"),
+            cleanup_worktree: false,
+            in_place: false,
+            resume_seeds: Some(&[CohortSeed::Fresh, CohortSeed::Fresh]),
+            launch_identities: &[],
+            fallback_channel: None,
+        },
     )
     .expect_err("identity count mismatch");
     assert_eq!(
         err.to_string(),
         "launch plan missing identity for agent cell 0"
+    );
+
+    let err = compile_layout_panes(
+        &layout,
+        CompileLayoutPanes {
+            cwd: Path::new("/repo"),
+            cleanup_worktree: false,
+            in_place: false,
+            resume_seeds: Some(&[CohortSeed::Fresh]),
+            launch_identities: &fresh,
+            fallback_channel: None,
+        },
+    )
+    .expect_err("resume seed count mismatch");
+    assert_eq!(err.to_string(), "resume plan has 1 seeds for 2 agent cells");
+
+    let surplus = [fresh[0].clone(), fresh[0].clone()];
+    let err = compile_layout_panes(
+        &layout,
+        CompileLayoutPanes {
+            cwd: Path::new("/repo"),
+            cleanup_worktree: false,
+            in_place: false,
+            resume_seeds: Some(&seeds),
+            launch_identities: &surplus,
+            fallback_channel: None,
+        },
+    )
+    .expect_err("surplus launch identity");
+    assert_eq!(
+        err.to_string(),
+        "launch plan has more identities than fresh agent cells"
     );
 }
 
@@ -1274,19 +1316,21 @@ fn pane_command_stamps_cli_identity_and_close_policy() {
         run_id: None,
         prompt: None,
     };
-    let plan = AgentPanePlan::Fresh(&launch);
-
-    let pane = pane_cmd_with_name(
-        &cell,
-        PaneCmdOptions {
-            rimz_bin: Path::new("/usr/bin/rimz"),
+    let layout = LayoutSpec::single(cell);
+    let launches = [launch];
+    let panes = compile_layout_panes(
+        &layout,
+        CompileLayoutPanes {
             cwd: Path::new("/tmp/project"),
             cleanup_worktree: false,
             in_place: false,
-            plan: Some(&plan),
+            resume_seeds: None,
+            launch_identities: &launches,
+            fallback_channel: None,
         },
     )
     .unwrap();
+    let pane = &panes.columns[0].panes[0];
 
     for (field, value) in [
         (RequestField::Name, "swift-otter"),
@@ -1308,18 +1352,24 @@ fn pane_command_stamps_cli_identity_and_close_policy() {
     assert!(exec_request(&pane.argv).close_pane_on_exit);
 
     for (cleanup_worktree, in_place) in [(false, true), (true, false)] {
-        let pane = pane_cmd_with_name(
-            &cell,
-            PaneCmdOptions {
-                rimz_bin: Path::new("/usr/bin/rimz"),
+        let panes = compile_layout_panes(
+            &layout,
+            CompileLayoutPanes {
                 cwd: Path::new("/tmp/project"),
                 cleanup_worktree,
                 in_place,
-                plan: Some(&plan),
+                resume_seeds: None,
+                launch_identities: &launches,
+                fallback_channel: None,
             },
         )
         .unwrap();
+        let pane = &panes.columns[0].panes[0];
         assert!(!exec_request(&pane.argv).close_pane_on_exit);
+        assert_eq!(
+            exec_request(&pane.argv).worktree_path.as_deref(),
+            cleanup_worktree.then_some(Path::new("/tmp/project"))
+        );
     }
 }
 
@@ -1352,26 +1402,21 @@ fn pane_command_resume_keeps_prior_identity_and_replays_cell_posture() {
     agent.channel = Some("design".to_owned());
     agent.model = Some("old-model".to_owned());
     agent.effort = Some("old-effort".to_owned());
-    let seed = CohortSeed::Resume(Box::new(agent));
-    let CohortSeed::Resume(agent) = &seed else {
-        unreachable!()
-    };
-    let plan = AgentPanePlan::Resume {
-        agent,
-        fallback_channel: Some("new-channel"),
-    };
-
-    let pane = pane_cmd_with_name(
-        &cell,
-        PaneCmdOptions {
-            rimz_bin: Path::new("/usr/bin/rimz"),
+    let seeds = [CohortSeed::Resume(Box::new(agent))];
+    let layout = LayoutSpec::single(cell);
+    let panes = compile_layout_panes(
+        &layout,
+        CompileLayoutPanes {
             cwd: Path::new("/tmp/project"),
             cleanup_worktree: false,
             in_place: false,
-            plan: Some(&plan),
+            resume_seeds: Some(&seeds),
+            launch_identities: &[],
+            fallback_channel: Some("new-channel"),
         },
     )
     .unwrap();
+    let pane = &panes.columns[0].panes[0];
 
     for (field, value) in [
         (RequestField::Resume, "sess-1"),

--- a/crates/rimz/src/harness/resume.rs
+++ b/crates/rimz/src/harness/resume.rs
@@ -22,7 +22,7 @@ use crate::agents::find_definition;
 use crate::agents::{AgentState, LocalSessionObservation};
 use crate::config::{CommandsConfig, ProfilesConfig, TeamsConfig};
 use crate::harness::plan::{
-    CompileLayoutPanes, cohort_cells, compile_layout_panes, launch_identity_requests,
+    LayoutPaneParams, cohort_cells, compile_layout_panes, launch_identity_requests,
 };
 use crate::harness::run::PermissionMode;
 use crate::harness::spec::LayoutSpec;
@@ -1384,7 +1384,7 @@ pub fn materialize_team_restore_tab(
         .map_or(&[] as &[_], |batch| batch.identities());
     let layout = compile_layout_panes(
         &planned.layout,
-        CompileLayoutPanes {
+        LayoutPaneParams {
             cwd: &planned.cwd,
             cleanup_worktree: false,
             in_place: false,

--- a/crates/rimz/src/harness/resume.rs
+++ b/crates/rimz/src/harness/resume.rs
@@ -22,8 +22,7 @@ use crate::agents::find_definition;
 use crate::agents::{AgentState, LocalSessionObservation};
 use crate::config::{CommandsConfig, ProfilesConfig, TeamsConfig};
 use crate::harness::plan::{
-    LayoutPaneParams, agent_pane_plans, cohort_cells, launch_identity_requests,
-    layout_panes_with_names,
+    CompileLayoutPanes, cohort_cells, compile_layout_panes, launch_identity_requests,
 };
 use crate::harness::run::PermissionMode;
 use crate::harness::spec::LayoutSpec;
@@ -1383,20 +1382,16 @@ pub fn materialize_team_restore_tab(
     let identities = batch
         .as_ref()
         .map_or(&[] as &[_], |batch| batch.identities());
-    let pane_plans = agent_pane_plans(
+    let layout = compile_layout_panes(
         &planned.layout,
-        Some(&planned.cohort.seeds),
-        identities,
-        planned.channel.as_deref(),
-    )?;
-    let layout = layout_panes_with_names(
-        &planned.layout,
-        LayoutPaneParams {
+        CompileLayoutPanes {
             cwd: &planned.cwd,
             cleanup_worktree: false,
             in_place: false,
+            resume_seeds: Some(&planned.cohort.seeds),
+            launch_identities: identities,
+            fallback_channel: planned.channel.as_deref(),
         },
-        &pane_plans,
     )
     .context("building team restore layout")?;
     Ok(ResumeTab {

--- a/crates/rimz/src/harness/schedule/fire.rs
+++ b/crates/rimz/src/harness/schedule/fire.rs
@@ -6,6 +6,7 @@
 //! not spawn the same occurrence twice.
 
 use std::collections::BTreeMap;
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use jiff::{Timestamp, Zoned};
@@ -156,17 +157,20 @@ fn state_path(runtime: &RuntimePaths) -> PathBuf {
 }
 
 fn spawn_loop_run(runtime: &RuntimePaths, project_root: Option<&Path>, name: &str) {
-    let mut cmd = crate::child_process::detached_rimz_command(crate::proc::rimz_exe(), runtime);
+    let mut args = Vec::<OsString>::new();
     if let Some(project_root) = project_root {
-        cmd.arg("--root").arg(project_root);
+        args.extend([
+            OsString::from("--root"),
+            project_root.as_os_str().to_owned(),
+        ]);
     }
-    cmd.args(["loop", "run", name]);
+    args.extend([OsString::from("loop"), OsString::from("run"), name.into()]);
     tracing::info!(
         target: crate::observability::BREADCRUMB_TARGET,
         task = name,
         "sidebar: firing loop task",
     );
-    if let Err(err) = crate::child_process::spawn_detached_reaped(&mut cmd, "loop-run") {
+    if let Err(err) = crate::child_process::spawn_detached_rimz(runtime, args, "loop-run") {
         tracing::debug!(
             task = name,
             tags.operation = "loop_fire.spawn",

--- a/crates/rimz/src/store/sidecar.rs
+++ b/crates/rimz/src/store/sidecar.rs
@@ -33,13 +33,17 @@ pub(crate) struct ParsedSidecar<R> {
     pub record: Option<R>,
 }
 
-pub(crate) fn path(dir: &Path, prefix: &str, kind: &str, agent_id: &str) -> PathBuf {
+pub(crate) fn digest(kind: &str, agent_id: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(kind.as_bytes());
     hasher.update([0]);
     hasher.update(agent_id.as_bytes());
     let digest = hex::encode(hasher.finalize());
-    dir.join(format!("{prefix}.{}.json", &digest[..32]))
+    digest[..32].to_owned()
+}
+
+pub(crate) fn path(dir: &Path, prefix: &str, kind: &str, agent_id: &str) -> PathBuf {
+    dir.join(format!("{prefix}.{}.json", digest(kind, agent_id)))
 }
 
 pub(crate) fn lock_path(dir: &Path, prefix: &str, kind: &str, agent_id: &str) -> PathBuf {
@@ -201,6 +205,18 @@ mod tests {
 
     fn read_all_test(dir: &Path) -> Vec<TestRecord> {
         TEST_PARSE_CACHE.with(|cache| read_all(dir, cache))
+    }
+
+    #[test]
+    fn digest_and_path_preserve_sidecar_names() {
+        assert_eq!(
+            digest("codex", "sess-1"),
+            "8b13d7a2e1e761f29386b7f853b83f17"
+        );
+        assert_eq!(
+            path(Path::new("/tmp/cache"), "test", "codex", "sess-1"),
+            Path::new("/tmp/cache/test.8b13d7a2e1e761f29386b7f853b83f17.json")
+        );
     }
 
     #[test]

--- a/crates/rimz/src/store/snapshot/view.rs
+++ b/crates/rimz/src/store/snapshot/view.rs
@@ -293,6 +293,17 @@ pub struct SidebarSnapshot {
 }
 
 impl SidebarSnapshot {
+    pub(crate) fn live_agent_pane(
+        &self,
+        kind: &AgentKind,
+        agent_id: &AgentSessionId,
+    ) -> Option<PaneId> {
+        self.agent_panes
+            .iter()
+            .find(|pane| &pane.kind == kind && pane.agent_id.as_ref() == Some(agent_id))
+            .map(|pane| pane.pane_id.clone())
+    }
+
     #[cfg(test)]
     pub fn build(workspace_id: WorkspaceId, events: Vec<EventEnvelope>, now: Timestamp) -> Self {
         Self::build_with_carryover(workspace_id, events, Vec::new(), now)

--- a/docs/internals/harness/budget.md
+++ b/docs/internals/harness/budget.md
@@ -79,7 +79,7 @@ Both daily reads compare the cache's own `day_cutoff_secs` against the cutoff co
 | `budget.account.<kind>.json` | one login, machine-wide | a runtime raise or disable, and the park stamp |
 | `budget.scopes.json` | this room | per-agent turn baselines, parks, and interrupt throttles, plus fleet and account waivers, park thresholds, and interrupt throttles |
 
-The agent digest is the first 32 hex characters of a SHA-256 over the kind and session id, which keeps a session id out of a filename. [`auto_continue.rs`](../../../crates/rimz/src/harness/auto_continue.rs) reuses the same digest for its park records, so the two files for one agent sit side by side.
+The shared [`store/sidecar.rs`](../../../crates/rimz/src/store/sidecar.rs) digest is the first 32 hex characters of a SHA-256 over the kind and session id, which keeps a session id out of a filename. Budget ledgers use `budget.<digest>.json`, auto-continue parks use `auto-continue.<digest>.json`, and idle-compaction fire records use `idle-compact/<digest>.json`.
 
 All of these are cache-class: `write_temp_then_rename_cache`, rebuildable, and safe to delete. Losing one loses a park, not money. The two scope ledgers additionally take a lock file around read-modify-write, so a producer tick merging a fresh park cannot clobber a cap change a CLI made in the same instant. The producer merges only the `parked` field back and leaves the cap fields as it found them.
 


### PR DESCRIPTION
## Context

Two shallow seams had accumulated in `crates/rimz/src/harness/`.

`plan.rs` exposed pane compilation as a public two-step chain: `agent_pane_plans(...)` built an `AgentPanePlans` whose only purpose was to be handed straight to `layout_panes_with_names(...)` on the next line, at all three call sites. Count validation lived in the first call and pane compilation in the second, so a reader had to hold both to know what a layout compiles to.

Separately, five automation modules each hand-rolled the same mechanics: `auto_continue.rs`, `idle_compact.rs`, `auto_redeem.rs`, `budget.rs`, and `schedule/fire.rs` all built a detached `rimz` helper command the same way, and four of them carried a paired `#[cfg(not(test))]`/`#[cfg(test)]` spawn implementation purely to keep unit tests from leaking subprocesses. Three of them repeated an identical `(kind, agent_id)` live-pane scan, and three depended on a SHA-256 cache-name digest that `store/sidecar.rs` already encoded — with `auto_continue.rs` and `idle_compact.rs` reaching into `budget.rs` for nothing but that naming rule.

This is a behavior-preserving refactor. Structure changes; observable CLI output, pane argv, cache filenames, launch ordering, error text, helper stdio, multiplexer behavior, and durable records do not.

## Design choices

- **Kept the existing harness pipeline decomposition.** A generic automation framework or splitting the large files by size would have added shallow interfaces or moved code sideways without reducing what a reader has to hold. The two seams above were the ones where deletion actually bought locality.
- **Required each pass to be net-negative in production source.** Test lines were allowed to grow, but only to pin behavior that had to be provable before the old code could be deleted.
- **Moved mechanics into existing owners rather than a new module.** The digest went to `store/sidecar.rs`, which already encoded that exact `(kind, NUL, agent_id)` rule for its own sidecar names; the live-pane lookup went onto `SidebarSnapshot` beside the data it reads; the helper spawn went into `child_process.rs` beside the reaper. No new single-implementation seam was introduced.
- **Kept policy local.** Per-policy argv, arm/fire decisions, and tracing stay in their own modules. The shared helper owns process mechanics and the reaper label only.
- **Kept `detached_rimz_command` and `spawn_detached_reaped` as lower-level machinery.** They retain production callers outside this pass (four and eleven respectively, in message fire, diagnostics, sidebar refresh, ttyd, and the codex daemon). Folding them away would have grown the blast radius well past the harness.

## Implementation

**Pane layout compilation.** `compile_layout_panes(&layout, LayoutPaneParams { .. })` is now the single layout-to-pane boundary. It validates resume-seed and launch-identity counts, traverses the layout once, selects fresh or resumed launch data per agent cell, and returns `LayoutPanes`. Per-cell compilation is private (`fresh_agent_pane`). `AgentPanePlan`, `AgentPanePlans`, `agent_pane_plans`, `PaneCmdOptions`, and `pane_cmd_with_name` are deleted; `cli/agents_cmd/launch.rs` and `harness/resume.rs` use only the deep interface. Production source fell 56 lines.

**Automation mechanics.** `store::sidecar::digest(kind, agent_id)` is now the canonical cache-name rule, with `sidecar::path(...)` delegating to it and `budget::agent_digest` deleted. `SidebarSnapshot::live_agent_pane(kind, agent_id)` replaces three byte-identical local scans. `child_process::spawn_detached_rimz` owns executable selection, runtime-anchored cwd, fresh null stdio, detached spawn and reaping, and unit-test spawn suppression in one place, so the four paired `#[cfg(test)]`/`#[cfg(not(test))]` spawn implementations are gone and callers configure only their own argv. Production source fell a further 45 lines.

Policy argv is carried as `OsString` rather than `String` so a non-UTF-8 loop project root keeps the behavior it had when it was passed to `Command::arg` as a `&Path`.

**Evidence the pass is behavior-preserving.** Behavior was pinned before deletion, not after:

- Exact cache filenames are asserted end to end — `budget.4a8d94f232e55a6a0879ba0858b59241.json`, `auto-continue.4a8d94f232e55a6a0879ba0858b59241.json`, and `idle-compact/4a8d94f232e55a6a0879ba0858b59241.json` — plus the raw digest bytes and a representative sidecar path in `store/sidecar.rs`.
- `harness/plan/tests.rs` pins the missing-identity and surplus-identity errors by exact text, the resume-seed count mismatch, mixed fresh/resume alignment in layout order, fallback channel selection, command cells and empty shell cells, worktree cleanup, and the in-place `close_pane_on_exit` flag.
- `child_process.rs` tests pin the helper executable, the anchored cwd, argv construction, and the central no-spawn behavior.
- Helper argv for all five spawners was compared line for line: flag order, optional-flag append order, and value formatting are unchanged.

Review re-derived these independently against the code rather than the report, and separately confirmed that `LayoutSpec::agent_cells` walks columns then rows exactly as the new single traversal does, so cell-to-seed alignment and the existing count guards still hold.

Sandbox and live-backend placement checks were not run. The plan gated them on a change to pane placement or backend-specific argv; neither moved, and nothing under `mux/` is touched.

## Advisories

- **Pre-existing test failure inside a filter this branch touches.** `cargo xtask test resume` is not green: its substring filter pulls in `backend::tmux::agent_lifecycle::resumed_lazy_agent_is_addressable_before_provider_registration`, which fails at `agent_lifecycle.rs:371` looking for its attached live pane. The same isolated test fails identically on an untouched base worktree; the other 135 matches pass and `cargo xtask gate` is green. It is unrelated to this pass and stays open.
- **Validation ordering shifted, outcomes did not.** The surplus-identity check now runs after the layout traversal rather than before it, so per-cell name validation can be reached first. Error text is unchanged, and `launch_identity_requests` emits exactly one identity per fresh agent cell over the same cell ordering, which makes a count fault an internal invariant break rather than a reachable input. The only divergence needs a count fault and an invalid-name fault at the same time.
- **Stdio configuration is not directly asserted.** `std::process::Command` exposes no stdio getter, so the new tests pin what is pinnable — program, argv, cwd, and central spawn suppression — and fresh/null stdio stays covered by source review and the gate.
- **Follow-up available.** `message/fire.rs`, `diag/focus_repair.rs`, and `sidebar/refresh/{usage,sessions}.rs` still assemble detached helpers by hand. They were deliberately left alone to keep this pass scoped to the harness; moving them onto `spawn_detached_rimz` is a clean follow-up.
