### PR TITLE
Collapse remote readiness and CLI duplication

### DIFF
--- a/crates/rimz/src/agents/adapters/claude/mod.rs
+++ b/crates/rimz/src/agents/adapters/claude/mod.rs
@@ -824,10 +824,6 @@ impl crate::agents::capabilities::RuntimeControlCapability for ClaudeAdapter {
         }
     }
 
-    fn runtime_control_host_argv(&self) -> Option<Vec<String>> {
-        Some(remote_control::host_argv())
-    }
-
     fn prepare_runtime_control(&self, enabled: bool) {
         remote_control::ensure_consent(enabled);
     }

--- a/crates/rimz/src/agents/capabilities.rs
+++ b/crates/rimz/src/agents/capabilities.rs
@@ -681,10 +681,6 @@ pub trait RuntimeControlCapability: CoreCapability {
         runtime_control::RuntimeControlReadiness::Disabled
     }
 
-    fn runtime_control_host_argv(&self) -> Option<Vec<String>> {
-        None
-    }
-
     fn ensure_runtime_control(&self, _enabled: bool) {}
 
     /// Fill the preconditions this host needs before it can be launched at all —

--- a/crates/rimz/src/agents/runtime_control.rs
+++ b/crates/rimz/src/agents/runtime_control.rs
@@ -64,10 +64,6 @@ impl RuntimeControlIssue {
     pub const fn code(&self) -> &'static str {
         self.code
     }
