### PR TITLE
fix(agents): manual compaction close resumes the prior resting status

### DIFF
--- a/crates/rimz/src/agents/lifecycle.rs
+++ b/crates/rimz/src/agents/lifecycle.rs
@@ -492,12 +492,13 @@ fn map_status(
         LifecycleSignal::CompactionEnded { auto: Some(true) } => {
             reconcile_activity(prior_status, "auto-compaction resumed a turn", kind)
         }
-        LifecycleSignal::CompactionEnded { auto: Some(false) }
-            if prior_status == Some(AgentStatus::Waiting) =>
-        {
-            AgentStatus::Running
-        }
-        LifecycleSignal::CompactionEnded { auto: Some(false) } => AgentStatus::Idle,
+        LifecycleSignal::CompactionEnded { auto: Some(false) } => match prior_status {
+            Some(AgentStatus::Waiting) => AgentStatus::Running,
+            // A stale running row rests: the manual close proves the user typed
+            // at the prompt, and no Stop will end the turn the row remembers.
+            Some(AgentStatus::Running) | None => AgentStatus::Idle,
+            Some(resting) => resting,
+        },
         LifecycleSignal::CompactionEnded { auto: None } => {
             if prior_status == Some(AgentStatus::Waiting) {
                 AgentStatus::Running
@@ -564,10 +565,7 @@ fn map_phase(signal: &LifecycleSignal, prior_phase: TurnPhase, status: AgentStat
             parked_on_background: true,
         } => TurnPhase::Parked,
         LifecycleSignal::Compacting => prior_phase,
-        LifecycleSignal::CompactionEnded {
-            auto: Some(true) | None,
-        } => prior_phase,
-        LifecycleSignal::CompactionEnded { auto: Some(false) } => TurnPhase::Idle,
+        LifecycleSignal::CompactionEnded { .. } => prior_phase,
         LifecycleSignal::Registered
         | LifecycleSignal::TurnEnded { .. }
         | LifecycleSignal::TurnInterrupted

--- a/crates/rimz/src/agents/lifecycle/tests.rs
+++ b/crates/rimz/src/agents/lifecycle/tests.rs
@@ -367,6 +367,24 @@ fn compaction_bracket_follows_trigger_and_counts_one_close() {
             state(AgentStatus::Idle, TurnPhase::Idle, false),
         ),
         (
+            "manual after success",
+            state(AgentStatus::Success, TurnPhase::Idle, true),
+            Some(false),
+            state(AgentStatus::Success, TurnPhase::Idle, false),
+        ),
+        (
+            "manual after failure",
+            state(AgentStatus::Failed, TurnPhase::Idle, true),
+            Some(false),
+            state(AgentStatus::Failed, TurnPhase::Idle, false),
+        ),
+        (
+            "manual while idle",
+            state(AgentStatus::Idle, TurnPhase::Idle, true),
+            Some(false),
+            state(AgentStatus::Idle, TurnPhase::Idle, false),
+        ),
+        (
             "unknown",
             state(AgentStatus::Running, TurnPhase::Reasoning, true),
             None,

--- a/crates/rimz/src/store/snapshot/project.rs
+++ b/crates/rimz/src/store/snapshot/project.rs
@@ -782,19 +782,19 @@ fn lifecycle_projection(
             *total = total.saturating_add(1);
         }
     }
-    // A context reset that rests the agent retires the prior turn's subagents: a
-    // manual `/compact` (`CompactionEnded` resting to idle) summarizes away the
-    // turn the children belonged to, and a `/clear` (`Registered`) drops it
-    // outright. Advancing the subagent boundary here makes a user-typed reset
-    // behave like automatic compaction from a rested state, which already opens a
-    // turn. The rest gate is load-bearing: automatic compaction *mid-turn* resumes
-    // the same turn (stays `running`), so its in-flight children stay listed.
+    // A context reset that lands the agent at rest retires the prior turn's
+    // subagents: a manual `/compact` summarizes away the turn the children
+    // belonged to, and a `/clear` (`Registered`) drops it outright. Advancing
+    // the subagent boundary here makes a user-typed reset behave like automatic
+    // compaction from a rested state, which already opens a turn. The rest gate
+    // is load-bearing: automatic compaction *mid-turn* resumes the same turn
+    // (stays `running`), so its in-flight children stay listed.
     // Matching the signal — not `compaction_closed` — still fires when the
     // `PreCompact` bracket open was missed. A first-event `Registered` leaves
     // `turn_started_at` unset because the session has never opened a turn; pane
     // recovery reads that absence as first-turn-start eligibility.
     let resets_context = prior.is_some()
-        && next.status == AgentStatus::Idle
+        && !matches!(next.status, AgentStatus::Running | AgentStatus::Waiting)
         && matches!(
             &signal,
             lifecycle::LifecycleSignal::CompactionEnded { .. }

--- a/crates/rimz/src/store/snapshot/project/tests/compaction.rs
+++ b/crates/rimz/src/store/snapshot/project/tests/compaction.rs
@@ -215,6 +215,32 @@ fn compaction_end_clears_marker_and_counts_completed_brackets() {
 }
 
 #[test]
+fn manual_compaction_resumes_success_and_advances_the_turn_boundary() {
+    let prompt = lifecycle_at("claude", 1, "UserPromptSubmit", signal("turn_started"));
+    let stop = lifecycle_at(
+        "claude",
+        2,
+        "Stop",
+        serde_json::json!({
+            "signal": "turn_ended",
+            "errored": false,
+            "parked_on_background": false
+        }),
+    );
+    let compact = lifecycle_at("claude", 3, "PreCompact", signal("compacting"));
+    let post = lifecycle_at("claude", 4, "PostCompact", compaction_ended(Some(false)));
+    let expected_boundary = post.timestamp;
+
+    let agents = reduce_agent_states(&[prompt, stop, compact, post]);
+
+    assert_eq!(agents[0].status, AgentStatus::Success);
+    assert_eq!(agents[0].phase, TurnPhase::Idle);
+    assert!(agents[0].compacting_since.is_none());
+    assert_eq!(agents[0].compaction_count, 1);
+    assert_eq!(agents[0].turn_started_at, Some(expected_boundary));
+}
+
+#[test]
 fn compaction_end_resumes_interrupted_turn_for_auto_or_unknown_edges() {
     for (source, prompt_event, edit_event, compact_event, post_event, end_signal) in [
         (

--- a/crates/rimz/src/store/snapshot/view/tests/status/compaction.rs
+++ b/crates/rimz/src/store/snapshot/view/tests/status/compaction.rs
@@ -237,6 +237,41 @@ fn compaction_end_stays_orthogonal_to_display_status() {
     .remove(0)
     .worktree("/repo/main")
     .active_ago(default_stall_secs() + 10);
+    let successful_manual = reduce_agent_states(&[
+        lifecycle_at(
+            &ws,
+            "codex",
+            "UserPromptSubmit",
+            "successful-manual",
+            LifecycleSignal::TurnStarted,
+        ),
+        lifecycle_at(
+            &ws,
+            "codex",
+            "Stop",
+            "successful-manual",
+            LifecycleSignal::TurnEnded {
+                errored: false,
+                parked_on_background: false,
+            },
+        ),
+        lifecycle_at(
+            &ws,
+            "codex",
+            "PreCompact",
+            "successful-manual",
+            LifecycleSignal::Compacting,
+        ),
+        lifecycle_at(
+            &ws,
+            "codex",
+            "PostCompact",
+            "successful-manual",
+            LifecycleSignal::CompactionEnded { auto: Some(false) },
+        ),
+    ])
+    .remove(0)
+    .worktree("/repo/main");
 
     let snapshot = room_with_agent_panes(vec![auto]);
     assert_eq!(
@@ -249,5 +284,11 @@ fn compaction_end_stays_orthogonal_to_display_status() {
         row(&snapshot, "manual").status(),
         Some(AgentStatus::Idle),
         "manual compaction rests the row, so it is stall-exempt"
+    );
+    let snapshot = room_with_agent_panes(vec![successful_manual]);
+    assert_eq!(
+        row(&snapshot, "successful-manual").status(),
+        Some(AgentStatus::Success),
+        "manual compaction resumes the successful status from before the bracket"
     );
 }

--- a/docs/internals/agents/model.md
+++ b/docs/internals/agents/model.md
@@ -142,7 +142,7 @@ The edges, precisely:
 | `subagent_stopped` | `running` → `success` / `failed` | the child's terminal verdict, kept through the parent's turn |
 | `tool_used` (mutating) | resting or *(none)* → `running`, reconciled; `waiting` → `running` | completed work proves a turn; attention rows hold; a keyed ask clears only for a tool with the same native key, while either key being absent preserves the any-completion fallback; the first file-editing tool moves the phase to `acting` |
 | `compacting` | status and phase held, except `waiting` → `running`, reconciled | stamps the [compaction head](#the-compaction-bracket); compaction proves the native prompt released the pane, so it clears a waiting row and the ask behind it |
-| `compaction_ended` | auto → `running` (phase carried) · manual → `idle` · trigger unknown → held · any close on `waiting` → `running` | closes and counts an open [bracket](#the-compaction-bracket) |
+| `compaction_ended` | auto → `running` (phase carried) · manual → prior resting status resumed, or stale `running` → `idle` · trigger unknown → held · any close on `waiting` → `running` | closes and counts an open [bracket](#the-compaction-bracket) |
 | `ended` | held, row stamped ended | the reducer records `ended_at`; reaching `step` preserves the prior lifecycle state as an ignored no-op |
 | `lost` | held | legacy `rimz.agent-lost` marker retained for log replay compatibility, reaching `step` as an ignored no-op |
 
@@ -187,7 +187,7 @@ Compaction is a transient head over the status. The opening signal (`Compacting`
 | Trigger | Lands | Because |
 | --- | --- | --- |
 | known automatic | `running`, interrupted phase carried | automatic compaction happens mid-turn |
-| known manual | `idle` | `/compact` runs between turns |
+| known manual | prior resting status resumed; a stale `running` row rests to `idle` | `/compact` runs between turns |
 | absent | prior status and phase held | the provider reported no trigger bit |
 
 A close that rests the agent advances `turn_started_at`, retiring the prior turn's subagents the same as a fresh prompt or `/clear`; an automatic mid-turn close resumes the turn and holds the boundary. Redundant close signals are idempotent, since an absent bracket closes nothing, and the projection expires the head past a short display window, so a crash mid-compact can never pulse it forever.


### PR DESCRIPTION
## Context

A manual `/compact` wiped the agent's resting state. `map_status` rested the row to `idle` unconditionally on `CompactionEnded { auto: Some(false) }`, so a card showing `✓` before the command came back `○` after it. RimZ's own idle-compaction made this routine rather than rare: `should_compact` fires on `idle` **and** `success` rows, so the automation regularly erased the success badge it had no business touching.

The fix should restore whatever the row showed before the command, without new state machinery standing behind it.

## Design choices

**No stored "status before compaction".** `Compacting` is a transient head that preserves the prior status, so at close time the reducer already holds the pre-compact value in `prior_status` — the `auto: None` arm was resuming it all along. The manual arm was the only one throwing it away. One match arm, no new field, no history mechanism.

**Resume every resting prior, not just the two named.** `idle`, `success`, and `failed` all resume. `failed` is attention-bearing; wiping it would be worse than wiping `success`.

**A `running` prior still rests to `idle`.** A manual close from `running` means the row was stale — the turn was dismissed with `esc`, which reaches RimZ through no hook — so no `Stop` will ever close it. Resuming `running` would spin forever. Existing tests pin this edge and stay green.

**`waiting` → `running` is unchanged**, and the phase arms merge: every `CompactionEnded` now carries `prior_phase`, because the non-running clamp already rests the phase for any resting landing. Behaviour-identical for every pre-existing edge, one arm shorter.

## Implementation

- `agents/lifecycle.rs` — the manual `CompactionEnded` arm resumes a resting `prior_status`; `Some(Running) | None` still lands `idle`. `map_phase` collapses its two compaction-close arms into one.
- `store/snapshot/project.rs` — `resets_context` keys off "landed at rest" (`!matches!(next.status, Running | Waiting)`) instead of `== Idle`, so a `success`-preserving manual compact still retires the prior turn's subagents and advances `turn_started_at`. Without it the change would restore the badge and silently strand the children.
- `docs/internals/agents/model.md` — both the signal table and the trigger table carry the resumed-prior mapping.
- Tests: lifecycle table cases for manual closes from `success`, `failed`, and `idle`; a durable-projection test for the crux sequence (`prompt → stop → precompact → postcompact(manual)`) asserting `success`, one counted bracket, and the advanced turn boundary; a sidebar-projection test that the row still reads `success` after the close. Each fails against the pre-fix reducer.

No adapter, renderer, or CLI change: adapters already emit the trigger bit, and every surface reads the same `status` field. Adapters that report no trigger were already correct through the unknown arm.

No deviations from the plan.

## Advisories

**The reset predicate is trigger-blind.** `resets_context` fires for `auto` and unknown-trigger closes too, and on a `failed` landing it advances `turn_started_at` past the row's turn-error marker, which `agents/state.rs` gates on exactly that boundary (`error.at >= turn_started_at`). The row keeps its `failed` badge but loses the reason behind it — the sidebar label, the `paused` projection for limit-class markers, the `agents show` error line, and `resume_park`'s auto-continue arming.

On the reachable path this is not a regression: a manual close on a `failed` row previously landed `idle`, where the terminal marker never applied either, so the label was already lost. The narrow regression is an `auto` or unknown-trigger close on a `failed` row, which previously held the boundary and kept the marker; an auto close normally arrives mid-turn on a `running` row, so the trigger is plausible rather than demonstrated.

Underneath sits one overloaded field: `turn_started_at` is both the subagent-retirement boundary and the "current turn" window for the failure marker, and a manual compact on a failed row genuinely wants to move the first and hold the second. Narrowing the predicate to `Idle | Success` restores the auto/unknown paths at the cost of leaving that row's prior children listed. Left as-is deliberately; the generality matches the lifecycle invariant and keeps retirement aligned with future resting outcomes.

`docs/internals/agents/model.md` still reads "a close that rests the agent advances `turn_started_at`", which is now narrower than the predicate — it fires for a close that *leaves* an already-resting agent at rest.

## Verification

`cargo xtask gate` passes (fmt, invariants, docs-links, lint, test), reproduced independently at review. Focused: `cargo xtask test lifecycle` 169 passed, `cargo xtask test compaction` 38 passed.
