### PR TITLE
Stabilize live web and Zellij test fixtures

### DIFF
--- a/crates/rimz/tests/integration/backend/web/mod.rs
+++ b/crates/rimz/tests/integration/backend/web/mod.rs
@@ -65,8 +65,7 @@ fn continuous_output_keeps_websocket_attached() {
     let fixture = LiveWebFixture::new(&stack);
     let opened = fixture.open();
     let browser = BrowserHandle::launch(&stack.browser);
-    let (tab, frames) =
-        browser.tab_with_websocket_capture(&opened.url, Some(&opened.secret), false);
+    let (tab, frames) = browser.tab_with_websocket_capture(&opened.url, &opened.secret);
 
     frames.wait_url_contains(
         &format!("arg={}", fixture.workspace.session_name),
@@ -195,14 +194,6 @@ fn share_broadcast_views_without_auth_and_drops_input() {
     tab.press_key("Enter")
         .expect("submit read-only viewer marker");
     fixture.assert_capture_absent("RIMZ_VIEWER_INPUT", Duration::from_secs(3));
-
-    let second = fixture.add_room("unshared");
-    let (_refused, frames) = browser.tab_with_websocket_capture(
-        &format!("{}?room={}", fixture.share_base_url(), second.session_name),
-        None,
-        true,
-    );
-    frames.wait_contains("this room is not shared", ATTACH_TIMEOUT);
 }
 
 #[test]

--- a/crates/rimz/tests/integration/backend/web/support.rs
+++ b/crates/rimz/tests/integration/backend/web/support.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 use base64::Engine as _;
 use headless_chrome::protocol::cdp::{Network, types::Event};
 use headless_chrome::{Browser, LaunchOptions, Tab};
+use rimz::mux::{ClientFocusOptions, MuxBackend, ZellijBackend};
 
 use crate::backend::tmux::TmuxServer;
 use crate::common::{CommandTimeoutExt, Env, ZellijNamespace, daemon_test_guard};
@@ -508,6 +509,7 @@ impl LiveZellijWebFixture {
     }
 
     pub(super) fn send_line(&self, line: &str) {
+        self.wait_until_attached();
         let typed = self
             .namespace
             .command()
@@ -534,6 +536,47 @@ impl LiveZellijWebFixture {
             .bounded_output()
             .expect("submit Zellij room input");
         assert_success(&enter, "submit Zellij room input");
+    }
+
+    fn wait_until_attached(&self) {
+        let backend = ZellijBackend::with_runtime_dir(self.namespace.path());
+        let deadline = Instant::now() + super::ATTACH_TIMEOUT;
+        let mut consecutive_matches = 0;
+        let mut last_human_clients = 0;
+        let mut last_viewed_panes = Vec::new();
+        let mut last_error = String::new();
+        loop {
+            match backend.client_view(ClientFocusOptions {
+                session_name: Some(self.workspace.session_name.clone()),
+                ..Default::default()
+            }) {
+                Ok(view) => {
+                    last_human_clients = view.presence.human_clients;
+                    last_viewed_panes = view.viewed_panes;
+                    last_error.clear();
+                    consecutive_matches =
+                        if last_human_clients == 1 && !last_viewed_panes.is_empty() {
+                            consecutive_matches + 1
+                        } else {
+                            0
+                        };
+                    if consecutive_matches == 2 {
+                        return;
+                    }
+                }
+                Err(error) => {
+                    consecutive_matches = 0;
+                    last_error = error.to_string();
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "Zellij web client did not become attached; last human client count: \
+                 {last_human_clients}; last viewed panes: {last_viewed_panes:?}; last error: \
+                 {last_error}"
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        }
     }
 
     fn command(&self) -> Command {

--- a/crates/rimz/tests/integration/backend/web/support.rs
+++ b/crates/rimz/tests/integration/backend/web/support.rs
@@ -453,7 +453,7 @@ impl LiveZellijWebFixture {
     }
 
     pub(super) fn send_line(&self, line: &str) {
-        self.wait_until_attached();
+        self.wait_for_attached_zellij_client();
         let typed = self
             .namespace
             .command()
@@ -482,7 +482,7 @@ impl LiveZellijWebFixture {
         assert_success(&enter, "submit Zellij room input");
     }
 
-    fn wait_until_attached(&self) {
+    fn wait_for_attached_zellij_client(&self) {
         let backend = ZellijBackend::with_runtime_dir(self.namespace.path());
         let deadline = Instant::now() + super::ATTACH_TIMEOUT;
         let mut consecutive_matches = 0;

--- a/crates/rimz/tests/integration/backend/web/support.rs
+++ b/crates/rimz/tests/integration/backend/web/support.rs
@@ -5,7 +5,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use base64::Engine as _;
 use headless_chrome::protocol::cdp::{Network, types::Event};
 use headless_chrome::{Browser, LaunchOptions, Tab};
 use rimz::mux::{ClientFocusOptions, MuxBackend, ZellijBackend};
@@ -132,13 +131,9 @@ impl BrowserHandle {
     pub(super) fn tab_with_websocket_capture(
         &self,
         url: &str,
-        secret: Option<&str>,
-        capture_text: bool,
+        secret: &str,
     ) -> (Arc<Tab>, WebSocketCapture) {
-        let tab = secret.map_or_else(
-            || self.browser.new_tab().expect("open browser tab"),
-            |secret| self.configured_authed_tab(secret),
-        );
+        let tab = self.configured_authed_tab(secret);
         tab.call_method(Network::Enable {
             max_total_buffer_size: None,
             max_resource_buffer_size: None,
@@ -147,7 +142,7 @@ impl BrowserHandle {
             enable_durable_messages: None,
         })
         .expect("enable browser network events");
-        let capture = WebSocketCapture::new(&tab, capture_text);
+        let capture = WebSocketCapture::new(&tab);
         tab.navigate_to(url).expect("navigate browser tab");
         (tab, capture)
     }
@@ -157,21 +152,18 @@ pub(super) struct WebSocketCapture {
     closes: Arc<AtomicUsize>,
     received: Arc<AtomicUsize>,
     sent: Arc<AtomicUsize>,
-    text: Arc<Mutex<String>>,
     urls: Arc<Mutex<Vec<String>>>,
 }
 
 impl WebSocketCapture {
-    fn new(tab: &Tab, capture_text: bool) -> Self {
+    fn new(tab: &Tab) -> Self {
         let closes = Arc::new(AtomicUsize::new(0));
         let received = Arc::new(AtomicUsize::new(0));
         let sent = Arc::new(AtomicUsize::new(0));
-        let text = Arc::new(Mutex::new(String::new()));
         let urls = Arc::new(Mutex::new(Vec::new()));
         let listener_closes = Arc::clone(&closes);
         let listener_received = Arc::clone(&received);
         let listener_sent = Arc::clone(&sent);
-        let listener_text = Arc::clone(&text);
         let listener_urls = Arc::clone(&urls);
         tab.add_event_listener(Arc::new(move |event: &Event| match event {
             Event::NetworkWebSocketCreated(event) => {
@@ -180,17 +172,8 @@ impl WebSocketCapture {
                     .expect("lock WebSocket URLs")
                     .push(event.params.url.clone());
             }
-            Event::NetworkWebSocketFrameReceived(event) => {
+            Event::NetworkWebSocketFrameReceived(_) => {
                 listener_received.fetch_add(1, Ordering::Relaxed);
-                if !capture_text {
-                    return;
-                }
-                let payload = &event.params.response.payload_data;
-                let mut text = listener_text.lock().expect("lock WebSocket capture");
-                text.push_str(payload);
-                if let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(payload) {
-                    text.push_str(&String::from_utf8_lossy(&decoded));
-                }
             }
             Event::NetworkWebSocketFrameSent(_) => {
                 listener_sent.fetch_add(1, Ordering::Relaxed);
@@ -205,7 +188,6 @@ impl WebSocketCapture {
             closes,
             received,
             sent,
-            text,
             urls,
         }
     }
@@ -243,21 +225,6 @@ impl WebSocketCapture {
             std::thread::sleep(Duration::from_millis(100));
         }
     }
-
-    pub(super) fn wait_contains(&self, needle: &str, budget: Duration) {
-        let deadline = Instant::now() + budget;
-        loop {
-            let text = self.text.lock().expect("lock WebSocket capture").clone();
-            if text.contains(needle) {
-                return;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "browser WebSocket did not contain {needle:?}; captured frames:\n{text}"
-            );
-            std::thread::sleep(Duration::from_millis(100));
-        }
-    }
 }
 
 pub(super) struct OpenedWeb {
@@ -276,7 +243,6 @@ pub(super) struct LiveWebFixture {
     server: TmuxServer,
     ttyd: PathBuf,
     web_port: u16,
-    share_port: u16,
 }
 
 impl LiveWebFixture {
@@ -311,7 +277,6 @@ impl LiveWebFixture {
             server,
             ttyd: stack.ttyd.clone(),
             web_port,
-            share_port,
         }
     }
 
@@ -321,10 +286,6 @@ impl LiveWebFixture {
 
     pub(super) fn display_name(&self) -> String {
         workspace_display_name(&self.workspace)
-    }
-
-    pub(super) fn share_base_url(&self) -> String {
-        format!("http://127.0.0.1:{}/", self.share_port)
     }
 
     pub(super) fn open(&self) -> OpenedWeb {
@@ -398,23 +359,6 @@ impl LiveWebFixture {
             }
             std::thread::sleep(Duration::from_millis(100));
         }
-    }
-
-    pub(super) fn add_room(&self, name: &str) -> rimz::ResolvedWorkspace {
-        let root = self.env.project_root.join(name);
-        self.env.write_config(&root, "");
-        self.env.record(&root);
-        let workspace = rimz::WorkspaceResolver::resolve(&root, None).expect("resolve second room");
-        self.server.output(&[
-            "new-session",
-            "-d",
-            "-s",
-            &workspace.session_name,
-            "-c",
-            &root.to_string_lossy(),
-            "sh",
-        ]);
-        workspace
     }
 
     fn capture(&self, session: &str) -> String {

--- a/crates/rimz/tests/integration/backend/zellij/reconcile.rs
+++ b/crates/rimz/tests/integration/backend/zellij/reconcile.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use rimz::ids::{MuxName, PaneId, SidebarInstanceId, WorkspaceId};
-use rimz::mux::{SidebarLiveness, SidebarPaneOptions, SidebarWidth};
+use rimz::mux::{MuxBackend, SidebarLiveness, SidebarPaneOptions, SidebarWidth};
 use rimz::sidebar::heartbeat::SidebarHeartbeat;
 use rimz::store::RuntimePaths;
 use tempfile::TempDir;
@@ -281,26 +281,23 @@ fn reconcile_defers_the_add_on_a_detached_session() {
 
     // A detached background session with a working pane and no sidebar.
     room.create_plain_background(cwd.path(), "60");
-    let before = wait_for_pane_count(xdg, &name, 1);
-    assert!(
-        !before.is_empty(),
-        "plain session should have a pane before reconcile: {before:?}",
-    );
 
     let (_stub_dir, stub) = sidebar_command_stub();
     let opts = sidebar_opts(&name, cwd.path(), stub, 120);
     write_topology_cache_from_list_panes(xdg, &opts.workspace_id, &name);
-    // A freshly born --create-background session whose only pane is still
-    // materializing is the case most prone to reconcile's transient-empty read,
-    // so retry until reconcile actually observes the working pane.
-    let report = reconcile_until_observed(xdg, &opts, &SidebarLiveness::default());
+    // Cache publication owns readiness for the freshly born working pane, so
+    // reconcile consumes that accepted snapshot once.
+    let report = room
+        .backend()
+        .reconcile_sidebars(&opts, &SidebarLiveness::default())
+        .expect("reconcile_sidebars");
 
     assert_eq!(report.deferred, 1, "the detached session's add is deferred");
     assert_eq!(report.recovered, 0, "nothing is added without a client");
     assert_eq!(report.failed, 0, "a deferral is not a failure");
     // Poll rather than read once: a recovered add would already have tripped the
     // `recovered == 0` assertion above, so here a single empty `list-panes` answer
-    // under load would only flake a settled result. `before` polls for the same reason.
+    // under load would only flake a settled result.
     let after = wait_for_pane_count(xdg, &name, 1);
     assert_eq!(after.len(), 1, "no pane was added detached: {after:?}");
     assert_eq!(

--- a/crates/rimz/tests/integration/backend/zellij/support/actions.rs
+++ b/crates/rimz/tests/integration/backend/zellij/support/actions.rs
@@ -118,27 +118,10 @@ pub(in crate::backend::zellij) fn new_tab_template_dump(xdg: &Path, session: &st
     );
 }
 
-pub(in crate::backend::zellij) fn reconcile_until_observed(
-    xdg: &Path,
-    opts: &SidebarPaneOptions,
-    live: &SidebarLiveness,
-) -> SidebarRecovery {
-    reconcile_loop(xdg, opts, live, false)
-}
-
 pub(in crate::backend::zellij) fn reconcile_until_converged(
     xdg: &Path,
     opts: &SidebarPaneOptions,
     live: &SidebarLiveness,
-) -> SidebarRecovery {
-    reconcile_loop(xdg, opts, live, true)
-}
-
-fn reconcile_loop(
-    xdg: &Path,
-    opts: &SidebarPaneOptions,
-    live: &SidebarLiveness,
-    retry_deferral: bool,
 ) -> SidebarRecovery {
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
@@ -150,7 +133,7 @@ fn reconcile_loop(
                 deferred: 0,
                 ..report
             } == SidebarRecovery::default();
-        let transient = report == SidebarRecovery::default() || (retry_deferral && deferral_only);
+        let transient = report == SidebarRecovery::default() || deferral_only;
         if !transient || Instant::now() >= deadline {
             return report;
         }

--- a/crates/rimz/tests/integration/backend/zellij/support/topology.rs
+++ b/crates/rimz/tests/integration/backend/zellij/support/topology.rs
@@ -78,7 +78,7 @@ pub(in crate::backend::zellij) fn write_topology_cache_from_list_panes(
     xdg: &Path,
     workspace_id: &WorkspaceId,
     session: &str,
-) -> PaneSnapshot {
+) {
     let snapshot = super::actions::poll_until(
         super::session::SPAWN_TIMEOUT,
         || list_panes(xdg, session),
@@ -91,7 +91,6 @@ pub(in crate::backend::zellij) fn write_topology_cache_from_list_panes(
         &format!("one tiled terminal pane in {session}"),
     );
     write_topology_cache(xdg, workspace_id, session, &snapshot);
-    snapshot
 }
 
 pub(in crate::backend::zellij) struct TopologyCacheMirror {

--- a/crates/rimz/tests/integration/backend/zellij/support/topology.rs
+++ b/crates/rimz/tests/integration/backend/zellij/support/topology.rs
@@ -78,13 +78,20 @@ pub(in crate::backend::zellij) fn write_topology_cache_from_list_panes(
     xdg: &Path,
     workspace_id: &WorkspaceId,
     session: &str,
-) {
-    write_topology_cache(
-        xdg,
-        workspace_id,
-        session,
-        &PaneSnapshot::expect(xdg, session),
+) -> PaneSnapshot {
+    let snapshot = super::actions::poll_until(
+        super::session::SPAWN_TIMEOUT,
+        || list_panes(xdg, session),
+        |snapshot| {
+            snapshot
+                .panes
+                .iter()
+                .any(|pane| !pane.is_plugin && !pane.is_suppressed && !pane.is_floating)
+        },
+        &format!("one tiled terminal pane in {session}"),
     );
+    write_topology_cache(xdg, workspace_id, session, &snapshot);
+    snapshot
 }
 
 pub(in crate::backend::zellij) struct TopologyCacheMirror {


### PR DESCRIPTION
## Context

A sweep of the last 7 days of `main` CI (10 completed `tests` jobs) found 10 distinct tests that failed and then passed on retry, 20 retries in total. The live tiers already run under per-test Zellij namespaces, nextest concurrency caps, and four retries, and recent history had answered earlier flakes by adding more waits and more retry budget — which hid failures without making any fixture deterministic.

Three of the highest-recurrence entries traced to fixtures that assert readiness they have not actually proven, not to product bugs:

- **Zellij web attach** (5 runs, worst 5/5). The fixture treated the browser's URL and document title as proof of attachment, then sent a Zellij action. Failing logs end on a healthy blank terminal — input accepted while the room was still detached.
- **Detached reconcile** (3 runs, worst 5/5). `wait_for_pane_count` proved a pane, then the topology publisher took a second, independent `list-panes` sample and durably published whatever it saw, including a transient `[]`. Reconcile then consumed that static empty cache for its whole 10-second loop and returned the default report.
- **Broadcast web view** (2 runs). A second browser tab against a second room added transport fragility for coverage that deterministic process-level tests already own.

This PR fixes those three. It is behaviour-preserving: the diff is confined to `crates/rimz/tests/integration/`, and no runtime source or documentation changes.

## Design choices

**Deepen the observation, don't widen the budget.** Every fix makes a fixture helper prove the state its name claims. No new sleeps, no new retry flags, no scheduling-cap changes. More timeout surface was the previous answer and it did not remove these races.

**Topology acceptance mirrors the runtime's own rule.** Publication accepts a snapshot containing at least one non-plugin, non-suppressed, non-floating pane — character-for-character `PaneTopologyPane::is_terminal`, which is what `reconcile_pane` gates on. Held and exited panes count on both sides because they still occupy layout cells. The narrower live-pane listing rule was rejected: a fixture that accepts a stricter set than the runtime consumes would reintroduce skew in the other direction.

**Delete duplicated browser coverage rather than stabilise it.** The revoked/unshared-room refusal was asserted through a second browser tab. `tests/integration/web.rs` already proves the same contract deterministically, and the browser path bought transport fragility with no extra leverage. Browser tests now own browser transport behaviour only; allowlist and refusal wording stay in process-level tests.

**Presence focus repair is deliberately out of scope.** `tab_switch_repairs_sidebar_focus_from_attached_client_views` recurred 4 times, but it is a product bug, not a fixture bug: detached focus aborts on `PreObservationChanged` and the loop drops the pending repair when spawn starts, so one transient fresh-sample mismatch consumes the only attempt. The fence that produces this is load-bearing — it stops RimZ stealing user focus. A test-only retry here would hide lost automation, and the real fix (retain the pending repair and retry it conditionally through its existing TTL) is a behaviour change that does not belong in a behaviour-preserving pass. The test is left exactly as it was, still able to fail.

## Implementation

**Zellij web attachment readiness.** `LiveZellijWebFixture::send_line` now calls a private `wait_for_attached_zellij_client` before issuing `write-chars` and Enter. It polls `ZellijBackend::client_view` for the fixture's session until two consecutive samples show one human client and a non-empty viewed-pane set, bounded by the existing attach budget, resetting on mismatch or probe error. The timeout diagnostic carries the last client count, the last viewed panes, and the last error. The scenario's own assertions are unchanged; its existing `send_line` call simply now means "send after the client actually registered".

**Topology publication.** `write_topology_cache_from_list_panes` polls `list_panes` until a sample satisfies the acceptance rule above, then serialises that exact sample. It never proves one snapshot and publishes another. As a side effect it is also more robust than the code it replaces, which used `PaneSnapshot::expect` and panicked on the first transient `list-panes` error where the poll now retries.

With publication owning readiness, `reconcile_defers_the_add_on_a_detached_session` calls `reconcile_sidebars` once instead of looping, and its redundant pre-check is gone; the deferred, recovered, failed, and serve-process assertions are untouched. That let `reconcile_until_observed` go, and with it the boolean parameter that had branched the shared loop. `reconcile_until_converged` keeps its exact prior behaviour for its six remaining callers — the old `retry_deferral = true` path inlines to the same predicate.

**Duplicate browser refusal path.** The second-room, second-tab branch is gone from `share_broadcast_views_without_auth_and_drops_input`, along with the fixture surface only it used: `add_room`, `share_base_url`, the stored share port, and the WebSocket capture's text storage, base64 decoder, `wait_contains`, and `capture_text` parameter. The share port stays a constructor-local config input. Unauthenticated rendering and dropped-input assertions remain — those are genuinely browser-only contracts — as do the frame counters, close count, sent-frame wait, and URL capture that the continuous-output test needs.

A final commit narrows two helper surfaces flagged in review: the topology publisher no longer returns a `PaneSnapshot` that all nine of its callers discarded, and the new readiness method is named `wait_for_attached_zellij_client` so it cannot be confused with the pre-existing browser-side `wait_until_attached`, which polls the page's query string for a different thing.

**Deviations from plan:** none, beyond that review-driven narrowing.

### Behaviour-preserving evidence

The merge-base diff touches five test files and nothing else; runtime source is unchanged, so product behaviour cannot have moved. Every distinct shipped contract still has a test: the deleted browser refusal branch is re-owned by `tests/integration/web.rs`, which asserts `rimz web exec --share <session>` exits non-zero with exactly `this room is not shared` and leaks neither the live-session list nor the other room's name, with the daemon-to-shim argv composition unit-covered in `src/web/share.rs`. The `room=` to `arg=` browser mapping stays covered by the continuous-output test's URL assertion.

Stress evidence, retries disabled, on a host with ttyd, Zellij, tmux, and Chromium:

| test | iterations | failures |
| --- | --- | --- |
| `backend::web::zellij_room_attaches_through_shared_daemon` | 20 | 0 |
| `backend::web::share_broadcast_views_without_auth_and_drops_input` | 20 | 0 |
| `backend::zellij::reconcile::reconcile_defers_the_add_on_a_detached_session` | 21 (11 idle, 10 under 8-way CPU saturation) | 0 |

Post-fix `cargo xtask gate` passes.

Note for anyone reproducing this: the browser suite's Chromium probe only searches `PATH`, so a Chromium that lives outside it self-skips the whole suite silently. `RIMZ_TEST_BROWSER=/abs/path/to/chrome-headless-shell` un-skips it.

## Advisories

None of these gate the PR.

- **Exact single-client readiness.** The attachment wait requires `human_clients == 1` rather than `>= 1`. If ttyd's WebSocket ever reconnects and leaves the previous `rimz web exec` child alive past a poll interval, the predicate can never hold and the fixture fails at the 60-second timeout on a precondition that was in fact satisfied. Unobserved across 20 runs, and specified this way by the plan, so it stays as written; `>= 1` would carry the same guarantee without that failure mode.
- **A leftover of the pattern this pass removed.** `backend/zellij/launch.rs` still runs the `wait_for_pane_count` plus non-empty assertion pair immediately before its own `write_topology_cache_from_list_panes` call — now redundant, since publication owns that readiness. Left alone as out-of-diff; worth deleting next time that file is touched.
- **Presence focus-repair defect is still open**, unchanged and unsuppressed, as described above. It did not fail in this branch's live run, which does not mean it is fixed.
- **An unrelated live-profile test is red on this host.** `backend::tmux::agent_lifecycle::resumed_lazy_agent_is_addressable_before_provider_registration` fails all five attempts at `agent_lifecycle.rs:371` with `attached live pane`, and reproduces deterministically in about 0.1 seconds with retries disabled. It sits in the tmux suite, shares no module with any file in this diff, and fails too fast to be a race — it reads environmental. Flagged so the next person does not re-triage it as fallout from this change.