-
-    pub fn is_uninstalled_host(&self) -> bool {
-        matches!(self.code, "uninstalled" | "standalone_missing")
-    }
 }
 
 impl std::fmt::Display for RuntimeControlIssue {
@@ -98,10 +94,6 @@ pub fn readiness(kind: &str, enabled: bool) -> RuntimeControlReadiness {
     super::find_definition(kind).map_or(RuntimeControlReadiness::Disabled, |definition| {
         definition.runtime_control_readiness(enabled)
     })
-}
-
-pub fn host_argv(kind: &str) -> Option<Vec<String>> {
-    super::find_definition(kind)?.runtime_control_host_argv()
 }
 
 /// Ask an enabled host whether it is still serving `project_root`. Read-only

--- a/crates/rimz/src/cli/doctor/runtime.rs
+++ b/crates/rimz/src/cli/doctor/runtime.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
+use rimz::agents::runtime_control::{self, RuntimeControlLiveness, RuntimeControlReadiness};
 use rimz::config::{ColorDepth, MachineConfig, ThemeMode};
 use rimz::ids::MuxName;
 use rimz::mux::{
@@ -944,23 +945,19 @@ pub(super) fn collect_remote_control(
             // A ready host is one that *can* start. Whether one is serving right
             // now is a separate question the provider's own record answers, and
             // doctor is the place a stalled host should become visible.
-            rimz::remote_control::HostState::Ready => match project_root
-                .map(|root| rimz::agents::runtime_control::host_liveness("claude", root))
-            {
-                Some(rimz::agents::runtime_control::RuntimeControlLiveness::Up) => {
-                    ("ready, host serving".to_owned(), true)
+            RuntimeControlReadiness::Ready { .. } => {
+                match project_root.map(|root| runtime_control::host_liveness("claude", root)) {
+                    Some(RuntimeControlLiveness::Up) => ("ready, host serving".to_owned(), true),
+                    Some(RuntimeControlLiveness::Down) => (
+                        "ready, but the host stopped serving this project".to_owned(),
+                        false,
+                    ),
+                    _ => ("ready".to_owned(), true),
                 }
-                Some(rimz::agents::runtime_control::RuntimeControlLiveness::Down) => (
-                    "ready, but the host stopped serving this project".to_owned(),
-                    false,
-                ),
-                _ => ("ready".to_owned(), true),
-            },
-            rimz::remote_control::HostState::Uninstalled(_) => {
-                ("enabled, not on PATH".to_owned(), false)
             }
-            rimz::remote_control::HostState::Blocked(_) => ("enabled, blocked".to_owned(), false),
-            rimz::remote_control::HostState::Disabled => ("ready".to_owned(), true),
+            RuntimeControlReadiness::Uninstalled(_) => ("enabled, not on PATH".to_owned(), false),
+            RuntimeControlReadiness::Blocked(_) => ("enabled, blocked".to_owned(), false),
+            RuntimeControlReadiness::Disabled => ("ready".to_owned(), true),
         };
         agents.push(model::RemoteAgent {
             kind: "claude",
@@ -971,12 +968,13 @@ pub(super) fn collect_remote_control(
     if config.enabled_for("codex") {
         let (detail, ready) =
             match readiness.for_host(rimz::remote_control::RemoteControlHost::Codex) {
-                rimz::remote_control::HostState::Uninstalled(_) => {
+                RuntimeControlReadiness::Uninstalled(_) => {
                     ("enabled, standalone install missing".to_owned(), false)
                 }
-                rimz::remote_control::HostState::Ready
-                | rimz::remote_control::HostState::Disabled => ("ready".to_owned(), true),
-                rimz::remote_control::HostState::Blocked(_) => {
+                RuntimeControlReadiness::Ready { .. } | RuntimeControlReadiness::Disabled => {
+                    ("ready".to_owned(), true)
+                }
+                RuntimeControlReadiness::Blocked(_) => {
                     ("enabled, standalone install missing".to_owned(), false)
                 }
             };
@@ -988,11 +986,15 @@ pub(super) fn collect_remote_control(
     }
 
     let skipped = match readiness.for_host(rimz::remote_control::RemoteControlHost::Codex) {
-        rimz::remote_control::HostState::Uninstalled(issue) => vec![issue.to_string()],
+        RuntimeControlReadiness::Uninstalled(issue) => {
+            vec![issue.to_string()]
+        }
         _ => Vec::new(),
     };
     let refusals = match readiness.for_host(rimz::remote_control::RemoteControlHost::Claude) {
-        rimz::remote_control::HostState::Blocked(issue) => vec![issue.to_string()],
+        RuntimeControlReadiness::Blocked(issue) => {
+            vec![issue.to_string()]
+        }
         _ => Vec::new(),
     };
     model::RemoteControl::On {

--- a/crates/rimz/src/cli/remote.rs
+++ b/crates/rimz/src/cli/remote.rs
@@ -38,16 +38,8 @@ enum RemoteSubcmd {
     )]
     Add {
         name: String,
-        target: String,
-        /// Hand the link to a single ssh run instead of supervising reconnects.
-        #[arg(long)]
-        no_reconnect: bool,
-        /// Come up empty when this alias births a remote room.
-        #[arg(long)]
-        no_resume: bool,
-        /// Disable automatic forwarding of new remote listeners.
-        #[arg(long)]
-        no_auto_forward: bool,
+        #[command(flatten)]
+        args: saved_alias::Args,
     },
     /// Replace a saved remote target.
     #[command(
@@ -58,43 +50,16 @@ enum RemoteSubcmd {
             crate::cli::complete::remote_aliases
         ))]
         name: String,
-        target: String,
-        /// Hand the link to a single ssh run instead of supervising reconnects.
-        #[arg(long)]
-        no_reconnect: bool,
-        /// Come up empty when this alias births a remote room.
-        #[arg(long)]
-        no_resume: bool,
-        /// Disable automatic forwarding of new remote listeners.
-        #[arg(long)]
-        no_auto_forward: bool,
+        #[command(flatten)]
+        args: saved_alias::Args,
     },
     /// Connect to a remote alias or raw `[user@]host:<session-or-path>` target.
     Connect {
-        #[arg(add = clap_complete::ArgValueCandidates::new(
-            crate::cli::complete::remote_aliases
-        ))]
-        alias_or_target: String,
         /// Force a fresh remote room by passing `--no-resume` to the remote rimz.
         #[arg(long)]
         reset: bool,
-        /// Hand the link to a single ssh run instead of supervising reconnects.
-        #[arg(long)]
-        no_reconnect: bool,
-        /// Attach despite a minor version mismatch with the host.
-        #[arg(long)]
-        force_version: bool,
-        /// Open the remote Zellij room in the local browser through an SSH tunnel.
-        #[arg(long)]
-        web: bool,
-        /// Local tunnel port for `--web`.
-        #[arg(long, requires = "web")]
-        web_port: Option<u16>,
-        /// Disable automatic forwarding of new remote listeners.
-        #[arg(long)]
-        no_auto_forward: bool,
         #[command(flatten)]
-        attach: AttachFlags,
+        args: connection::Args,
     },
     /// Install rimz on a remote alias, `[user@]host:<session-or-path>` target, or `[user@]host`.
     Setup {
@@ -105,27 +70,8 @@ enum RemoteSubcmd {
     },
     /// Connect to a remote alias or raw target with `--no-resume`.
     Reset {
-        #[arg(add = clap_complete::ArgValueCandidates::new(
-            crate::cli::complete::remote_aliases
-        ))]
-        alias_or_target: String,
-        /// Hand the link to a single ssh run instead of supervising reconnects.
-        #[arg(long)]
-        no_reconnect: bool,
-        /// Attach despite a minor version mismatch with the host.
-        #[arg(long)]
-        force_version: bool,
-        /// Open the remote Zellij room in the local browser through an SSH tunnel.
-        #[arg(long)]
-        web: bool,
-        /// Local tunnel port for `--web`.
-        #[arg(long, requires = "web")]
-        web_port: Option<u16>,
-        /// Disable automatic forwarding of new remote listeners.
-        #[arg(long)]
-        no_auto_forward: bool,
         #[command(flatten)]
-        attach: AttachFlags,
+        args: connection::Args,
     },
     /// Delete a saved remote alias.
     Rm {
@@ -162,21 +108,63 @@ enum LinkStatsSubcmd {
     Ingest(link_stats::LinkStatsIngestArgs),
 }
 
-fn build_alias(
-    name: String,
-    target: String,
-    no_reconnect: bool,
-    no_resume: bool,
-    no_auto_forward: bool,
-    globals: &GlobalFlags,
-) -> RemoteAlias {
-    RemoteAlias {
-        name,
-        target,
-        reconnect: !no_reconnect,
-        no_resume,
-        mux: globals.mux,
-        auto_forward: !no_auto_forward,
+mod saved_alias {
+    use super::{MuxName, RemoteAlias};
+
+    #[derive(Debug, clap::Args)]
+    pub(super) struct Args {
+        pub(super) target: String,
+        /// Hand the link to a single ssh run instead of supervising reconnects.
+        #[arg(long)]
+        pub(super) no_reconnect: bool,
+        /// Come up empty when this alias births a remote room.
+        #[arg(long)]
+        pub(super) no_resume: bool,
+        /// Disable automatic forwarding of new remote listeners.
+        #[arg(long)]
+        pub(super) no_auto_forward: bool,
+    }
+
+    impl Args {
+        pub(super) fn into_alias(self, name: String, mux: Option<MuxName>) -> RemoteAlias {
+            RemoteAlias {
+                name,
+                target: self.target,
+                reconnect: !self.no_reconnect,
+                no_resume: self.no_resume,
+                mux,
+                auto_forward: !self.no_auto_forward,
+            }
+        }
+    }
+}
+
+mod connection {
+    use super::AttachFlags;
+
+    #[derive(Debug, clap::Args)]
+    pub(super) struct Args {
+        #[arg(add = clap_complete::ArgValueCandidates::new(
+            crate::cli::complete::remote_aliases
+        ))]
+        pub(super) alias_or_target: String,
+        /// Hand the link to a single ssh run instead of supervising reconnects.
+        #[arg(long)]
+        pub(super) no_reconnect: bool,
+        /// Attach despite a minor version mismatch with the host.
+        #[arg(long)]
+        pub(super) force_version: bool,
+        /// Open the remote Zellij room in the local browser through an SSH tunnel.
+        #[arg(long)]
+        pub(super) web: bool,
+        /// Local tunnel port for `--web`.
+        #[arg(long, requires = "web")]
+        pub(super) web_port: Option<u16>,
+        /// Disable automatic forwarding of new remote listeners.
+        #[arg(long)]
+        pub(super) no_auto_forward: bool,
+        #[command(flatten)]
+        pub(super) attach: AttachFlags,
     }
 }
 
@@ -199,22 +187,9 @@ impl RemoteArgs {
 
 pub fn run(args: RemoteArgs, globals: &GlobalFlags) -> Result<()> {
     match args.command {
-        RemoteSubcmd::Add {
-            name,
-            target,
-            no_reconnect,
-            no_resume,
-            no_auto_forward,
-        } => {
+        RemoteSubcmd::Add { name, args } => {
             let mut aliases = RemoteAliases::load().context("loading remote aliases")?;
-            let entry = build_alias(
-                name,
-                target,
-                no_reconnect,
-                no_resume,
-                no_auto_forward,
-                globals,
-            );
+            let entry = args.into_alias(name, globals.mux);
             if aliases.contains(&entry.name)
                 && std::io::stdin().is_terminal()
                 && super::confirm(&format!(
@@ -229,73 +204,15 @@ pub fn run(args: RemoteArgs, globals: &GlobalFlags) -> Result<()> {
             aliases.save().context("saving remote aliases")?;
             Ok(())
         }
-        RemoteSubcmd::Update {
-            name,
-            target,
-            no_reconnect,
-            no_resume,
-            no_auto_forward,
-        } => {
+        RemoteSubcmd::Update { name, args } => {
             let mut aliases = RemoteAliases::load().context("loading remote aliases")?;
-            aliases.update(build_alias(
-                name,
-                target,
-                no_reconnect,
-                no_resume,
-                no_auto_forward,
-                globals,
-            ))?;
+            aliases.update(args.into_alias(name, globals.mux))?;
             aliases.save().context("saving remote aliases")?;
             Ok(())
         }
-        RemoteSubcmd::Connect {
-            alias_or_target,
-            reset,
-            no_reconnect,
-            force_version,
-            web,
-            web_port,
-            no_auto_forward,
-            attach,
-        } => connect(
-            alias_or_target,
-            ConnectOptions {
-                reset,
-                no_reconnect,
-                force_version,
-                web: web::RemoteWebOptions {
-                    enabled: web,
-                    port: web_port,
-                },
-                no_auto_forward,
-            },
-            attach,
-            globals,
-        ),
+        RemoteSubcmd::Connect { reset, args } => connect(args, reset, globals),
         RemoteSubcmd::Setup { alias_or_host } => setup::run(alias_or_host, globals),
-        RemoteSubcmd::Reset {
-            alias_or_target,
-            no_reconnect,
-            force_version,
-            web,
-            web_port,
-            no_auto_forward,
-            attach,
-        } => connect(
-            alias_or_target,
-            ConnectOptions {
-                reset: true,
-                no_reconnect,
-                force_version,
-                web: web::RemoteWebOptions {
-                    enabled: web,
-                    port: web_port,
-                },
-                no_auto_forward,
-            },
-            attach,
-            globals,
-        ),
+        RemoteSubcmd::Reset { args } => connect(args, true, globals),
         RemoteSubcmd::Rm { name } => {
             let mut aliases = RemoteAliases::load().context("loading remote aliases")?;
             aliases.remove(&name)?;
@@ -331,12 +248,19 @@ struct RemoteConnect {
     auto_forward: bool,
 }
 
-struct ConnectOptions {
-    reset: bool,
-    no_reconnect: bool,
-    force_version: bool,
-    web: web::RemoteWebOptions,
-    no_auto_forward: bool,
+impl RemoteConnect {
+    fn attach_plan(&self, client_size: Option<(u16, u16)>) -> Result<SshAttachPlan> {
+        Ok(SshAttachPlan::new(SshAttachOptions {
+            target: self.target.clone(),
+            lineage: local_remote_lineage(&self.target)?,
+            force_version: self.force_version,
+            no_resume: self.no_resume,
+            mux: self.mux,
+            term: remote_term_plan(),
+            truecolor: rimz::tui::truecolor(),
+            client_size,
+        }))
+    }
 }
 
 fn resolve_connect(
@@ -387,23 +311,30 @@ fn resolve_setup_destination(input: &str, aliases: &RemoteAliases) -> Result<Ssh
     }
 }
 
-fn connect(
-    alias_or_target: String,
-    options: ConnectOptions,
-    attach: AttachFlags,
-    globals: &GlobalFlags,
-) -> Result<()> {
+fn connect(args: connection::Args, reset: bool, globals: &GlobalFlags) -> Result<()> {
+    let connection::Args {
+        alias_or_target,
+        no_reconnect,
+        force_version,
+        web,
+        web_port,
+        no_auto_forward,
+        attach,
+    } = args;
     let aliases = RemoteAliases::load().context("loading remote aliases")?;
     let mut remote = resolve_connect(
         &alias_or_target,
-        options.reset,
-        options.no_reconnect,
-        options.no_auto_forward,
+        reset,
+        no_reconnect,
+        no_auto_forward,
         globals.mux,
         &aliases,
     )?;
-    remote.force_version = options.force_version;
-    remote.web = options.web;
+    remote.force_version = force_version;
+    remote.web = web::RemoteWebOptions {
+        enabled: web,
+        port: web_port,
+    };
     attach_remote(remote, attach.mode())
 }
 
@@ -425,18 +356,7 @@ fn attach_remote(remote: RemoteConnect, mode: AttachMode) -> Result<()> {
             if remote.web.enabled {
                 bail!("--web is web-only and has no SSH attach command; drop --print");
             }
-            let term = remote_term_plan();
-            let lineage = local_remote_lineage(&remote.target)?;
-            let plan = SshAttachPlan::new(SshAttachOptions {
-                target: remote.target,
-                lineage,
-                force_version: remote.force_version,
-                no_resume: remote.no_resume,
-                mux: remote.mux,
-                term,
-                truecolor: rimz::tui::truecolor(),
-                client_size,
-            });
+            let plan = remote.attach_plan(client_size)?;
             let plain_spec = plan.initial().plain();
             supervisor::print_remote_command(&plain_spec);
             Ok(())
@@ -452,18 +372,7 @@ fn attach_remote(remote: RemoteConnect, mode: AttachMode) -> Result<()> {
             if remote.web.enabled {
                 return web::run_remote_web(&remote, client_size);
             }
-            let term = remote_term_plan();
-            let lineage = local_remote_lineage(&remote.target)?;
-            let plan = SshAttachPlan::new(SshAttachOptions {
-                target: remote.target,
-                lineage,
-                force_version: remote.force_version,
-                no_resume: remote.no_resume,
-                mux: remote.mux,
-                term,
-                truecolor: rimz::tui::truecolor(),
-                client_size,
-            });
+            let plan = remote.attach_plan(client_size)?;
             if remote.reconnect {
                 let control = rimz::remote::link::validated_control_path()
                     .context("checking SSH ControlMaster socket path")?;
@@ -561,14 +470,13 @@ mod tests {
             color: super::super::ColorWhen::Auto,
         };
 
-        let built_alias = build_alias(
-            "prod".to_owned(),
-            "prod-box:query-engine".to_owned(),
-            false,
-            false,
-            true,
-            &globals,
-        );
+        let built_alias = saved_alias::Args {
+            target: "prod-box:query-engine".to_owned(),
+            no_reconnect: false,
+            no_resume: false,
+            no_auto_forward: true,
+        }
+        .into_alias("prod".to_owned(), globals.mux);
 
         assert_eq!(built_alias.mux, Some(MuxName::Tmux));
         assert!(!built_alias.auto_forward);

--- a/crates/rimz/src/cli/remote.rs
+++ b/crates/rimz/src/cli/remote.rs
@@ -39,7 +39,7 @@ enum RemoteSubcmd {
     Add {
         name: String,
         #[command(flatten)]
-        args: saved_alias::Args,
+        args: SavedAliasArgs,
     },
     /// Replace a saved remote target.
     #[command(
@@ -51,7 +51,7 @@ enum RemoteSubcmd {
         ))]
         name: String,
         #[command(flatten)]
-        args: saved_alias::Args,
+        args: SavedAliasArgs,
     },
     /// Connect to a remote alias or raw `[user@]host:<session-or-path>` target.
     Connect {
@@ -59,7 +59,7 @@ enum RemoteSubcmd {
         #[arg(long)]
         reset: bool,
         #[command(flatten)]
-        args: connection::Args,
+        args: ConnectionArgs,
     },
     /// Install rimz on a remote alias, `[user@]host:<session-or-path>` target, or `[user@]host`.
     Setup {
@@ -71,7 +71,7 @@ enum RemoteSubcmd {
     /// Connect to a remote alias or raw target with `--no-resume`.
     Reset {
         #[command(flatten)]
-        args: connection::Args,
+        args: ConnectionArgs,
     },
     /// Delete a saved remote alias.
     Rm {
@@ -108,64 +108,56 @@ enum LinkStatsSubcmd {
     Ingest(link_stats::LinkStatsIngestArgs),
 }
 
-mod saved_alias {
-    use super::{MuxName, RemoteAlias};
+#[derive(Debug, Args)]
+struct SavedAliasArgs {
+    target: String,
+    /// Hand the link to a single ssh run instead of supervising reconnects.
+    #[arg(long)]
+    no_reconnect: bool,
+    /// Come up empty when this alias births a remote room.
+    #[arg(long)]
+    no_resume: bool,
+    /// Disable automatic forwarding of new remote listeners.
+    #[arg(long)]
+    no_auto_forward: bool,
+}
 
-    #[derive(Debug, clap::Args)]
-    pub(super) struct Args {
-        pub(super) target: String,
-        /// Hand the link to a single ssh run instead of supervising reconnects.
-        #[arg(long)]
-        pub(super) no_reconnect: bool,
-        /// Come up empty when this alias births a remote room.
-        #[arg(long)]
-        pub(super) no_resume: bool,
-        /// Disable automatic forwarding of new remote listeners.
-        #[arg(long)]
-        pub(super) no_auto_forward: bool,
-    }
-
-    impl Args {
-        pub(super) fn into_alias(self, name: String, mux: Option<MuxName>) -> RemoteAlias {
-            RemoteAlias {
-                name,
-                target: self.target,
-                reconnect: !self.no_reconnect,
-                no_resume: self.no_resume,
-                mux,
-                auto_forward: !self.no_auto_forward,
-            }
+impl SavedAliasArgs {
+    fn into_alias(self, name: String, mux: Option<MuxName>) -> RemoteAlias {
+        RemoteAlias {
+            name,
+            target: self.target,
+            reconnect: !self.no_reconnect,
+            no_resume: self.no_resume,
+            mux,
+            auto_forward: !self.no_auto_forward,
         }
     }
 }
 
-mod connection {
-    use super::AttachFlags;
-
-    #[derive(Debug, clap::Args)]
-    pub(super) struct Args {
-        #[arg(add = clap_complete::ArgValueCandidates::new(
-            crate::cli::complete::remote_aliases
-        ))]
-        pub(super) alias_or_target: String,
-        /// Hand the link to a single ssh run instead of supervising reconnects.
-        #[arg(long)]
-        pub(super) no_reconnect: bool,
-        /// Attach despite a minor version mismatch with the host.
-        #[arg(long)]
-        pub(super) force_version: bool,
-        /// Open the remote Zellij room in the local browser through an SSH tunnel.
-        #[arg(long)]
-        pub(super) web: bool,
-        /// Local tunnel port for `--web`.
-        #[arg(long, requires = "web")]
-        pub(super) web_port: Option<u16>,
-        /// Disable automatic forwarding of new remote listeners.
-        #[arg(long)]
-        pub(super) no_auto_forward: bool,
-        #[command(flatten)]
-        pub(super) attach: AttachFlags,
-    }
+#[derive(Debug, Args)]
+struct ConnectionArgs {
+    #[arg(add = clap_complete::ArgValueCandidates::new(
+        crate::cli::complete::remote_aliases
+    ))]
+    alias_or_target: String,
+    /// Hand the link to a single ssh run instead of supervising reconnects.
+    #[arg(long)]
+    no_reconnect: bool,
+    /// Attach despite a minor version mismatch with the host.
+    #[arg(long)]
+    force_version: bool,
+    /// Open the remote Zellij room in the local browser through an SSH tunnel.
+    #[arg(long)]
+    web: bool,
+    /// Local tunnel port for `--web`.
+    #[arg(long, requires = "web")]
+    web_port: Option<u16>,
+    /// Disable automatic forwarding of new remote listeners.
+    #[arg(long)]
+    no_auto_forward: bool,
+    #[command(flatten)]
+    attach: AttachFlags,
 }
 
 impl RemoteArgs {
@@ -311,8 +303,8 @@ fn resolve_setup_destination(input: &str, aliases: &RemoteAliases) -> Result<Ssh
     }
 }
 
-fn connect(args: connection::Args, reset: bool, globals: &GlobalFlags) -> Result<()> {
-    let connection::Args {
+fn connect(args: ConnectionArgs, reset: bool, globals: &GlobalFlags) -> Result<()> {
+    let ConnectionArgs {
         alias_or_target,
         no_reconnect,
         force_version,
@@ -470,7 +462,7 @@ mod tests {
             color: super::super::ColorWhen::Auto,
         };
 
-        let built_alias = saved_alias::Args {
+        let built_alias = SavedAliasArgs {
             target: "prod-box:query-engine".to_owned(),
             no_reconnect: false,
             no_resume: false,

--- a/crates/rimz/src/cli/remote/web.rs
+++ b/crates/rimz/src/cli/remote/web.rs
@@ -193,16 +193,7 @@ fn run_direct_web(remote: &RemoteConnect, client_size: Option<(u16, u16)>) -> Re
 fn run_supervised_web(remote: &RemoteConnect, client_size: Option<(u16, u16)>) -> Result<()> {
     let control = rimz::remote::link::validated_control_path()
         .context("checking SSH ControlMaster socket path")?;
-    let plan = rimz::remote::SshAttachPlan::new(rimz::remote::SshAttachOptions {
-        target: remote.target.clone(),
-        lineage: super::local_remote_lineage(&remote.target)?,
-        force_version: remote.force_version,
-        no_resume: remote.no_resume,
-        mux: remote.mux,
-        term: super::remote_term_plan(),
-        truecolor: rimz::tui::truecolor(),
-        client_size,
-    });
+    let plan = remote.attach_plan(client_size)?;
     let policy = rimz::remote::ReconnectPolicy::from_env();
     let mut reconnect = rimz::remote::ReconnectState::new();
     let dial_plan = super::supervisor::resolve_dial_plan(remote.target.ssh_destination().as_str());

--- a/crates/rimz/src/daemon_view/tests.rs
+++ b/crates/rimz/src/daemon_view/tests.rs
@@ -94,7 +94,7 @@ fn daemon_view_spec_orders_the_ungated_broker_then_claude() {
     };
 
     assert!(
-        spec(RuntimeControlReadiness::Disabled, false,)
+        spec(RuntimeControlReadiness::Disabled, false)
             .hosts
             .is_empty()
     );
@@ -110,7 +110,7 @@ fn daemon_view_spec_orders_the_ungated_broker_then_claude() {
                 "claude",
                 "uninstalled",
                 "Claude is not installed",
-            ),),
+            )),
             false,
         )
         .hosts

--- a/crates/rimz/src/daemon_view/tests.rs
+++ b/crates/rimz/src/daemon_view/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::agents::runtime_control::{RuntimeControlIssue, RuntimeControlReadiness};
 use crate::config::DaemonConfig;
 use crate::ids::MuxName;
 use std::path::PathBuf;
@@ -66,10 +67,19 @@ fn daemon_view_spec_orders_the_ungated_broker_then_claude() {
     let rimz_bin = Path::new("/usr/bin/rimz");
     let project_root = Path::new("/proj");
     let worktree_root = Path::new("/proj/wt");
-    let spec = |claude: crate::remote_control::HostState, codex_present| {
+    let claude_argv = vec![
+        "claude".to_owned(),
+        "remote-control".to_owned(),
+        "--spawn".to_owned(),
+        "worktree".to_owned(),
+    ];
+    let ready = || RuntimeControlReadiness::Ready {
+        host_argv: Some(claude_argv.clone()),
+    };
+    let spec = |claude: RuntimeControlReadiness, codex_present| {
         let remote_control = crate::remote_control::ReadinessSnapshot::from_states(
             claude,
-            crate::remote_control::HostState::Disabled,
+            RuntimeControlReadiness::Disabled,
         );
         daemon_view_spec(DaemonViewSpecParams {
             claude_host_argv: remote_control.claude_host_argv(),
@@ -84,11 +94,11 @@ fn daemon_view_spec_orders_the_ungated_broker_then_claude() {
     };
 
     assert!(
-        spec(crate::remote_control::HostState::Disabled, false)
+        spec(RuntimeControlReadiness::Disabled, false,)
             .hosts
             .is_empty()
     );
-    let codex = spec(crate::remote_control::HostState::Disabled, true);
+    let codex = spec(RuntimeControlReadiness::Disabled, true);
     assert_eq!(codex.hosts.len(), 1);
     assert_eq!(codex.hosts[0].argv[0], "/usr/bin/rimz");
     assert!(codex.hosts[0].argv.iter().any(|arg| arg == "app-server"));
@@ -96,27 +106,22 @@ fn daemon_view_spec_orders_the_ungated_broker_then_claude() {
 
     assert!(
         spec(
-            crate::remote_control::HostState::Uninstalled(
-                crate::remote_control::PreflightError::from_parts(
-                    "claude",
-                    "uninstalled",
-                    "Claude is not installed",
-                ),
-            ),
+            RuntimeControlReadiness::Uninstalled(RuntimeControlIssue::from_parts(
+                "claude",
+                "uninstalled",
+                "Claude is not installed",
+            ),),
             false,
         )
         .hosts
         .is_empty()
     );
-    let claude = spec(crate::remote_control::HostState::Ready, false);
+    let claude = spec(ready(), false);
     assert_eq!(claude.hosts.len(), 1);
-    assert_eq!(
-        claude.hosts[0].argv,
-        crate::agents::runtime_control::host_argv("claude").expect("Claude host argv")
-    );
+    assert_eq!(claude.hosts[0].argv, claude_argv);
     assert_eq!(claude.hosts[0].cwd, project_root);
 
-    let pair = spec(crate::remote_control::HostState::Ready, true);
+    let pair = spec(ready(), true);
     assert_eq!(pair.hosts.len(), 2);
     assert!(pair.hosts[0].argv.iter().any(|arg| arg == "app-server"));
     assert_eq!(pair.hosts[1].argv[0], "claude");

--- a/crates/rimz/src/remote_control.rs
+++ b/crates/rimz/src/remote_control.rs
@@ -1,8 +1,8 @@
 //! Provider-neutral remote-control readiness, room lifecycle, and sidebar wakes.
 //!
 //! Claude owns its foreground host protocol. Codex owns its managed per-user
-//! daemon protocol. This module probes each provider once per operation, maps
-//! their native readiness through explicit matches, and coordinates effects.
+//! daemon protocol. This module probes each provider once per operation and
+//! coordinates effects.
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -29,70 +29,56 @@ impl RemoteControlHost {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum HostState {
-    Disabled,
-    Ready,
-    Uninstalled(PreflightError),
-    Blocked(PreflightError),
-}
-
 /// One batch probe of both configured provider hosts.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ReadinessSnapshot {
-    states: BTreeMap<crate::ids::AgentKind, HostState>,
-    host_argv: BTreeMap<crate::ids::AgentKind, Vec<String>>,
+    states: BTreeMap<crate::ids::AgentKind, RuntimeControlReadiness>,
 }
 
 impl ReadinessSnapshot {
     pub fn probe(config: &RemoteControlConfig) -> Self {
-        let (claude, claude_host_argv) = probe_claude(config.enabled_for("claude"));
-        let codex = probe_codex(config.enabled_for("codex"));
-        Self::from_probes(
-            [("claude", claude), ("codex", codex)],
-            claude_host_argv.map(|argv| ("claude", argv)),
+        Self::from_readiness(
+            runtime_control::readiness("claude", config.enabled_for("claude")),
+            runtime_control::readiness("codex", config.enabled_for("codex")),
         )
     }
 
     pub fn probe_transition(host: RemoteControlHost) -> Self {
         match host {
-            RemoteControlHost::Claude => {
-                let (claude, claude_host_argv) = probe_claude(true);
-                Self::from_probes(
-                    [("claude", claude), ("codex", HostState::Disabled)],
-                    claude_host_argv.map(|argv| ("claude", argv)),
-                )
-            }
-            RemoteControlHost::Codex => Self::from_probes(
-                [
-                    ("claude", HostState::Disabled),
-                    ("codex", probe_codex(true)),
-                ],
-                None,
+            RemoteControlHost::Claude => Self::from_readiness(
+                runtime_control::readiness("claude", true),
+                RuntimeControlReadiness::Disabled,
+            ),
+            RemoteControlHost::Codex => Self::from_readiness(
+                RuntimeControlReadiness::Disabled,
+                runtime_control::readiness("codex", true),
             ),
         }
     }
 
-    pub fn for_host(&self, host: RemoteControlHost) -> &HostState {
+    pub fn for_host(&self, host: RemoteControlHost) -> &RuntimeControlReadiness {
         self.for_kind(host.kind())
     }
 
-    pub fn for_kind(&self, kind: &str) -> &HostState {
+    pub fn for_kind(&self, kind: &str) -> &RuntimeControlReadiness {
         self.states
             .get(&crate::ids::AgentKind::new_unchecked(kind))
-            .unwrap_or(&HostState::Disabled)
+            .unwrap_or(&RuntimeControlReadiness::Disabled)
     }
 
     pub fn claude_host_argv(&self) -> Option<&[String]> {
-        self.host_argv
-            .get(&crate::ids::AgentKind::new_unchecked("claude"))
-            .map(Vec::as_slice)
+        match self.for_host(RemoteControlHost::Claude) {
+            RuntimeControlReadiness::Ready {
+                host_argv: Some(argv),
+            } => Some(argv),
+            _ => None,
+        }
     }
 
     /// Skip uninstalled providers and refuse the first installed-provider block.
-    pub fn start_gate(&self) -> Result<(), PreflightError> {
+    pub fn start_gate(&self) -> Result<(), RuntimeControlIssue> {
         for host in [RemoteControlHost::Codex, RemoteControlHost::Claude] {
-            if let HostState::Blocked(issue) = self.for_host(host) {
+            if let RuntimeControlReadiness::Blocked(issue) = self.for_host(host) {
                 return Err(issue.clone());
             }
         }
@@ -100,48 +86,20 @@ impl ReadinessSnapshot {
     }
 
     #[cfg(test)]
-    pub(crate) fn from_states(claude: HostState, codex: HostState) -> Self {
-        let claude_host_argv = matches!(claude, HostState::Ready)
-            .then(|| runtime_control::host_argv("claude"))
-            .flatten();
-        Self::from_probes(
-            [("claude", claude), ("codex", codex)],
-            claude_host_argv.map(|argv| ("claude", argv)),
-        )
+    pub(crate) fn from_states(
+        claude: RuntimeControlReadiness,
+        codex: RuntimeControlReadiness,
+    ) -> Self {
+        Self::from_readiness(claude, codex)
     }
 
-    fn from_probes(
-        states: impl IntoIterator<Item = (&'static str, HostState)>,
-        host_argv: Option<(&'static str, Vec<String>)>,
-    ) -> Self {
+    fn from_readiness(claude: RuntimeControlReadiness, codex: RuntimeControlReadiness) -> Self {
         Self {
-            states: states
+            states: [("claude", claude), ("codex", codex)]
                 .into_iter()
                 .map(|(kind, state)| (crate::ids::AgentKind::new_unchecked(kind), state))
                 .collect(),
-            host_argv: host_argv
-                .into_iter()
-                .map(|(kind, argv)| (crate::ids::AgentKind::new_unchecked(kind), argv))
-                .collect(),
         }
-    }
-}
-
-fn probe_claude(enabled: bool) -> (HostState, Option<Vec<String>>) {
-    match runtime_control::readiness("claude", enabled) {
-        RuntimeControlReadiness::Disabled => (HostState::Disabled, None),
-        RuntimeControlReadiness::Ready { host_argv } => (HostState::Ready, host_argv),
-        RuntimeControlReadiness::Uninstalled(issue) => (HostState::Uninstalled(issue), None),
-        RuntimeControlReadiness::Blocked(issue) => (HostState::Blocked(issue), None),
-    }
-}
-
-fn probe_codex(enabled: bool) -> HostState {
-    match runtime_control::readiness("codex", enabled) {
-        RuntimeControlReadiness::Disabled => HostState::Disabled,
-        RuntimeControlReadiness::Ready { .. } => HostState::Ready,
-        RuntimeControlReadiness::Uninstalled(issue) => HostState::Uninstalled(issue),
-        RuntimeControlReadiness::Blocked(issue) => HostState::Blocked(issue),
     }
 }
 
@@ -172,8 +130,6 @@ pub fn advisories(config: &RemoteControlConfig) -> Vec<String> {
     }
     out
 }
-
-pub type PreflightError = RuntimeControlIssue;
 
 /// Apply one persisted runtime toggle across provider lifecycle, live Claude
 /// room panes, and every known workspace's sidebar.

--- a/crates/rimz/src/remote_control.rs
+++ b/crates/rimz/src/remote_control.rs
@@ -4,7 +4,6 @@
 //! daemon protocol. This module probes each provider once per operation and
 //! coordinates effects.
 
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use crate::agents::runtime_control::{
@@ -32,7 +31,8 @@ impl RemoteControlHost {
 /// One batch probe of both configured provider hosts.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ReadinessSnapshot {
-    states: BTreeMap<crate::ids::AgentKind, RuntimeControlReadiness>,
+    claude: RuntimeControlReadiness,
+    codex: RuntimeControlReadiness,
 }
 
 impl ReadinessSnapshot {
@@ -57,13 +57,18 @@ impl ReadinessSnapshot {
     }
 
     pub fn for_host(&self, host: RemoteControlHost) -> &RuntimeControlReadiness {
-        self.for_kind(host.kind())
+        match host {
+            RemoteControlHost::Claude => &self.claude,
+            RemoteControlHost::Codex => &self.codex,
+        }
     }
 
     pub fn for_kind(&self, kind: &str) -> &RuntimeControlReadiness {
-        self.states
-            .get(&crate::ids::AgentKind::new_unchecked(kind))
-            .unwrap_or(&RuntimeControlReadiness::Disabled)
+        match kind {
+            "claude" => &self.claude,
+            "codex" => &self.codex,
+            _ => &RuntimeControlReadiness::Disabled,
+        }
     }
 
     pub fn claude_host_argv(&self) -> Option<&[String]> {
@@ -94,12 +99,7 @@ impl ReadinessSnapshot {
     }
 
     fn from_readiness(claude: RuntimeControlReadiness, codex: RuntimeControlReadiness) -> Self {
-        Self {
-            states: [("claude", claude), ("codex", codex)]
-                .into_iter()
-                .map(|(kind, state)| (crate::ids::AgentKind::new_unchecked(kind), state))
-                .collect(),
-        }
+        Self { claude, codex }
     }
 }
 

--- a/crates/rimz/src/remote_control/tests.rs
+++ b/crates/rimz/src/remote_control/tests.rs
@@ -2,31 +2,41 @@ use super::*;
 
 #[test]
 fn snapshot_returns_each_host_state_and_ready_claude_argv() {
-    let snapshot = ReadinessSnapshot::from_states(HostState::Ready, HostState::Disabled);
+    let host_argv = vec![
+        "claude".to_owned(),
+        "remote-control".to_owned(),
+        "--spawn".to_owned(),
+        "worktree".to_owned(),
+    ];
+    let snapshot = ReadinessSnapshot::from_states(
+        RuntimeControlReadiness::Ready {
+            host_argv: Some(host_argv.clone()),
+        },
+        RuntimeControlReadiness::Disabled,
+    );
 
     assert_eq!(
         snapshot.for_host(RemoteControlHost::Claude),
-        &HostState::Ready
+        &RuntimeControlReadiness::Ready {
+            host_argv: Some(host_argv.clone()),
+        }
     );
     assert_eq!(
         snapshot.for_host(RemoteControlHost::Codex),
-        &HostState::Disabled
+        &RuntimeControlReadiness::Disabled
     );
-    assert_eq!(
-        snapshot.claude_host_argv().expect("ready argv"),
-        runtime_control::host_argv("claude").expect("Claude host argv")
-    );
+    assert_eq!(snapshot.claude_host_argv().expect("ready argv"), host_argv);
 }
 
 #[test]
 fn start_gate_skips_uninstalled_hosts_and_keeps_hard_refusals() {
     let skipped = ReadinessSnapshot::from_states(
-        HostState::Uninstalled(PreflightError::from_parts(
+        RuntimeControlReadiness::Uninstalled(RuntimeControlIssue::from_parts(
             "claude",
             "uninstalled",
             "Claude is not installed",
         )),
-        HostState::Uninstalled(PreflightError::from_parts(
+        RuntimeControlReadiness::Uninstalled(RuntimeControlIssue::from_parts(
             "codex",
             "standalone_missing",
             "Codex standalone is missing",
@@ -34,26 +44,14 @@ fn start_gate_skips_uninstalled_hosts_and_keeps_hard_refusals() {
     );
     assert_eq!(skipped.start_gate(), Ok(()));
 
-    let issue = PreflightError::from_parts("claude", "blocked", "Claude is too old");
+    let issue = RuntimeControlIssue::from_parts("claude", "blocked", "Claude is too old");
     let blocked = ReadinessSnapshot::from_states(
-        HostState::Blocked(issue.clone()),
-        HostState::Uninstalled(PreflightError::from_parts(
+        RuntimeControlReadiness::Blocked(issue.clone()),
+        RuntimeControlReadiness::Uninstalled(RuntimeControlIssue::from_parts(
             "codex",
             "standalone_missing",
             "Codex standalone is missing",
         )),
     );
     assert_eq!(blocked.start_gate(), Err(issue));
-}
-
-#[test]
-fn only_uninstalled_states_are_skippable() {
-    assert!(PreflightError::from_parts("claude", "uninstalled", "missing").is_uninstalled_host());
-    assert!(
-        PreflightError::from_parts("codex", "standalone_missing", "missing").is_uninstalled_host()
-    );
-    assert!(
-        !PreflightError::from_parts("claude", "blocked", "remote control disabled")
-            .is_uninstalled_host()
-    );
 }


### PR DESCRIPTION
## Context

A from-scratch architecture review of the remote modules looked for structural improvements worth making. The core seam holds: `crates/rimz/src/remote/` owns pure target grammar, typed SSH compilation, and reconnect/link/recovery state, while `crates/rimz/src/cli/remote/` owns processes, clocks, threads, sockets, and terminal writes. Typed attach plans, centralized link transitions, and shared reconnect supervision had already removed the earlier accretion there, so no core rewrite earns its risk.

Three duplications did stand out, and this pass removes them:

- `remote_control::HostState` and `agents::runtime_control::RuntimeControlReadiness` encoded the same four states, with per-provider translators between them, and the snapshot split `Ready`'s host argv back out into a second map keyed by agent kind.
- A separate `RuntimeControlCapability::runtime_control_host_argv` capability existed although readiness already carried the argv.
- Three CLI paths built identical `SshAttachOptions` values (printed attach, launched attach, supervised web attach), and `remote add`/`remote update` plus `remote connect`/`remote reset` each restated the same clap fields.

The pass is behavior-preserving: structure changes, observable behavior does not.

## Design choices

- **Keep the pure/process seam.** A generic SSH compiler was considered and rejected: the lifecycle-specific knobs each caller needs would make it a shallow interface that adds weight without removing knowledge.
- **One canonical readiness value.** Provider adapters return `RuntimeControlReadiness`, whose `Ready` variant carries the optional host argv, and the coordinator batches those values without translating or splitting them. The alternative — keeping a coordinator-local vocabulary — was what created the translators and the second map in the first place.
- **Shared clap groups as flattened structs**, per `docs/contributing/rust-conventions.md`. The groups are module-scope structs named for what they hold, matching `GlobalFlags`, `AttachFlags`, `SendFlags`, and `CohortLaunchArgs` elsewhere in the CLI.
- **`resolve_connect` stays a standalone alias-precedence function** rather than folding into the clap argument types, which keeps the tested domain boundary and avoids coupling resolution to parser shape.
- **Test fixtures construct `Ready` with explicit argv.** Production gains no fixture seam.

## Implementation

Readiness, in `crates/rimz/src/remote_control.rs`:

- `ReadinessSnapshot` stores `RuntimeControlReadiness` in `claude` and `codex` fields. `HostState`, the `PreflightError` alias, the second argv map, `probe_claude`, and `probe_codex` are gone; `claude_host_argv()` reads the argv out of `Ready { host_argv: Some(..) }`. Probe order (Claude then Codex) and `start_gate`'s refusal order (Codex then Claude) are unchanged.
- The redundant argv path is deleted: `runtime_control::host_argv`, `RuntimeControlCapability::runtime_control_host_argv`, and Claude's override of it. `RuntimeControlReadiness::Ready` is the sole home for launch argv, and Claude's adapter already populated it. `RuntimeControlIssue::is_uninstalled_host` and its test go too — no production path consumed it, since `start_gate` matches the `Uninstalled` variant rather than the issue code.
- Callers in `cli/doctor/runtime.rs` and the `daemon_view` / `remote_control` tests now speak `RuntimeControlReadiness` and `RuntimeControlIssue` directly.

CLI, in `crates/rimz/src/cli/remote.rs`:

- One private `RemoteConnect::attach_plan(client_size)` builds the `SshAttachPlan` for all three attach paths, including the supervised web path in `cli/remote/web.rs`.
- `SavedAliasArgs` (target plus the three alias flags, with `into_alias`) flattens into `Add` and `Update`, replacing positional `build_alias`. `ConnectionArgs` (target, connection flags, and nested `AttachFlags`) flattens into `Connect` and `Reset`; `Connect` keeps its own `--reset` flag and `Reset` supplies `reset = true`, so `ConnectOptions` is gone and both dispatch through one `connect` input shape.

Deviations from the plan: the plan sketched the two argument groups as private modules each exporting a type called `Args`; they shipped as module-scope `SavedAliasArgs` and `ConnectionArgs` instead, matching how every other shared option group in the CLI is written. The plan also left `ReadinessSnapshot`'s internal storage open; with `from_readiness` as the sole constructor always inserting the same two keys, the `BTreeMap` became two named fields and `for_host` a direct enum match.

Evidence the pass is behavior-preserving:

- The CLI surface snapshot is byte-identical to the base commit — no snapshot update was accepted — and `cargo xtask gate` passes.
- `remote connect <alias> --print` emits output byte-identical to a base build once the embedded build id is normalized. `remote reset X --print` is byte-identical to `remote connect X --reset --print`, and differs from a plain connect by exactly ` --no-resume`; `--force-version` adds exactly `RIMZ_REMOTE_FORCE_VERSION=1`.
- Checked live after the argument groups moved: positional order (`<NAME> <TARGET>`, `<ALIAS_OR_TARGET>`), `--web-port` still requiring `--web`, dynamic alias completion still firing on `connect`/`reset`/`update`, and the alias flag mapping through `add`/`update`/`list`.
- One evaluation-order change: in the print and launch paths the remote lineage is now resolved before the terminal plan, where it used to follow it. The two are independent — the terminal plan only shells out to `infocmp -x` — so the only difference is that a lineage failure no longer spawns that subprocess first.

Net 164 lines removed across 9 files.

## Advisories

- `ReadinessSnapshot::for_kind` is public and has no caller anywhere in the tree; `for_host` is the only thing that used to reach it. It was kept deliberately, because the plan pins missing-kind behavior as exact. Worth knowing: its string arms now restate the host-to-kind mapping `RemoteControlHost::kind()` already owns, and unlike `for_host`'s enum match they are not compiler-checked, so a future third host would silently read `Disabled` through it. Inert while nothing calls it, and a candidate for deletion in a pass that is allowed to change API surface.
- A separate pre-existing bug was found and deliberately left alone, since this pass is behavior-preserving: remote alias load validates alias names but not targets, although the docs claim target validation happens on load.
- Attach-plan inputs still depend on live hostname, passwd entry, `TERM`, and `infocmp`. Consolidating the three construction sites did not add a fixture seam for them, so that path stays covered by the print-path integration tests rather than by unit tests.
- The supervised web path now calls the shared attach-plan helper without a test of its own for that fact; it stays covered by existing remote-web coverage in the gate.
