### PR TITLE
xtask: batch focused tests, agent-visible progress, compact test failures, and a check task

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ rimz loop logs <task>                # full forensics for recent runs
 
 ## Testing
 
-- Run `cargo xtask gate` before a PR or hand-off, `cargo xtask test <filter>` for focused iteration, and `cargo xtask sandbox -- <command>` to drive a real multiplexer from disposable roots. The gate stack, the nextest-only runner, the sandbox roots, the test tiers and what each one owns, and the one-home rule for a module's unit tests all live in [rust-conventions.md](./docs/contributing/rust-conventions.md).
+- Run `cargo xtask gate` before a PR or hand-off, batch focused tests with `cargo xtask test --name <test> [--name <test>...]` (or pass a nextest filter), and use `cargo xtask sandbox -- <command>` to drive a real multiplexer from disposable roots. The gate stack, the nextest-only runner, the sandbox roots, the test tiers and what each one owns, and the one-home rule for a module's unit tests all live in [rust-conventions.md](./docs/contributing/rust-conventions.md).
 - Judge the reach of your own change and escalate past `gate` to journey, live-backend, performance, dependency gates, or full CI (`cargo xtask ci`) when it touches those surfaces, their fixtures, or shared infrastructure. CI's `tests` job is the branch-protection floor rather than the ceiling.
 - Capture planned behaviour in the owning doc and add the executable test when the implementation can make it pass; an ignored test standing in for a future product target does not land.
 - **Invariant.** `cargo xtask invariants` greps tracked text — Rust and Markdown alike — to guard the architectural boundaries. Because it matches text rather than parsed code, an `AGENTS.md` inside a guarded subtree is scanned along with it: describe a boundary in prose and leave the path the rule bans unwritten.

--- a/docs/contributing/rust-conventions.md
+++ b/docs/contributing/rust-conventions.md
@@ -175,7 +175,9 @@ Both helpers live next to the durability contract they enforce. No module hand-r
 
 ## Tests
 
-`cargo xtask test` wraps `cargo nextest run --workspace --all-features --locked`; trailing args forward as nextest filters and profiles (`cargo xtask test auth`, `cargo xtask test -P live`). Each invocation gives the suite a disposable HOME, every XDG root, and private tmux and Zellij server namespaces, while `common::Env` narrows CLI subprocesses to per-test roots for every persistent surface. nextest is the only suite runner; install it with `cargo install cargo-nextest --locked`. Drive it through `cargo xtask test` rather than reassembling the invocation — the flags carry as much weight as the runner, because unit tests reach `crate::testkit` and both bare `cargo test` and bare `cargo nextest run` fail to compile without `--all-features`. Three profiles in `.config/nextest.toml` partition the suite: `gate` (deterministic non-live tests, what `cargo xtask gate` runs), `live` (mux backend tests, the real-browser web suite, and deep mux smokes), and `journey` (non-deep rendered journeys).
+`cargo xtask test` wraps `cargo nextest run --workspace --all-features --locked`; trailing args forward as nextest filters and profiles (`cargo xtask test auth`, `cargo xtask test -P live`). Repeat `--name <test>` to batch copied leaf names or full `module::path` names through one exact, segment-anchored nextest run rather than launching parallel Cargo processes. Xtask lists the selection first, runs every matched test, and fails after the run if any requested name was unmatched; `cargo xtask test --list <term>` discovers the available full names. A raw nextest filter that matches nothing fails with the same discovery command as its next action.
+
+Each invocation gives the suite a disposable HOME, every XDG root, and private tmux and Zellij server namespaces, while `common::Env` narrows CLI subprocesses to per-test roots for every persistent surface. nextest is the only suite runner; install it with `cargo install cargo-nextest --locked`. Drive it through `cargo xtask test` rather than reassembling the invocation — the flags carry as much weight as the runner, because unit tests reach `crate::testkit` and both bare `cargo test` and bare `cargo nextest run` fail to compile without `--all-features`. Three profiles in `.config/nextest.toml` partition the suite: `gate` (deterministic non-live tests, what `cargo xtask gate` runs), `live` (mux backend tests, the real-browser web suite, and deep mux smokes), and `journey` (non-deep rendered journeys).
 
 Run interactive smoke checks of a built binary through `cargo xtask sandbox -- target/debug/rimz <args>`. The sandbox replaces HOME, every persistent XDG root, `TMUX_TMPDIR`, the Zellij runtime and config roots, and `TMPDIR`, then tears down both private mux servers when the command exits. A bare `target/debug/rimz start` is a real product invocation and therefore addresses the user's normal multiplexer server.
 
