### PR TITLE
agents attribution: move tool-call and compaction counts to their own line, hiding zeros

### DIFF
--- a/crates/rimz/src/cli/agents_cmd/attribution.rs
+++ b/crates/rimz/src/cli/agents_cmd/attribution.rs
@@ -144,6 +144,9 @@ pub(super) fn render_panel(w: &mut impl Write, report: &Attribution) -> std::io:
             )?;
             let mut details = render::KeyVals::new().indent(6);
             details.push("effort", render::cell(effort_label(member)));
+            if let Some(calls) = calls_label(member) {
+                details.push("calls", render::cell(calls));
+            }
             details.push("tokens", render::cell(token_label(member)));
             details.render(w)?;
         }
@@ -182,6 +185,9 @@ pub(super) fn render_markdown(w: &mut impl Write, report: &Attribution) -> std::
                 markdown_model_label(member),
             )?;
             writeln!(w, "  - effort: {}", markdown_escape(&effort_label(member)))?;
+            if let Some(calls) = calls_label(member) {
+                writeln!(w, "  - calls: {}", markdown_escape(&calls))?;
+            }
             writeln!(w, "  - tokens: {}", markdown_escape(&token_label(member)))?;
         }
     }
@@ -257,17 +263,22 @@ fn effort_label(member: &AttributionMember) -> String {
         .cost_usd
         .map(rimz::theme::fmt::dollars2)
         .unwrap_or_else(|| "cost unknown".to_owned());
-    let tools = match member.tool_calls {
-        0 => "no tool calls".to_owned(),
-        1 => "1 tool call".to_owned(),
-        count => format!("{count} tool calls"),
-    };
-    let compactions = match member.compactions {
-        0 => "no compactions".to_owned(),
-        1 => "1 compaction".to_owned(),
-        count => format!("{count} compactions"),
-    };
-    format!("{active} · {cost} · {tools}, {compactions}")
+    format!("{active} · {cost}")
+}
+
+fn calls_label(member: &AttributionMember) -> Option<String> {
+    let mut parts = Vec::with_capacity(2);
+    match member.tool_calls {
+        0 => {}
+        1 => parts.push("1 tool call".to_owned()),
+        count => parts.push(format!("{count} tool calls")),
+    }
+    match member.compactions {
+        0 => {}
+        1 => parts.push("1 compaction".to_owned()),
+        count => parts.push(format!("{count} compactions")),
+    }
+    (!parts.is_empty()).then(|| parts.join(" · "))
 }
 
 fn token_label(member: &AttributionMember) -> String {
@@ -458,13 +469,15 @@ mod tests {
         forge team · 1 agent · 1h05m active · $1.25
 
           @planner (plan|ner) · Claude · fable`2@high
-              effort: 1h05m active · $1.25 · 7 tool calls, 1 compaction
+              effort: 1h05m active · $1.25
+              calls:  7 tool calls · 1 compaction
               tokens: 1.2k input, 800 output, 2k cache write, 3k cache read
 
         Other agents · 1 agent · 1h05m active · $1.25
 
           @codex · Codex · gpt-5.5@high
-              effort: 1h05m active · $1.25 · 7 tool calls, 1 compaction
+              effort: 1h05m active · $1.25
+              calls:  7 tool calls · 1 compaction
               tokens: 1.2k input, 800 output, 2k cache write, 3k cache read
 
         Total · 2 agents · 2h10m active · $2.50
@@ -482,7 +495,8 @@ mod tests {
         render_panel(&mut output, &report).expect("render panel");
         insta::assert_snapshot!(String::from_utf8(output.into_inner()).expect("utf8"), @r"
           @codex · Codex · gpt-5.5@high
-              effort: 1h05m active · $1.25 · 7 tool calls, 1 compaction
+              effort: 1h05m active · $1.25
+              calls:  7 tool calls · 1 compaction
               tokens: 1.2k input, 800 output, 2k cache write, 3k cache read
 
         Total · 1 agent · 1h05m active · $1.25
@@ -500,13 +514,15 @@ mod tests {
         **forge team**
 
         - **plan|ner** — Claude fable&#96;2@high
-          - effort: 1h05m active · $1.25 · 7 tool calls, 1 compaction
+          - effort: 1h05m active · $1.25
+          - calls: 7 tool calls · 1 compaction
           - tokens: 1.2k input, 800 output, 2k cache write, 3k cache read
 
         **Other agents**
 
         - **@codex** — Codex `gpt-5.5@high`
-          - effort: 1h05m active · $1.25 · 7 tool calls, 1 compaction
+          - effort: 1h05m active · $1.25
+          - calls: 7 tool calls · 1 compaction
           - tokens: 1.2k input, 800 output, 2k cache write, 3k cache read
 
         </details>
@@ -561,6 +577,55 @@ mod tests {
 
         assert_eq!(identity_label(&matching), "@planner#auth");
         assert_eq!(identity_label(&displaced), "@quiet-fox (planner)");
+    }
+
+    #[test]
+    fn call_labels_name_only_recorded_components() {
+        let mut sample = member("@coder", Some("coder"), "Codex", "gpt-5.5");
+        sample.tool_calls = 0;
+        sample.compactions = 0;
+        assert_eq!(calls_label(&sample), None);
+
+        sample.tool_calls = 1;
+        assert_eq!(calls_label(&sample).as_deref(), Some("1 tool call"));
+
+        sample.tool_calls = 0;
+        sample.compactions = 1;
+        assert_eq!(calls_label(&sample).as_deref(), Some("1 compaction"));
+
+        sample.tool_calls = 2;
+        sample.compactions = 3;
+        assert_eq!(
+            calls_label(&sample).as_deref(),
+            Some("2 tool calls · 3 compactions")
+        );
+    }
+
+    #[test]
+    fn renderers_omit_calls_when_none_are_recorded() {
+        let mut report = report();
+        for group in &mut report.groups {
+            for member in &mut group.members {
+                member.tool_calls = 0;
+                member.compactions = 0;
+            }
+        }
+
+        let mut panel = anstream::StripStream::new(Vec::new());
+        render_panel(&mut panel, &report).expect("render panel");
+        assert!(
+            !String::from_utf8(panel.into_inner())
+                .expect("utf8")
+                .contains("calls:")
+        );
+
+        let mut markdown = Vec::new();
+        render_markdown(&mut markdown, &report).expect("render markdown");
+        assert!(
+            !String::from_utf8(markdown)
+                .expect("utf8")
+                .contains("  - calls:")
+        );
     }
 
     #[test]

--- a/crates/rimz/tests/integration/attribution.rs
+++ b/crates/rimz/tests/integration/attribution.rs
@@ -177,6 +177,7 @@ fn attribution_credits_exited_team_members_and_transcript_spend() {
     assert!(markdown.starts_with("<details>\n"));
     assert!(markdown.contains("<code>forge</code> team"));
     assert!(markdown.contains("- **planner** — Codex `gpt-5.5@high`"));
+    assert!(!markdown.contains("  - calls: "));
     assert!(markdown.contains("  - tokens: "));
 }
 

--- a/docs/guide/fleet.md
+++ b/docs/guide/fleet.md
@@ -181,11 +181,13 @@ $ rimz agents attribution
 forge team · 2 agents · 36m active · $29.39
 
   @planner · Claude · claude-opus-5@xhigh
-      effort: 15m active · $16.72 · 84 tool calls, no compactions
+      effort: 15m active · $16.72
+      calls:  84 tool calls
       tokens: 11k input, 148k output, 16m cache read
 
   @coder · Codex · gpt-5.6-sol@xhigh
-      effort: 21m active · $12.67 · 106 tool calls, no compactions
+      effort: 21m active · $12.67
+      calls:  106 tool calls
       tokens: 294k input, 41k output, 19m cache read
 
 Total · 2 agents · 36m active · $29.39


### PR DESCRIPTION
## Context

`rimz agents attribution` packed four figures onto one `effort:` line — active time, cost, tool calls, and compactions — and spelled a zero count out in words:

```
  @planner · Claude · claude-opus-5@xhigh
      effort: 15m active · $16.72 · 84 tool calls, no compactions
      tokens: 11k input, 148k output, 16m cache read
```

Most agents never compact, so "no compactions" was on nearly every line of a report whose whole job is to be pasted into a pull-request body. The line also mixed two different kinds of figure: what the work cost, and how much of it there was.

This splits the counts onto their own labelled line and drops any count that is zero.

```
  @planner · Claude · claude-opus-5@xhigh
      effort: 15m active · $16.72
      calls:  84 tool calls
      tokens: 11k input, 148k output, 16m cache read
```

`--md` mirrors it with a `  - calls: …` bullet between the effort and tokens bullets. When both counts are zero the line and bullet disappear entirely.

## Design choices

- **A labelled `calls:` line, not an extension of the tokens line.** Both were previewed against real output; the separate line won because it keeps `tokens:` a pure token split and gives the counts a name a reader can scan for.
- **Zero-skip per component, not per line.** One nonzero count still renders — `calls: 2 compactions` for a member with compactions but no recorded tool calls. That reads slightly oddly under a `calls:` label, and it was accepted as rare: no adapter in the support matrix reports compaction without reporting tool use, so it needs a session that compacted having made no tool call at all. The alternative — suppressing the line unless tool calls are nonzero — would hide a real figure.
- **` · ` inside the line**, matching the effort line's group separator rather than `token_label`'s comma. Singular forms stay: "1 tool call", "1 compaction".
- **Rendering only.** The counts already live on `AttributionMember`; nothing in the domain fold or the `--json` document moves, so machine consumers are unaffected. `totals_label` never carried these counts and is untouched.

## Implementation

All in `crates/rimz/src/cli/agents_cmd/attribution.rs`. `effort_label` loses its tool-call and compaction match arms and returns `"{active} · {cost}"`. A new `calls_label` returns `Option<String>`, built from the nonzero components; `render_panel` and `render_markdown` push the row only on `Some`. `KeyVals` keeps ownership of plain-text alignment — `calls` is narrower than `effort`/`tokens`, so the value column is identical whether or not the row renders, and members with and without counts stay aligned.

Two deviations from the plan, both deliberate:

- The plan asked for `token_label`'s collect-then-join shape; `calls_label` uses a `Vec` plus two match blocks instead, which carries the singular/plural forms more directly than a filter/map chain would.
- The plan expected the integration test's effort-line assertion to move to the new line. The fixture in `crates/rimz/tests/integration/attribution.rs` records no tool calls or compactions, so a positive assertion would have been untruthful; it asserts the zero-count bullet's absence instead, and the inline snapshots carry the positive case for both renderers.

Covered by a `calls_label` helper test (both-zero, either singular component, two plural components), a renderer test proving both output forms omit an empty row, four updated inline snapshots, and the real-CLI assertion above. `docs/guide/fleet.md` carries a real sample of this command and was updated to the new three-line shape.

## Advisories

Both are open minors from review, neither blocking:

- `docs/reference/cli/agents.md` describes the panel's figures as labelled lines, which stays true, but it does not record the new zero-omission rule. The page documents zero/null semantics for the JSON document, so a clause would fit its style.
- The integration assertion `!markdown.contains("  - calls: ")` never asserts the fixture's zero counts, so it would also pass if `calls_label` were broken into always returning `None`. The inline snapshots cover that case, but asserting `tool_calls == 0` from the JSON run earlier in the same test would let the guard carry its own premise.