### PR TITLE
Avoid redundant RimZ rebuilds between CI test tiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,6 @@ flamegraph.svg
 coverage/
 lcov.info
 
-# Generated pricing snapshot
-/crates/rimz/pricing/litellm-pricing.json
-
 # Agent Harness
 /blackboard.md
 /*-notes.md

--- a/crates/rimz/build.rs
+++ b/crates/rimz/build.rs
@@ -29,6 +29,7 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 const GENERATED_SNAPSHOT: &str = "pricing/litellm-pricing.json";
+const PRICING_DIR: &str = "pricing";
 const THEME_CATALOG_DIR: &str = "themes/alacritty";
 const PRESENCE_PLUGIN_ENV: &str = "RIMZ_EMBED_PRESENCE_PLUGIN";
 const BUILD_PROFILE_OVERRIDE_ENV: &str = "RIMZ_BUILD_PROFILE_OVERRIDE";
@@ -320,10 +321,7 @@ fn resolve_raw_json() -> String {
 
     let manifest = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
     let generated = manifest.join(GENERATED_SNAPSHOT);
-    // Register the path even before its first generation: pricing-refresh
-    // builds this helper binary, then creates the snapshot, so the next build
-    // must replace that run's empty embed.
-    println!("cargo:rerun-if-changed={}", generated.display());
+    println!("cargo:rerun-if-changed={PRICING_DIR}");
     match fs::read_to_string(&generated) {
         Ok(raw) => raw,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => "{}".to_owned(),

--- a/crates/rimz/build.rs
+++ b/crates/rimz/build.rs
@@ -321,6 +321,8 @@ fn resolve_raw_json() -> String {
 
     let manifest = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
     let generated = manifest.join(GENERATED_SNAPSHOT);
+    // The snapshot is optional, so watch its tracked directory: Cargo treats missing
+    // watched paths as dirty, and pricing/.gitignore preserves the directory in clean checkouts.
     println!("cargo:rerun-if-changed={PRICING_DIR}");
     match fs::read_to_string(&generated) {
         Ok(raw) => raw,

--- a/crates/rimz/pricing/.gitignore
+++ b/crates/rimz/pricing/.gitignore
@@ -1,0 +1,2 @@
+# Generated pricing snapshot
+/litellm-pricing.json


### PR DESCRIPTION
## Context

The CI `tests` job runs `cargo xtask test` three times in sequence, once per profile (`gate`, `live`, `journey`). Its runtime roughly doubled, from about 1.5 minutes to about 3 minutes.

The suites themselves were not the cause. Measured across the boundary commit, nextest runtimes were flat: `gate` went 103.083s to 102.162s, `journey` 14.783s to 16.766s. What changed is that each of the three profile steps began recompiling `rimz` for 86-91 seconds before it could enter nextest, where previously each step passed a sub-second freshness check.

The root cause is in `crates/rimz/build.rs`. The build script unconditionally emitted `cargo:rerun-if-changed` for `pricing/litellm-pricing.json`, a generated snapshot that is deliberately gitignored and therefore absent from every ordinary checkout. Cargo treats a missing watched path as perpetually dirty, so the build script and every dependent `rimz` target were marked stale on every single invocation. Each CI step paid a full rebuild the previous step had just finished.

## Design choices

**Watch the pricing directory, not the optional file inside it.** The old file watch existed for a real reason, recorded in the comment it replaced: `cargo xtask pricing-refresh` builds the helper binary first and only then writes the snapshot, so the following build has to notice a file that did not exist when the build script last ran. Watching only when the file is present would fix the churn but lose that first-generation detection.

Watching the containing directory keeps both properties. Cargo's directory watch reports the maximum mtime across the tree, so it fires on file creation, in-place content edits, atomic replace-by-rename, and deletion alike, while a stable always-present directory never goes dirty on its own.

**Keep the snapshot gitignored; track the directory.** The ignore rule moved from the root `.gitignore` into a new tracked `crates/rimz/pricing/.gitignore`. Git cannot track an empty directory, so this file is what makes the directory materialize in clean checkouts, which is the precondition the directory watch depends on. `litellm-pricing.json` stays untracked exactly as before, confirmed by `git check-ignore`.

**Rejected:** tuning nextest concurrency or the suite partitioning in `.config/nextest.toml`. The measurements show the test bodies were never the regression, so that would have traded real coverage for a problem living elsewhere.

## Implementation

Three files, no logic changes beyond the one Cargo directive.

- `crates/rimz/build.rs` emits `cargo:rerun-if-changed=pricing` in place of the full snapshot path. Reading the snapshot is unchanged: present it is read and compressed as before, absent it still embeds `{}` and leaves the runtime refresh to populate prices. Relative-directory watching is already the established pattern in this file, which watches `themes/alacritty` the same way.
- `crates/rimz/pricing/.gitignore` is new and holds the anchored `/litellm-pricing.json` rule.
- The root `.gitignore` loses that rule.

No deviations from the approved plan.

Verification, all from a clean tree:

- Freshness with no snapshot: one compile, then an identical second invocation finished in 0.11s with no compile phase.
- First generation: creating a probe snapshot reran the build script and the SHA-256 of the decompressed embed matched the source. Changing its content reran again and both hashes moved together, confirming the directory watch catches in-place rewrites and not merely creation.
- The exact CI sequence after rebase: `gate` 5,442 passed / 111 skipped, `live` 86 passed / 5,272 skipped, `journey` 25 passed / 5,333 skipped. All three entered nextest through a 0.11s freshness check with no `Compiling rimz` phase, and test counts are unchanged.
- `cargo xtask gate --check` passes: fmt, invariants, docs-links, lint, and test.

Review independently confirmed the mechanism against cargo 1.97.1 rather than taking it on trust: in an isolated crate, a watched directory holding a stable file stays fresh across no-op rebuilds and reruns on create, in-place edit, atomic rename, and delete, while a watched missing path reruns on every build.

## Advisories

The fix's durability rests on a convention nothing enforces. The entire win depends on `crates/rimz/pricing/` existing in every checkout, which depends on one tracked `.gitignore` whose only purpose is to hold the directory open. Consolidating ignore rules back into the root `.gitignore` would look like ordinary tidy-up and would silently restore the regression, with no failing test and no tripped gate to catch it. A build-script comment now records the rationale in place, which is the minimum guard.

A stronger guard would match existing practice: `xtask/src/invariants.rs` already gates `PACKAGED_BUILD_INPUTS` precisely because a build input can vanish silently and degrade what ships. An analogous check that the pricing directory stays tracked would put the guard at the same depth as the hazard. That is beyond this plan's scope and is left as a call for the plan owner.

Also worth knowing: the directory watch makes any future file added to `crates/rimz/pricing/` a build input. Today the directory holds only its ignore file and the optional snapshot, so there is no extra invalidation in practice.