@@ -229,7 +231,7 @@ Run `cargo xtask hooks` once per clone to activate the tracked git hooks (it poi
 
 ## Contributor command surface
 
-`cargo xtask <task>` is the entry point for contributor automation; new automation lands in `xtask/`, and the only tracked hook script is `.githooks/pre-commit`, which routes back to it. Tasks: `build`, `build-plugin`, `plugin-refresh`, `install`, `install-dev`, `stage-install`, `dist`, `brew-formula`, `profile-build`, `hooks`, `fmt`, `lint`, `test`, `test-archive`, `deps`, `deny`, `vet`, `semver`, `externals`, `coverage`, `perf`, `complexity`, `invariants`, `docs-links`, `gate`, `checks`, `ci`, `pricing-refresh`, `theme-refresh`, `screenshot`.
+`cargo xtask <task>` is the entry point for contributor automation; new automation lands in `xtask/`, and the only tracked hook script is `.githooks/pre-commit`, which routes back to it. Tasks: `build`, `build-plugin`, `plugin-refresh`, `install`, `install-dev`, `stage-install`, `dist`, `brew-formula`, `profile-build`, `hooks`, `fmt`, `lint`, `check`, `test`, `test-archive`, `deps`, `deny`, `vet`, `semver`, `externals`, `coverage`, `perf`, `complexity`, `invariants`, `docs-links`, `gate`, `checks`, `ci`, `pricing-refresh`, `theme-refresh`, `screenshot`.
 
 Three deserve a note:
 
@@ -246,6 +248,10 @@ Every PR gate runs in CI with warnings treated as errors; each has a local `carg
 - `cargo xtask externals` — the gates that talk to the crates.io registry: `deny` and `vet`. Both run so a single pass reports every signal.
 - `cargo xtask ci` — `checks` plus plain `cargo nextest run --workspace --all-features --locked`; the local full stack when a change calls for full validation.
 
+`cargo xtask check` (singular) is the fast `cargo check --workspace --all-targets --all-features --locked` structural compile pass. It is intentionally distinct from `cargo xtask checks` (plural), the non-test gate composite above; use singular `check` for early broad iteration.
+
+Run one Cargo-family command at a time in a worktree. Concurrent builds only wait on the same target-directory lock: batch focused names in one `cargo xtask test` invocation, let that run finish before starting `gate`, and use `check` for an early broad compile signal. Reserve `test-archive` plus partitioned execution for genuinely large CI suites.
+
 Escalate past `gate` when the change touches the matching surface: `cargo xtask test -P live` for live-backend and deep-mux-smoke coverage, `cargo xtask test -P journey` for rendered journeys, `cargo xtask externals` when dependencies change, and `cargo xtask ci` for both checks and the full suite.
 
 Two wall clocks bound a run, so a wedged compile, test process, or multiplexer costs a bounded wait instead of the caller's patience:
@@ -255,10 +261,11 @@ Two wall clocks bound a run, so a wedged compile, test process, or multiplexer c
 
 The individual gates:
 
-- Long-running human-facing phases show a TTY-gated stderr status line with the live phase and elapsed time; `xtask/src/spinner.rs` is a deliberate lightweight copy of the RimZ CLI spinner that keeps xtask independent of the runtime crate.
+- Long-running phases show an animated TTY status line or, for agents and redirected output, a newline heartbeat after 15 seconds and every 30 seconds thereafter. `RIMZ_NO_PROGRESS=1` silences both. `xtask/src/spinner.rs` is a deliberate lightweight copy of the RimZ CLI spinner that keeps xtask independent of the runtime crate.
 - `cargo fmt --all -- --check` — formatting (the `fmt` task).
 - `cargo xtask lint` — runs `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, then lints the `rimz` host without `testkit` in both install feature shapes: default for `cargo xtask install`, and `sentry` for `cargo xtask install-dev`; the host passes expose dead code that test-only references can mask.
-- `cargo nextest run --workspace --all-features --locked` — the `test` task; accepts nextest filters and profiles as trailing args.
+- `cargo xtask check` — the fast all-target, all-feature workspace compile pass.
+- `cargo nextest run --workspace --all-features --locked` — the `test` task; accepts nextest filters and profiles as trailing args, captures output into a compact pass or failure report, batches repeated exact `--name` selections, and exposes discovery through `--list`.
 - `cargo nextest archive --workspace --all-features --locked --archive-file <path>` — the `test-archive` task; compiles and packages the workspace test binaries for portable execution.
 - `cargo xtask sandbox -- <command> [args]` — runs an interactive target-binary smoke command with disposable host state and private tmux/Zellij servers.
 - `cargo xtask docs-links` — every relative markdown link target and `#anchor` resolves in the working tree (offline and deterministic; external URLs are out of scope).

--- a/xtask/src/gates.rs
+++ b/xtask/src/gates.rs
@@ -12,7 +12,9 @@ use serde::Deserialize;
 use crate::build::{build_plugin, verify_vendored_plugin};
 use crate::docs_links::docs_links;
 use crate::invariants::invariants;
-use crate::runner::{Captured, ensure_success, run, run_streamed, run_with_env_and_removed};
+use crate::runner::{
+    Captured, RtkPolicy, ensure_success, run, run_streamed, run_with_env_and_removed,
+};
 use crate::sandbox::HostSandbox;
 use crate::spinner::Spinner;
 
@@ -77,6 +79,7 @@ const CARGO_PROGRESS_VERBS: &[&str] = &[
     "Blocking",
     "Running",
 ];
+const NEXTEST_PROGRESS_PREFIXES: &[&str] = &["PASS [", "START [", "SLOW [", "TRY [", "LEAK ["];
 const TRIMMED_OUTPUT_MAX_CHARS: usize = 12_000;
 
 pub(crate) fn fmt(root: &Path) -> Result<()> {
@@ -339,7 +342,15 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<std::ffi::OsStr>,
 {
-    let captured = run_streamed(root, "cargo", args, envs, removed_envs, progress)?;
+    let captured = run_streamed(
+        root,
+        "cargo",
+        args,
+        envs,
+        removed_envs,
+        RtkPolicy::Configured,
+        progress,
+    )?;
     if captured.status.success() {
         return Ok(GateResult::Pass {
             note: note.and_then(|extract| extract(&captured.output)),
@@ -356,6 +367,7 @@ fn capture_cargo_task<I, S>(
     args: I,
     envs: &[(&str, PathBuf)],
     removed_envs: &[&str],
+    rtk_policy: RtkPolicy,
 ) -> Result<Captured>
 where
     I: IntoIterator<Item = S>,
@@ -369,7 +381,15 @@ where
             spinner.set(format!("{label} — {line}"));
         }
     };
-    let captured = run_streamed(root, "cargo", args, envs, removed_envs, &mut progress);
+    let captured = run_streamed(
+        root,
+        "cargo",
+        args,
+        envs,
+        removed_envs,
+        rtk_policy,
+        &mut progress,
+    );
     drop(spinner);
     captured
 }
@@ -379,14 +399,14 @@ fn finish_cargo_task(
     captured: Captured,
     note: Option<fn(&str) -> Option<String>>,
     invocation: &str,
-) -> Result<Captured> {
+) -> Result<()> {
     if captured.status.success() {
         report_gate_pass(
             name,
             note.and_then(|extract| extract(&captured.output))
                 .as_deref(),
         );
-        return Ok(captured);
+        return Ok(());
     }
     report_task_failure(name, &failure_detail(&captured.output), invocation);
     bail!("{name} failed");
@@ -538,22 +558,20 @@ fn report_gate_pass(name: &str, note: Option<&str>) {
     }
 }
 
-#[expect(
-    clippy::print_stderr,
-    reason = "xtask prints compact gate failures and the next action to stderr"
-)]
 fn report_gate_failure(name: &str, detail: &str, invocation: &str) {
-    eprintln!("gate: fail at {name}");
-    eprintln!("{detail}");
-    eprintln!("NEXT: fix the {name} errors above, then rerun `{invocation}`");
+    report_failure("gate", name, detail, invocation);
+}
+
+fn report_task_failure(name: &str, detail: &str, invocation: &str) {
+    report_failure("xtask", name, detail, invocation);
 }
 
 #[expect(
     clippy::print_stderr,
-    reason = "xtask prints compact task failures and the next action to stderr"
+    reason = "xtask prints compact failures and the next action to stderr"
 )]
-fn report_task_failure(name: &str, detail: &str, invocation: &str) {
-    eprintln!("xtask: fail at {name}");
+fn report_failure(prefix: &str, name: &str, detail: &str, invocation: &str) {
+    eprintln!("{prefix}: fail at {name}");
     eprintln!("{detail}");
     eprintln!("NEXT: fix the {name} errors above, then rerun `{invocation}`");
 }
@@ -578,7 +596,10 @@ fn failure_detail(output: &str) -> String {
 fn trim_cargo_noise(output: &str) -> String {
     let mut lines = Vec::new();
     let mut previous_blank = true;
-    for line in output.lines().filter(|line| !is_cargo_progress(line)) {
+    for line in output
+        .lines()
+        .filter(|line| !is_cargo_progress(line) && !is_nextest_progress(line))
+    {
         let line = line.trim_end();
         if line.trim().is_empty() {
             if !previous_blank {
@@ -603,19 +624,36 @@ fn is_cargo_progress(line: &str) -> bool {
         .any(|verb| line.starts_with(verb))
 }
 
+fn is_nextest_progress(line: &str) -> bool {
+    let line = line.trim_start();
+    NEXTEST_PROGRESS_PREFIXES
+        .iter()
+        .any(|prefix| line.starts_with(prefix))
+}
+
 fn bound_trimmed_output(output: String) -> String {
     if output.chars().count() <= TRIMMED_OUTPUT_MAX_CHARS {
         return output;
     }
-    let mut truncated: String = output.chars().take(TRIMMED_OUTPUT_MAX_CHARS).collect();
-    truncated.push_str("\n... output truncated ...");
-    truncated
+    let head_chars = TRIMMED_OUTPUT_MAX_CHARS / 3;
+    let tail_chars = TRIMMED_OUTPUT_MAX_CHARS - head_chars;
+    let head: String = output.chars().take(head_chars).collect();
+    let mut tail: Vec<char> = output.chars().rev().take(tail_chars).collect();
+    tail.reverse();
+    format!(
+        "{head}\n... output truncated; showing final diagnostics ...\n{}",
+        tail.into_iter().collect::<String>()
+    )
 }
 
 fn extract_test_summary(output: &str) -> Option<String> {
     output
         .lines()
-        .find(|line| line.contains("tests run:") || line.contains("test run:"))
+        .find(|line| {
+            line.contains("tests run:")
+                || line.contains("test run:")
+                || line.trim_start().starts_with("cargo nextest:")
+        })
         .map(|line| line.trim().to_owned())
 }
 
@@ -628,8 +666,15 @@ pub(crate) fn deps(root: &Path) -> Result<()> {
 }
 
 pub(crate) fn check(root: &Path) -> Result<()> {
-    let captured = capture_cargo_task(root, "check", CHECK_ARGS.iter().copied(), &[], &[])?;
-    finish_cargo_task("check", captured, None, "cargo xtask check").map(|_| ())
+    let captured = capture_cargo_task(
+        root,
+        "check",
+        CHECK_ARGS.iter().copied(),
+        &[],
+        &[],
+        RtkPolicy::Configured,
+    )?;
+    finish_cargo_task("check", captured, None, "cargo xtask check")
 }
 
 pub(crate) fn test(root: &Path, args: &[String]) -> Result<()> {
@@ -641,7 +686,14 @@ pub(crate) fn test(root: &Path, args: &[String]) -> Result<()> {
     if command.list {
         let mut cargo_args = nextest_args("list");
         cargo_args.extend(command.forwarded);
-        let captured = capture_cargo_task(root, "test list", cargo_args, &env, &["NO_COLOR"])?;
+        let captured = capture_cargo_task(
+            root,
+            "test list",
+            cargo_args,
+            &env,
+            &["NO_COLOR"],
+            RtkPolicy::Bypass,
+        )?;
         if !captured.status.success() {
             report_task_failure("test list", &failure_detail(&captured.output), &invocation);
             bail!("test list failed");
@@ -655,13 +707,19 @@ pub(crate) fn test(root: &Path, args: &[String]) -> Result<()> {
     if command.names.is_empty() {
         let mut cargo_args = nextest_args("run");
         cargo_args.extend(command.forwarded);
-        let captured = capture_cargo_task(root, "test", cargo_args, &env, &["NO_COLOR"])?;
-        if nextest_matched_no_tests(&captured) {
+        let captured = capture_cargo_task(
+            root,
+            "test",
+            cargo_args,
+            &env,
+            &["NO_COLOR"],
+            RtkPolicy::Configured,
+        )?;
+        if nextest_matched_no_tests(captured.status.code(), &captured.output) {
             report_zero_test_match(args);
             bail!("no tests matched");
         }
-        return finish_cargo_task("test", captured, Some(extract_test_summary), &invocation)
-            .map(|_| ());
+        return finish_cargo_task("test", captured, Some(extract_test_summary), &invocation);
     }
 
     run_named_tests(root, command, &env, &invocation)
@@ -753,7 +811,14 @@ fn run_named_tests(
         "--message-format".to_owned(),
         "json".to_owned(),
     ]);
-    let listed = capture_cargo_task(root, "test discovery", list_args, env, &["NO_COLOR"])?;
+    let listed = capture_cargo_task(
+        root,
+        "test discovery",
+        list_args,
+        env,
+        &["NO_COLOR"],
+        RtkPolicy::Bypass,
+    )?;
     if !listed.status.success() {
         report_task_failure(
             "test discovery",
@@ -773,7 +838,14 @@ fn run_named_tests(
     let mut run_args = nextest_args("run");
     run_args.extend(["-E".to_owned(), filterset]);
     run_args.extend(command.forwarded);
-    let captured = capture_cargo_task(root, "test", run_args, env, &["NO_COLOR"])?;
+    let captured = capture_cargo_task(
+        root,
+        "test",
+        run_args,
+        env,
+        &["NO_COLOR"],
+        RtkPolicy::Configured,
+    )?;
     report_test_selection(&command.names, &matches);
     finish_cargo_task("test", captured, Some(extract_test_summary), invocation)?;
     if !matches.unmatched.is_empty() {
@@ -904,8 +976,8 @@ fn test_invocation(args: &[String]) -> String {
     }
 }
 
-fn nextest_matched_no_tests(captured: &Captured) -> bool {
-    captured.status.code() == Some(4) || captured.output.contains("error: no tests to run")
+fn nextest_matched_no_tests(status_code: Option<i32>, output: &str) -> bool {
+    status_code == Some(4) || output.contains("error: no tests to run")
 }
 
 #[expect(
@@ -1083,6 +1155,8 @@ mod tests {
    Compiling foo v1.2.3
     Finished `dev` profile
      Running `cargo clippy`
+        PASS [   0.002s] crate tests::already_passed
+       START [   0.003s] crate tests::still_running
 
 
 error[E0599]: no method named `run`
@@ -1103,6 +1177,44 @@ warning: unused variable
     }
 
     #[test]
+    fn bounded_failure_output_keeps_the_first_and_final_diagnostics() {
+        let output = format!(
+            "error: first compiler diagnostic\n{}\nSummary: final failing test",
+            "unhelpful middle output\n".repeat(1_000)
+        );
+        let bounded = bound_trimmed_output(output);
+
+        assert!(bounded.starts_with("error: first compiler diagnostic"));
+        assert!(bounded.contains("output truncated; showing final diagnostics"));
+        assert!(bounded.ends_with("Summary: final failing test"));
+    }
+
+    #[test]
+    fn compact_failure_drops_default_profile_passes_before_bounding() {
+        let mut output = (0..135)
+            .map(|index| {
+                format!(
+                    "        PASS [   0.002s] ({index}/135) rimz::integration tests::passing_{index}\n"
+                )
+            })
+            .collect::<String>();
+        output.push_str(
+            "        FAIL [   0.010s] rimz::integration tests::broken\n\
+             panic: expected durable record\n\
+             Summary [   1.0s] 135 tests run: 134 passed, 1 failed\n",
+        );
+
+        let detail = failure_detail(&output);
+        assert!(!detail.contains("PASS ["), "{detail}");
+        assert!(detail.contains("FAIL ["), "{detail}");
+        assert!(
+            detail.contains("panic: expected durable record"),
+            "{detail}"
+        );
+        assert!(detail.contains("1 failed"), "{detail}");
+    }
+
+    #[test]
     fn extract_test_summary_reads_nextest_summary_line() {
         let output = "\
 some setup line
@@ -1117,7 +1229,24 @@ Summary [   12.3s] 2611 tests run: 2611 passed, 42 skipped
             extract_test_summary("Summary [ 0.01s] 1 test run: 1 passed").as_deref(),
             Some("Summary [ 0.01s] 1 test run: 1 passed")
         );
+        assert_eq!(
+            extract_test_summary("cargo nextest: 1 passed, 42 skipped (0.01s)").as_deref(),
+            Some("cargo nextest: 1 passed, 42 skipped (0.01s)")
+        );
         assert_eq!(extract_test_summary("no summary here"), None);
+    }
+
+    #[test]
+    fn zero_match_detection_uses_nextest_exit_code_or_message() {
+        assert!(nextest_matched_no_tests(Some(4), ""));
+        assert!(nextest_matched_no_tests(
+            Some(1),
+            "error: no tests to run\n"
+        ));
+        assert!(!nextest_matched_no_tests(
+            Some(1),
+            "test failed for another reason"
+        ));
     }
 
     #[test]

--- a/xtask/src/gates.rs
+++ b/xtask/src/gates.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -6,11 +7,12 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
+use serde::Deserialize;
 
 use crate::build::{build_plugin, verify_vendored_plugin};
 use crate::docs_links::docs_links;
 use crate::invariants::invariants;
-use crate::runner::{ensure_success, run, run_streamed, run_with_env_and_removed};
+use crate::runner::{Captured, ensure_success, run, run_streamed, run_with_env_and_removed};
 use crate::sandbox::HostSandbox;
 use crate::spinner::Spinner;
 
@@ -53,6 +55,13 @@ const GATE_TEST_ARGS: &[&str] = &[
     "--profile",
     "gate",
     "--workspace",
+    "--all-features",
+    "--locked",
+];
+const CHECK_ARGS: &[&str] = &[
+    "check",
+    "--workspace",
+    "--all-targets",
     "--all-features",
     "--locked",
 ];
@@ -341,6 +350,48 @@ where
     })
 }
 
+fn capture_cargo_task<I, S>(
+    root: &Path,
+    label: &str,
+    args: I,
+    envs: &[(&str, PathBuf)],
+    removed_envs: &[&str],
+) -> Result<Captured>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    let spinner = Spinner::new(label);
+    let mut progress = |line: &str| {
+        let line = line.trim();
+        if !line.is_empty() {
+            let line = line.chars().take(100).collect::<String>();
+            spinner.set(format!("{label} — {line}"));
+        }
+    };
+    let captured = run_streamed(root, "cargo", args, envs, removed_envs, &mut progress);
+    drop(spinner);
+    captured
+}
+
+fn finish_cargo_task(
+    name: &str,
+    captured: Captured,
+    note: Option<fn(&str) -> Option<String>>,
+    invocation: &str,
+) -> Result<Captured> {
+    if captured.status.success() {
+        report_gate_pass(
+            name,
+            note.and_then(|extract| extract(&captured.output))
+                .as_deref(),
+        );
+        return Ok(captured);
+    }
+    report_task_failure(name, &failure_detail(&captured.output), invocation);
+    bail!("{name} failed");
+}
+
 fn in_process_gate(gate: impl FnOnce() -> Result<()>) -> GateResult {
     match gate() {
         Ok(()) => GateResult::Pass { note: None },
@@ -499,6 +550,16 @@ fn report_gate_failure(name: &str, detail: &str, invocation: &str) {
 
 #[expect(
     clippy::print_stderr,
+    reason = "xtask prints compact task failures and the next action to stderr"
+)]
+fn report_task_failure(name: &str, detail: &str, invocation: &str) {
+    eprintln!("xtask: fail at {name}");
+    eprintln!("{detail}");
+    eprintln!("NEXT: fix the {name} errors above, then rerun `{invocation}`");
+}
+
+#[expect(
+    clippy::print_stderr,
     reason = "xtask prints compact gate completion to the operator's stderr"
 )]
 fn report_gate_complete() {
@@ -554,7 +615,7 @@ fn bound_trimmed_output(output: String) -> String {
 fn extract_test_summary(output: &str) -> Option<String> {
     output
         .lines()
-        .find(|line| line.contains("tests run:"))
+        .find(|line| line.contains("tests run:") || line.contains("test run:"))
         .map(|line| line.trim().to_owned())
 }
 
@@ -566,18 +627,320 @@ pub(crate) fn deps(root: &Path) -> Result<()> {
     run_with_env_and_removed(root, "cargo", ["machete"], &[], &["CARGO_PKG_NAME"])
 }
 
+pub(crate) fn check(root: &Path) -> Result<()> {
+    let captured = capture_cargo_task(root, "check", CHECK_ARGS.iter().copied(), &[], &[])?;
+    finish_cargo_task("check", captured, None, "cargo xtask check").map(|_| ())
+}
+
 pub(crate) fn test(root: &Path, args: &[String]) -> Result<()> {
+    let command = parse_test_command(args)?;
     let sandbox = HostSandbox::for_tests(root)?;
     let env = sandbox.command_env();
-    let mut cargo_args = vec![
-        "nextest".to_owned(),
-        "run".to_owned(),
-        "--workspace".to_owned(),
-        "--all-features".to_owned(),
-        "--locked".to_owned(),
-    ];
-    cargo_args.extend(args.iter().cloned());
-    run_with_env_and_removed(root, "cargo", cargo_args, &env, &["NO_COLOR"])
+    let invocation = test_invocation(args);
+
+    if command.list {
+        let mut cargo_args = nextest_args("list");
+        cargo_args.extend(command.forwarded);
+        let captured = capture_cargo_task(root, "test list", cargo_args, &env, &["NO_COLOR"])?;
+        if !captured.status.success() {
+            report_task_failure("test list", &failure_detail(&captured.output), &invocation);
+            bail!("test list failed");
+        }
+        std::io::stdout()
+            .write_all(captured.stdout.as_bytes())
+            .context("writing nextest list output")?;
+        return Ok(());
+    }
+
+    if command.names.is_empty() {
+        let mut cargo_args = nextest_args("run");
+        cargo_args.extend(command.forwarded);
+        let captured = capture_cargo_task(root, "test", cargo_args, &env, &["NO_COLOR"])?;
+        if nextest_matched_no_tests(&captured) {
+            report_zero_test_match(args);
+            bail!("no tests matched");
+        }
+        return finish_cargo_task("test", captured, Some(extract_test_summary), &invocation)
+            .map(|_| ());
+    }
+
+    run_named_tests(root, command, &env, &invocation)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct TestCommand {
+    names: Vec<String>,
+    forwarded: Vec<String>,
+    list: bool,
+}
+
+fn parse_test_command(args: &[String]) -> Result<TestCommand> {
+    let mut names = Vec::new();
+    let mut forwarded = Vec::new();
+    let mut list = false;
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--" {
+            forwarded.extend(args[index..].iter().cloned());
+            break;
+        }
+        if arg == "--list" {
+            if list {
+                bail!("cargo xtask test accepts `--list` once");
+            }
+            list = true;
+            index += 1;
+            continue;
+        }
+        if arg == "--name" {
+            let Some(name) = args.get(index + 1).filter(|name| name.as_str() != "--") else {
+                bail!("cargo xtask test `--name` requires a test name");
+            };
+            if name.is_empty() {
+                bail!("cargo xtask test `--name` cannot be empty");
+            }
+            names.push(name.clone());
+            index += 2;
+            continue;
+        }
+        if let Some(name) = arg.strip_prefix("--name=") {
+            if name.is_empty() {
+                bail!("cargo xtask test `--name` cannot be empty");
+            }
+            names.push(name.to_owned());
+            index += 1;
+            continue;
+        }
+        forwarded.push(arg.clone());
+        index += 1;
+    }
+    if list && !names.is_empty() {
+        bail!("cargo xtask test does not combine `--list` with `--name`");
+    }
+    Ok(TestCommand {
+        names,
+        forwarded,
+        list,
+    })
+}
+
+fn nextest_args(subcommand: &str) -> Vec<String> {
+    [
+        "nextest",
+        subcommand,
+        "--workspace",
+        "--all-features",
+        "--locked",
+    ]
+    .into_iter()
+    .map(str::to_owned)
+    .collect()
+}
+
+fn run_named_tests(
+    root: &Path,
+    command: TestCommand,
+    env: &[(&str, PathBuf)],
+    invocation: &str,
+) -> Result<()> {
+    let filterset = exact_name_filterset(&command.names);
+    let mut list_args = nextest_args("list");
+    list_args.extend(nextest_profile_args(&command.forwarded));
+    list_args.extend([
+        "-E".to_owned(),
+        filterset.clone(),
+        "--message-format".to_owned(),
+        "json".to_owned(),
+    ]);
+    let listed = capture_cargo_task(root, "test discovery", list_args, env, &["NO_COLOR"])?;
+    if !listed.status.success() {
+        report_task_failure(
+            "test discovery",
+            &failure_detail(&listed.output),
+            invocation,
+        );
+        bail!("test discovery failed");
+    }
+
+    let listed_names = parse_nextest_list(&listed.stdout)?;
+    let matches = match_requested_names(&command.names, &listed_names);
+    if matches.matched_tests == 0 {
+        report_test_selection(&command.names, &matches);
+        bail!("none of the requested test names matched");
+    }
+
+    let mut run_args = nextest_args("run");
+    run_args.extend(["-E".to_owned(), filterset]);
+    run_args.extend(command.forwarded);
+    let captured = capture_cargo_task(root, "test", run_args, env, &["NO_COLOR"])?;
+    report_test_selection(&command.names, &matches);
+    finish_cargo_task("test", captured, Some(extract_test_summary), invocation)?;
+    if !matches.unmatched.is_empty() {
+        bail!("some requested test names matched no tests");
+    }
+    Ok(())
+}
+
+fn exact_name_filterset(names: &[String]) -> String {
+    names
+        .iter()
+        .map(|name| format!("test(/(^|::){}$/)", escape_test_name(name)))
+        .collect::<Vec<_>>()
+        .join(" | ")
+}
+
+fn escape_test_name(name: &str) -> String {
+    let mut escaped = String::with_capacity(name.len());
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '_' | ':') || !ch.is_ascii() {
+            escaped.push(ch);
+        } else {
+            escaped.push('\\');
+            escaped.push(ch);
+        }
+    }
+    escaped
+}
+
+fn nextest_profile_args(args: &[String]) -> Vec<String> {
+    let mut profiles = Vec::new();
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--" {
+            break;
+        }
+        if matches!(arg.as_str(), "-P" | "--profile") {
+            profiles.push(arg.clone());
+            if let Some(value) = args.get(index + 1) {
+                profiles.push(value.clone());
+                index += 2;
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+        if arg.starts_with("--profile=") || (arg.starts_with("-P") && arg.len() > 2) {
+            profiles.push(arg.clone());
+        }
+        index += 1;
+    }
+    profiles
+}
+
+#[derive(Deserialize)]
+struct NextestList {
+    #[serde(rename = "rust-suites")]
+    rust_suites: BTreeMap<String, ListedSuite>,
+}
+
+#[derive(Deserialize)]
+struct ListedSuite {
+    testcases: BTreeMap<String, ListedTest>,
+}
+
+#[derive(Deserialize)]
+struct ListedTest {
+    #[serde(rename = "filter-match")]
+    filter_match: ListedFilterMatch,
+}
+
+#[derive(Deserialize)]
+struct ListedFilterMatch {
+    status: String,
+}
+
+fn parse_nextest_list(output: &str) -> Result<Vec<String>> {
+    let listing: NextestList =
+        serde_json::from_str(output).context("parsing `cargo nextest list` JSON")?;
+    Ok(listing
+        .rust_suites
+        .into_values()
+        .flat_map(|suite| suite.testcases)
+        .filter_map(|(name, test)| (test.filter_match.status == "matches").then_some(name))
+        .collect())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct RequestedMatches {
+    matched_requests: usize,
+    matched_tests: usize,
+    unmatched: Vec<String>,
+}
+
+fn match_requested_names(requested: &[String], listed: &[String]) -> RequestedMatches {
+    let mut unmatched = Vec::new();
+    let mut matched_requests = 0;
+    for requested_name in requested {
+        if listed
+            .iter()
+            .any(|listed_name| test_name_matches_request(listed_name, requested_name))
+        {
+            matched_requests += 1;
+        } else {
+            unmatched.push(requested_name.clone());
+        }
+    }
+    RequestedMatches {
+        matched_requests,
+        matched_tests: listed.len(),
+        unmatched,
+    }
+}
+
+fn test_name_matches_request(listed: &str, requested: &str) -> bool {
+    listed == requested
+        || listed
+            .strip_suffix(requested)
+            .is_some_and(|prefix| prefix.ends_with("::"))
+}
+
+fn test_invocation(args: &[String]) -> String {
+    if args.is_empty() {
+        "cargo xtask test".to_owned()
+    } else {
+        format!("cargo xtask test {}", args.join(" "))
+    }
+}
+
+fn nextest_matched_no_tests(captured: &Captured) -> bool {
+    captured.status.code() == Some(4) || captured.output.contains("error: no tests to run")
+}
+
+#[expect(
+    clippy::print_stderr,
+    reason = "xtask reports exact-name selection results to the operator"
+)]
+fn report_test_selection(requested: &[String], matches: &RequestedMatches) {
+    eprintln!(
+        "test selection: {} requested, {} matched name(s), {} matched test(s)",
+        requested.len(),
+        matches.matched_requests,
+        matches.matched_tests
+    );
+    if !matches.unmatched.is_empty() {
+        eprintln!("unmatched: {}", matches.unmatched.join(", "));
+        eprintln!(
+            "NEXT: inspect available names with `cargo xtask test --list {}`",
+            matches.unmatched.join(" ")
+        );
+    }
+}
+
+#[expect(
+    clippy::print_stderr,
+    reason = "xtask explains empty nextest selections and gives a discovery command"
+)]
+fn report_zero_test_match(args: &[String]) {
+    let rendered = if args.is_empty() {
+        "<none>".to_owned()
+    } else {
+        args.join(" ")
+    };
+    eprintln!("xtask: no tests matched nextest arguments: {rendered}");
+    eprintln!("The filter or active profile excluded every workspace test.");
+    eprintln!("NEXT: inspect available names with `cargo xtask test --list {rendered}`");
 }
 
 pub(crate) fn test_archive(root: &Path, args: &[String]) -> Result<()> {
@@ -750,7 +1113,152 @@ Summary [   12.3s] 2611 tests run: 2611 passed, 42 skipped
             extract_test_summary(output).as_deref(),
             Some("Summary [   12.3s] 2611 tests run: 2611 passed, 42 skipped")
         );
+        assert_eq!(
+            extract_test_summary("Summary [ 0.01s] 1 test run: 1 passed").as_deref(),
+            Some("Summary [ 0.01s] 1 test run: 1 passed")
+        );
         assert_eq!(extract_test_summary("no summary here"), None);
+    }
+
+    #[test]
+    fn test_command_extracts_names_and_list_without_rewriting_nextest_args() {
+        let command = parse_test_command(&[
+            "--name".to_owned(),
+            "leaf".to_owned(),
+            "--name=tests::full".to_owned(),
+            "-P".to_owned(),
+            "gate".to_owned(),
+            "auth".to_owned(),
+        ])
+        .unwrap();
+        assert_eq!(
+            command,
+            TestCommand {
+                names: vec!["leaf".to_owned(), "tests::full".to_owned()],
+                forwarded: vec!["-P".to_owned(), "gate".to_owned(), "auth".to_owned()],
+                list: false,
+            }
+        );
+
+        let command = parse_test_command(&["--list".to_owned(), "auth".to_owned()]).unwrap();
+        assert_eq!(
+            command,
+            TestCommand {
+                names: Vec::new(),
+                forwarded: vec!["auth".to_owned()],
+                list: true,
+            }
+        );
+    }
+
+    #[test]
+    fn test_command_leaves_libtest_args_after_separator_untouched() {
+        let command = parse_test_command(&[
+            "auth".to_owned(),
+            "--".to_owned(),
+            "--name".to_owned(),
+            "literal".to_owned(),
+        ])
+        .unwrap();
+        assert_eq!(
+            command.forwarded,
+            ["auth", "--", "--name", "literal"].map(str::to_owned)
+        );
+        assert!(command.names.is_empty());
+    }
+
+    #[test]
+    fn test_command_rejects_missing_names_and_mixed_discovery_modes() {
+        assert!(
+            parse_test_command(&["--name".to_owned()])
+                .unwrap_err()
+                .to_string()
+                .contains("requires a test name")
+        );
+        assert!(
+            parse_test_command(&["--name=".to_owned()])
+                .unwrap_err()
+                .to_string()
+                .contains("cannot be empty")
+        );
+        assert!(
+            parse_test_command(&["--list".to_owned(), "--name=leaf".to_owned()])
+                .unwrap_err()
+                .to_string()
+                .contains("does not combine")
+        );
+    }
+
+    #[test]
+    fn exact_name_filterset_anchors_leaf_and_full_names() {
+        assert_eq!(
+            exact_name_filterset(&["leaf".to_owned(), "tests::full.name".to_owned()]),
+            r"test(/(^|::)leaf$/) | test(/(^|::)tests::full\.name$/)"
+        );
+        assert_eq!(
+            exact_name_filterset(&["unicode::café".to_owned()]),
+            "test(/(^|::)unicode::café$/)"
+        );
+    }
+
+    #[test]
+    fn list_step_forwards_only_nextest_profiles() {
+        assert_eq!(
+            nextest_profile_args(&[
+                "auth".to_owned(),
+                "-P".to_owned(),
+                "live".to_owned(),
+                "--profile=journey".to_owned(),
+                "--no-capture".to_owned(),
+                "--".to_owned(),
+                "-P".to_owned(),
+                "ignored".to_owned(),
+            ]),
+            ["-P", "live", "--profile=journey"].map(str::to_owned)
+        );
+    }
+
+    #[test]
+    fn nextest_json_keeps_only_filterset_matches() {
+        let output = r#"{
+            "rust-suites": {
+                "xtask::bin/xtask": {
+                    "testcases": {
+                        "tests::matched": {
+                            "filter-match": {"status": "matches"}
+                        },
+                        "tests::other": {
+                            "filter-match": {"status": "mismatch", "reason": "expression"}
+                        }
+                    }
+                }
+            }
+        }"#;
+        assert_eq!(
+            parse_nextest_list(output).unwrap(),
+            vec!["tests::matched".to_owned()]
+        );
+    }
+
+    #[test]
+    fn requested_names_match_whole_path_suffixes_only() {
+        let matches = match_requested_names(
+            &[
+                "leaf".to_owned(),
+                "nested::leaf".to_owned(),
+                "missing".to_owned(),
+            ],
+            &["tests::leaf".to_owned(), "tests::nested::leaf".to_owned()],
+        );
+        assert_eq!(
+            matches,
+            RequestedMatches {
+                matched_requests: 2,
+                matched_tests: 2,
+                unmatched: vec!["missing".to_owned()],
+            }
+        );
+        assert!(!test_name_matches_request("tests::leaf_extra", "leaf"));
     }
 
     #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -98,9 +98,14 @@ const TASKS: &[TaskInfo] = &[
         runs: "cargo clippy for all workspace targets and both host install feature shapes without testkit; every pass denies warnings",
     },
     TaskInfo {
+        name: "check",
+        summary: "Run a fast structural compile check across the workspace.",
+        runs: "cargo check --workspace --all-targets --all-features --locked",
+    },
+    TaskInfo {
         name: "test",
-        summary: "Run the workspace test suite through nextest; accepts nextest filters.",
-        runs: "cargo nextest run --workspace --all-features --locked [nextest filter]...",
+        summary: "Run nextest filters, batch exact --name selections, or discover tests with --list.",
+        runs: "cargo nextest run --workspace --all-features --locked [--name <test>]... [nextest filter]...; --list uses cargo nextest list",
     },
     TaskInfo {
         name: "test-archive",
@@ -318,6 +323,7 @@ fn dispatch(task: &str, args: &[String], root: &Path) -> Result<()> {
         "hooks" => hooks::install(root),
         "fmt" => gates::fmt(root),
         "lint" => gates::lint(root),
+        "check" => gates::check(root),
         "test" => gates::test(root, args),
         "test-archive" => gates::test_archive(root, args),
         "sandbox" => sandbox::run(root, args),

--- a/xtask/src/runner.rs
+++ b/xtask/src/runner.rs
@@ -20,6 +20,7 @@ const TERMINATE_GRACE: Duration = Duration::from_secs(5);
 
 pub(crate) struct Captured {
     pub(crate) status: ExitStatus,
+    pub(crate) stdout: String,
     pub(crate) output: String,
 }
 
@@ -111,10 +112,12 @@ where
         .map_err(|_| anyhow::anyhow!("command stderr reader panicked"))?
         .context("reading command stderr")?;
 
-    let mut combined = String::from_utf8_lossy(&stdout).into_owned();
+    let stdout = String::from_utf8_lossy(&stdout).into_owned();
+    let mut combined = stdout.clone();
     combined.push_str(&stderr_output);
     Ok(Captured {
         status,
+        stdout,
         output: combined,
     })
 }

--- a/xtask/src/runner.rs
+++ b/xtask/src/runner.rs
@@ -24,6 +24,12 @@ pub(crate) struct Captured {
     pub(crate) output: String,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum RtkPolicy {
+    Configured,
+    Bypass,
+}
+
 pub(crate) fn run<I, S>(root: &Path, program: &str, args: I) -> Result<()>
 where
     I: IntoIterator<Item = S>,
@@ -57,9 +63,16 @@ where
     S: AsRef<OsStr>,
 {
     let args: Vec<_> = args.into_iter().collect();
-    let mut child = build_command(root, program, &args, envs, removed_envs)
-        .spawn()
-        .with_context(|| format!("running `{program}`"))?;
+    let mut child = build_command(
+        root,
+        program,
+        &args,
+        envs,
+        removed_envs,
+        RtkPolicy::Configured,
+    )
+    .spawn()
+    .with_context(|| format!("running `{program}`"))?;
     let status = wait_bounded(&mut child, program, &args, &mut || {})?;
     ensure_success(program, &args, status)
 }
@@ -70,6 +83,7 @@ pub(crate) fn run_streamed<I, S>(
     args: I,
     envs: &[(&str, PathBuf)],
     removed_envs: &[&str],
+    rtk_policy: RtkPolicy,
     on_line: &mut dyn FnMut(&str),
 ) -> Result<Captured>
 where
@@ -77,7 +91,7 @@ where
     S: AsRef<OsStr>,
 {
     let args: Vec<_> = args.into_iter().collect();
-    let mut child = build_command(root, program, &args, envs, removed_envs)
+    let mut child = build_command(root, program, &args, envs, removed_envs, rtk_policy)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
@@ -193,14 +207,16 @@ fn build_command<S: AsRef<OsStr>>(
     args: &[S],
     envs: &[(&str, PathBuf)],
     removed_envs: &[&str],
+    rtk_policy: RtkPolicy,
 ) -> Command {
-    let mut command = if crate::rtk::wrap_cargo(program, args) {
-        let mut command = Command::new("rtk");
-        command.arg(program);
-        command
-    } else {
-        Command::new(program)
-    };
+    let mut command =
+        if matches!(rtk_policy, RtkPolicy::Configured) && crate::rtk::wrap_cargo(program, args) {
+            let mut command = Command::new("rtk");
+            command.arg(program);
+            command
+        } else {
+            Command::new(program)
+        };
     command
         .args(args.iter().map(AsRef::as_ref))
         .current_dir(root)
@@ -290,5 +306,19 @@ mod tests {
 
         assert_eq!(lines, ["first� line", "second line"]);
         assert_eq!(output, "first� line\r\nsecond line");
+    }
+
+    #[test]
+    fn rtk_bypass_builds_the_requested_cargo_command_directly() {
+        let command = build_command(
+            Path::new("."),
+            "cargo",
+            &["nextest", "list"],
+            &[],
+            &[],
+            RtkPolicy::Bypass,
+        );
+
+        assert_eq!(command.get_program(), "cargo");
     }
 }

--- a/xtask/src/spinner.rs
+++ b/xtask/src/spinner.rs
@@ -13,6 +13,9 @@ use std::time::{Duration, Instant};
 
 const SPINNER_FRAMES: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 const SPINNER_TICK: Duration = Duration::from_millis(80);
+const HEARTBEAT_TICK: Duration = Duration::from_secs(1);
+const HEARTBEAT_FIRST: Duration = Duration::from_secs(15);
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 const ENV_NO_PROGRESS: &str = "RIMZ_NO_PROGRESS";
 const ENV_AGENT_KIND: &str = "RIMZ_AGENT_KIND";
 
@@ -24,11 +27,47 @@ struct SpinnerInner {
     label: Arc<Mutex<String>>,
     stop: Arc<AtomicBool>,
     worker: Option<JoinHandle<()>>,
+    mode: ProgressMode,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProgressMode {
+    Animated,
+    Heartbeat,
+    Silent,
+}
+
+struct HeartbeatPolicy {
+    next_due: Duration,
+}
+
+impl HeartbeatPolicy {
+    fn new() -> Self {
+        Self {
+            next_due: HEARTBEAT_FIRST,
+        }
+    }
+
+    fn due(&mut self, elapsed: Duration) -> bool {
+        if elapsed < self.next_due {
+            return false;
+        }
+        while self.next_due <= elapsed {
+            self.next_due += HEARTBEAT_INTERVAL;
+        }
+        true
+    }
 }
 
 impl Spinner {
     pub(crate) fn new(label: impl Into<String>) -> Self {
-        if !animation_enabled() {
+        let mode = progress_mode(
+            std::io::stderr().is_terminal(),
+            std::env::var(ENV_NO_PROGRESS).ok().as_deref(),
+            std::env::var(ENV_AGENT_KIND).ok().as_deref(),
+            std::env::var("TERM").ok().as_deref(),
+        );
+        if mode == ProgressMode::Silent {
             return Self { inner: None };
         }
 
@@ -39,20 +78,38 @@ impl Spinner {
         let started = Instant::now();
         let worker = thread::spawn(move || {
             let mut frame = 0;
+            let mut heartbeat = HeartbeatPolicy::new();
             while !worker_stop.load(Ordering::Relaxed) {
-                if let Ok(label) = worker_label.lock() {
-                    let elapsed = format_elapsed(started.elapsed());
-                    let mut stderr = std::io::stderr().lock();
-                    let _ = write!(
-                        stderr,
-                        "\r{} {} ({elapsed})\x1b[K",
-                        SPINNER_FRAMES[frame % SPINNER_FRAMES.len()],
-                        *label
-                    );
-                    let _ = stderr.flush();
-                    frame += 1;
+                let elapsed = started.elapsed();
+                match mode {
+                    ProgressMode::Animated => {
+                        if let Ok(label) = worker_label.lock() {
+                            let elapsed = format_elapsed(elapsed);
+                            let mut stderr = std::io::stderr().lock();
+                            let _ = write!(
+                                stderr,
+                                "\r{} {} ({elapsed})\x1b[K",
+                                SPINNER_FRAMES[frame % SPINNER_FRAMES.len()],
+                                *label
+                            );
+                            let _ = stderr.flush();
+                            frame += 1;
+                        }
+                    }
+                    ProgressMode::Heartbeat if heartbeat.due(elapsed) => {
+                        if let Ok(label) = worker_label.lock() {
+                            let elapsed = format_elapsed(elapsed);
+                            let mut stderr = std::io::stderr().lock();
+                            let _ = writeln!(stderr, "xtask: {} still running ({elapsed})", *label);
+                            let _ = stderr.flush();
+                        }
+                    }
+                    ProgressMode::Heartbeat | ProgressMode::Silent => {}
                 }
-                thread::sleep(SPINNER_TICK);
+                thread::park_timeout(match mode {
+                    ProgressMode::Animated => SPINNER_TICK,
+                    ProgressMode::Heartbeat | ProgressMode::Silent => HEARTBEAT_TICK,
+                });
             }
         });
 
@@ -61,6 +118,7 @@ impl Spinner {
                 label,
                 stop,
                 worker: Some(worker),
+                mode,
             }),
         }
     }
@@ -82,23 +140,23 @@ impl Spinner {
     }
 }
 
-fn animation_enabled() -> bool {
-    std::io::stderr().is_terminal()
-        && animation_allowed(
-            std::env::var(ENV_NO_PROGRESS).ok().as_deref(),
-            std::env::var(ENV_AGENT_KIND).ok().as_deref(),
-            std::env::var("TERM").ok().as_deref(),
-        )
-}
-
-fn animation_allowed(
+fn progress_mode(
+    stderr_is_terminal: bool,
     no_progress: Option<&str>,
     agent_kind: Option<&str>,
     term: Option<&str>,
-) -> bool {
-    !matches!(no_progress, Some("1") | Some("true"))
-        && agent_kind.is_none_or(str::is_empty)
-        && term != Some("dumb")
+) -> ProgressMode {
+    if matches!(no_progress, Some("1") | Some("true")) {
+        ProgressMode::Silent
+    } else if stderr_is_terminal && animation_allowed(agent_kind, term) {
+        ProgressMode::Animated
+    } else {
+        ProgressMode::Heartbeat
+    }
+}
+
+fn animation_allowed(agent_kind: Option<&str>, term: Option<&str>) -> bool {
+    agent_kind.is_none_or(str::is_empty) && term != Some("dumb")
 }
 
 fn format_elapsed(elapsed: Duration) -> String {
@@ -117,9 +175,12 @@ impl Drop for Spinner {
         };
         inner.stop.store(true, Ordering::Relaxed);
         if let Some(worker) = inner.worker.take() {
+            worker.thread().unpark();
             let _ = worker.join();
         }
-        let _ = Self::clear();
+        if inner.mode == ProgressMode::Animated {
+            let _ = Self::clear();
+        }
     }
 }
 
@@ -128,15 +189,54 @@ mod tests {
     use super::*;
 
     #[test]
-    fn animation_requires_an_interactive_human_environment() {
-        assert!(animation_allowed(None, None, None));
-        assert!(!animation_allowed(Some("1"), None, None));
-        assert!(!animation_allowed(Some("true"), None, None));
-        assert!(animation_allowed(Some("0"), None, None));
-        assert!(!animation_allowed(None, Some("codex"), None));
-        assert!(animation_allowed(None, Some(""), None));
-        assert!(!animation_allowed(None, None, Some("dumb")));
-        assert!(animation_allowed(None, None, Some("xterm-256color")));
+    fn progress_mode_distinguishes_animation_heartbeat_and_silence() {
+        assert_eq!(
+            progress_mode(true, None, None, Some("xterm-256color")),
+            ProgressMode::Animated
+        );
+        assert_eq!(
+            progress_mode(false, None, None, Some("xterm-256color")),
+            ProgressMode::Heartbeat
+        );
+        assert_eq!(
+            progress_mode(true, None, Some("codex"), Some("xterm-256color")),
+            ProgressMode::Heartbeat
+        );
+        assert_eq!(
+            progress_mode(true, None, None, Some("dumb")),
+            ProgressMode::Heartbeat
+        );
+        assert_eq!(
+            progress_mode(true, Some("1"), None, None),
+            ProgressMode::Silent
+        );
+        assert_eq!(
+            progress_mode(false, Some("true"), Some("codex"), Some("dumb")),
+            ProgressMode::Silent
+        );
+        assert_eq!(
+            progress_mode(true, Some("0"), Some(""), None),
+            ProgressMode::Animated
+        );
+    }
+
+    #[test]
+    fn heartbeat_starts_at_fifteen_seconds_then_repeats_every_thirty() {
+        let mut heartbeat = HeartbeatPolicy::new();
+        assert!(!heartbeat.due(Duration::from_secs(14)));
+        assert!(heartbeat.due(Duration::from_secs(15)));
+        assert!(!heartbeat.due(Duration::from_secs(44)));
+        assert!(heartbeat.due(Duration::from_secs(45)));
+        assert!(!heartbeat.due(Duration::from_secs(74)));
+        assert!(heartbeat.due(Duration::from_secs(75)));
+    }
+
+    #[test]
+    fn heartbeat_coalesces_missed_intervals() {
+        let mut heartbeat = HeartbeatPolicy::new();
+        assert!(heartbeat.due(Duration::from_secs(80)));
+        assert!(!heartbeat.due(Duration::from_secs(81)));
+        assert!(heartbeat.due(Duration::from_secs(105)));
     }
 
     #[test]

--- a/xtask/src/spinner.rs
+++ b/xtask/src/spinner.rs
@@ -100,7 +100,7 @@ impl Spinner {
                         if let Ok(label) = worker_label.lock() {
                             let elapsed = format_elapsed(elapsed);
                             let mut stderr = std::io::stderr().lock();
-                            let _ = writeln!(stderr, "xtask: {} still running ({elapsed})", *label);
+                            let _ = writeln!(stderr, "{}", heartbeat_line(&label, &elapsed));
                             let _ = stderr.flush();
                         }
                     }
@@ -157,6 +157,14 @@ fn progress_mode(
 
 fn animation_allowed(agent_kind: Option<&str>, term: Option<&str>) -> bool {
     agent_kind.is_none_or(str::is_empty) && term != Some("dumb")
+}
+
+fn heartbeat_line(label: &str, elapsed: &str) -> String {
+    if let Some((task, phase)) = label.split_once(" — ") {
+        format!("xtask: {task} still running ({elapsed}) — {phase}")
+    } else {
+        format!("xtask: {label} still running ({elapsed})")
+    }
 }
 
 fn format_elapsed(elapsed: Duration) -> String {
@@ -237,6 +245,18 @@ mod tests {
         assert!(heartbeat.due(Duration::from_secs(80)));
         assert!(!heartbeat.due(Duration::from_secs(81)));
         assert!(heartbeat.due(Duration::from_secs(105)));
+    }
+
+    #[test]
+    fn heartbeat_keeps_the_latest_phase_after_the_elapsed_time() {
+        assert_eq!(
+            heartbeat_line("test — Checking rimz", "45s"),
+            "xtask: test still running (45s) — Checking rimz"
+        );
+        assert_eq!(
+            heartbeat_line("test", "15s"),
+            "xtask: test still running (15s)"
+        );
     }
 
     #[test]

--- a/xtask/src/spinner.rs
+++ b/xtask/src/spinner.rs
@@ -1,4 +1,4 @@
-//! TTY-gated stderr spinner adapted from `crates/rimz/src/cli/spinner.rs`.
+//! Stderr progress indicator adapted from `crates/rimz/src/cli/spinner.rs`.
 //!
 //! The small implementation is duplicated deliberately so xtask stays free of
 //! a dependency on the runtime crate.

--- a/xtask/src/tests.rs
+++ b/xtask/src/tests.rs
@@ -59,6 +59,22 @@ fn test_forwards_filter_args() {
 }
 
 #[test]
+fn test_forwards_exact_names_and_list_requests() {
+    for argv in [
+        args(&["test", "--name", "leaf", "--name=tests::full"]),
+        args(&["test", "--list", "auth"]),
+    ] {
+        assert_eq!(
+            parse_args(&argv).unwrap(),
+            Action::Run {
+                task: "test",
+                args: &argv[1..],
+            },
+        );
+    }
+}
+
+#[test]
 fn test_archive_forwards_archive_args() {
     let argv = args(&[
         "test-archive",
@@ -150,5 +166,23 @@ fn profile_build_is_a_first_class_no_arg_task() {
             task: "profile-build",
             args: &[],
         },
+    );
+}
+
+#[test]
+fn check_is_a_first_class_no_arg_task() {
+    assert!(task_info("check").is_some());
+    assert_eq!(
+        parse_args(&args(&["check"])).unwrap(),
+        Action::Run {
+            task: "check",
+            args: &[],
+        },
+    );
+    assert!(
+        parse_args(&args(&["check", "--package", "rimz"]))
+            .unwrap_err()
+            .to_string()
+            .contains("takes no arguments")
     );
 }


### PR DESCRIPTION
## Context

Agents driving `cargo xtask` hit four problems, all costing turns rather than correctness:

- Separate focused `cargo xtask test` processes contend on the target-dir and package-cache locks, so parallel invocations serialize behind each other anyway.
- Non-TTY runs are silent for minutes. The spinner is a no-op when stderr is not a terminal or `RIMZ_AGENT_KIND` is set, so an agent watching a ten-minute compile sees nothing and cannot distinguish work from a wedge.
- A focused filter that matches zero tests exits with nextest's bare error and no route to the right name.
- Standalone `cargo xtask test` ran with inherited stdio, bypassing the `run_streamed` / `failure_detail` / `extract_test_summary` machinery `gate` already had, so a failure meant a follow-up read to find the first useful diagnostic.

## Design choices

- **Exact names are segment-anchored, not full-path equality.** `--name` builds one filterset joining `test(/(^|::)<name>$/)` per name. nextest test names are full module paths, so `test(=leaf)` would match nothing for the common copy-a-leaf-name case; the anchored form accepts both a bare leaf and a full `module::path` with no substring drift. Always the explicit `/…/` form — a bare `test(name)` is a substring match.
- **List, then run.** `--name` runs `nextest list --message-format json` before the run and diffs requested names against matched ones. The listing pays the build the run needs anyway, so validation is close to free, and it is the only way to name *which* requested leaf was absent. Unmatched names still let the matched ones run, then fail the command, so one turn carries both the results and the correction.
- **Heartbeat is a spinner mode, not a second type.** Animated when stderr is a TTY and no agent env is set; otherwise a newline heartbeat at 15s then every 30s; `RIMZ_NO_PROGRESS=1|true` silences both. The policy is a pure struct unit-tested with injected durations, matching how `deadline.rs` and `animation_allowed` are tested.
- **RTK is bypassed only where stdout is the contract.** `rtk` compresses cargo output, which is right for runs an agent watches and fatal for a command whose stdout must be parsed. An explicit `RtkPolicy` on the runner opts out for exactly two invocations — JSON discovery and `--list` — and leaves every check/test/gate run compressed as configured.
- **`check` is singular and deliberately adjacent to `checks`.** `cargo xtask check` is the fast `cargo check --workspace --all-targets --all-features --locked` structural pass; `cargo xtask checks` remains the non-test gate composite. One letter apart with different meanings, so the docs disambiguate them explicitly.
- **No cross-process advisory lock.** Considered and rejected: batching removes the contention at its source, and `.config/nextest.toml` documents this codebase deliberately removing a machine-global flock in favour of per-test isolated runtime dirs. The docs policy — one Cargo-family command at a time per worktree — carries the rest.

## Implementation

- `xtask/src/spinner.rs` — three progress modes behind one `Spinner`, with `progress_mode` and `HeartbeatPolicy` as pure functions. Heartbeat lines carry the latest captured phase (`xtask: test still running (45s) — Checking rimz`); drop skips the ANSI line-clear outside animated mode.
- `xtask/src/gates.rs` — standalone `test` and the new `check` route through the existing capture path, so both get the spinner/heartbeat, an `extract_test_summary` note on success, and a bounded failure excerpt with the rerun command inline. `--name`/`--name=` batching, `--list` discovery, and a zero-match diagnostic that names the filter and points at `--list`.
- `xtask/src/runner.rs` — `Captured` keeps stdout separately so structured output is parsed without splitting a combined string heuristically, and `RtkPolicy` threads the wrap decision to the call site.
- Docs: `docs/contributing/rust-conventions.md` gains the batching grammar, discovery, the `check`/`checks` disambiguation, and the one-Cargo-command-per-worktree policy; the root `AGENTS.md` testing line points at `--name` batching.

Deviations from the plan, all narrowing rather than widening it: non-ASCII identifier characters are preserved rather than backslash-escaped (a blanket escape would produce an invalid Rust regex; `unicode::café` is covered by a test); `Captured` gained the `stdout` field the plan did not name; and the standalone failure banner reads `xtask: fail at <task>` rather than reusing `gate:`, which would claim a standalone command was a composite gate.

Review found two bugs, both fixed here and both in the paths the change exists to serve. `--name` and `--list` parsed rtk-wrapped stdout, so under `RIMZ_RTK=auto` — the agent environment this targets — `--name` died on empty JSON and `--list` exited 0 printing one byte. And the compact failure report inherited a head-only 12,000-character bound applied to a runner whose default profile prints a line per *passing* test, so a failure past roughly the hundredth test showed a wall of `PASS` lines and nothing else; the gate step had been safe only because its profile sets `status-level = "retry"`. Nextest's non-failure status lines are now dropped the way cargo progress verbs are, and the bound keeps a head and a tail so the summary and failed-test list survive regardless.

## Verification

`cargo xtask gate --check` passes end to end (`✓ fmt`, `✓ invariants`, `✓ docs-links`, `✓ lint`, `✓ test (5526 passed)`). Both fixes were re-confirmed against the real environment rather than a flag-disabled one: with ambient `RIMZ_RTK=auto`, a partial `--name` match runs the known test, reports the unknown one and exits 1, and `--list heartbeat` returns 23 names. The status-line filter takes a real 135-test default-profile capture from 15,888 characters to 230, leaving the run header and the summary.

## Advisories

- **Mixing `--name` with other forwarded selectors reports an optimistic count.** Discovery forwards `-P`/`--profile` only, so a package selector or positional filter can narrow the final run after workspace-wide name validation — nextest intersects a filterset with positional filters. The run still fails honestly; only the preceding selection line is optimistic. Forwarding everything breaks on run-only flags that `list` rejects, and rejecting positionals at parse time needs per-flag arity to tell `gate` in `-P gate` from a filter. Both routes mean owning nextest's option grammar, so this stays a documented limit.
- **Standalone `test` no longer streams.** A deliberate trade of live per-test chatter for bounded diagnostics and low-noise progress. This reaches CI, which runs the suite through `cargo xtask test --profile gate|live|journey`: those job logs now carry the heartbeat and a compact report instead of the full stream, and a failure is bounded to 12,000 characters split head and tail.
- **Under rtk the heartbeat has no phase suffix.** rtk buffers the child's stderr, so the progress closure never sees a line and the heartbeat shows the bare label with elapsed time. Liveness still reads correctly; the phase appears in non-rtk environments such as CI.
- **Panic-shaped failure output is the least directly exercised path.** Unit tests reproduce the `PASS`-flood-plus-`FAIL` shape and the head/tail bound, and the real compact-failure smoke used an invalid nextest flag rather than a deliberately panicking test.
