### PR TITLE
subagents: trim launch flags, add foreground mode, described children, and a types catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ rimz teams forge -w feat-x           # launch one configured cohort in a worktre
 rimz teams resume forge              # reopen a configured team cohort
 rimz teams focus|restart|stop forge  # drive one live team cohort
 rimz subagents claude "review this"  # from an agent: launch a supervised child
+rimz subagents types                 # agent types available to launch
 rimz subagents wait                  # join every live child and collect results
 rimz subagents list|stop --all       # inspect or stop the caller's own children
 rimz message @coder "rebase first"   # park for the next turn boundary

--- a/crates/rimz/src/cli/snapshots/rimz__cli__surface_tests__cli_surface.snap
+++ b/crates/rimz/src/cli/snapshots/rimz__cli__surface_tests__cli_surface.snap
@@ -997,6 +997,8 @@ rimz help subagents list
 
 rimz help subagents stop
 
+rimz help subagents types
+
 rimz help subagents wait
 
 rimz help teams
@@ -2082,11 +2084,10 @@ rimz subagents
     <prompt>  [action=set takes=1..=1]
     <spec>  [action=set takes=1..=1]
     --agent <PROFILE|KIND>  [action=set takes=1..=1]
-    --ask  [action=set-true takes=0..=0]
-    --budget <AMOUNT[/day]>  [action=set takes=1..=1]
     --color <COLOR>  [action=set takes=1..=1 global default=auto values=auto|always|never]
     --description <TEXT>  [action=set takes=1..=1]
     --effort <LEVEL>  [action=set takes=1..=1]
+    --fg  [action=set-true takes=0..=0]
     -h, --help  [action=help takes=0..=0]
     --json  [action=set-true takes=0..=0]
     --keep  [action=set-true takes=0..=0]
@@ -2097,7 +2098,6 @@ rimz subagents
     --root <ROOT>  [action=set takes=1..=1 global]
     --timeout <TIMEOUT>  [action=set takes=1..=1]
     --tmux  [action=set-true takes=0..=0 global]
-    --yolo  [action=set-true takes=0..=0]
     --zellij  [action=set-true takes=0..=0 global]
 
 rimz subagents help
@@ -2110,6 +2110,8 @@ rimz subagents help list
 
 rimz subagents help stop
 
+rimz subagents help types
+
 rimz subagents help wait
 
 rimz subagents launch
@@ -2117,11 +2119,10 @@ rimz subagents launch
     <prompt>  [action=set takes=1..=1]
     <spec>  [action=set takes=1..=1]
     --agent <PROFILE|KIND>  [action=set takes=1..=1]
-    --ask  [action=set-true takes=0..=0]
-    --budget <AMOUNT[/day]>  [action=set takes=1..=1]
     --color <COLOR>  [action=set takes=1..=1 global default=auto values=auto|always|never]
     --description <TEXT>  [action=set takes=1..=1]
     --effort <LEVEL>  [action=set takes=1..=1]
+    --fg  [action=set-true takes=0..=0]
     -h, --help  [action=help takes=0..=0]
     --keep  [action=set-true takes=0..=0]
     --max-turns <N>  [action=set takes=1..=1]
@@ -2131,7 +2132,6 @@ rimz subagents launch
     --root <ROOT>  [action=set takes=1..=1 global]
     --timeout <TIMEOUT>  [action=set takes=1..=1]
     --tmux  [action=set-true takes=0..=0 global]
-    --yolo  [action=set-true takes=0..=0]
     --zellij  [action=set-true takes=0..=0 global]
 
 rimz subagents list (aliases: ls)
@@ -2148,6 +2148,15 @@ rimz subagents stop
     --all  [action=set-true takes=0..=0]
     --color <COLOR>  [action=set takes=1..=1 global default=auto values=auto|always|never]
     -h, --help  [action=help takes=0..=0]
+    --mux <MUX>  [action=set takes=1..=1 global]
+    --root <ROOT>  [action=set takes=1..=1 global]
+    --tmux  [action=set-true takes=0..=0 global]
+    --zellij  [action=set-true takes=0..=0 global]
+
+rimz subagents types
+    --color <COLOR>  [action=set takes=1..=1 global default=auto values=auto|always|never]
+    -h, --help  [action=help takes=0..=0]
+    --json  [action=set-true takes=0..=0]
     --mux <MUX>  [action=set takes=1..=1 global]
     --root <ROOT>  [action=set takes=1..=1 global]
     --tmux  [action=set-true takes=0..=0 global]

--- a/crates/rimz/src/cli/subagents/mod.rs
+++ b/crates/rimz/src/cli/subagents/mod.rs
@@ -264,7 +264,8 @@ fn list_children(json: bool, globals: &GlobalFlags) -> Result<()> {
     if reports.is_empty() {
         return Ok(());
     }
-    let mut table = render::Table::new(["SUBAGENT", "KIND", "STATUS", "RUN"]);
+    let mut table = render::Table::new(["SUBAGENT", "KIND", "STATUS", "RUN"])
+        .max_width(render::terminal_columns(120));
     for child in reports {
         let detail = child
             .description
@@ -311,6 +312,7 @@ impl AgentTypeReport {
 
 fn available_types(config: &rimz::config::MachineConfig) -> Vec<AgentTypeReport> {
     let mut types = rimz::agents::known_kinds()
+        .filter(|kind| !config.agents.profiles.0.contains_key(*kind))
         .map(|kind| AgentTypeReport {
             name: kind.to_owned(),
             source: "kind",
@@ -575,6 +577,19 @@ mod tests {
                 args: None,
             },
         );
+        config.agents.profiles.0.insert(
+            "claude".to_owned(),
+            rimz::config::Profile {
+                agent: "claude".to_owned(),
+                mode: None,
+                model: None,
+                effort: None,
+                budget: None,
+                system_prompt_file: None,
+                append_system_prompt_files: Vec::new(),
+                args: None,
+            },
+        );
         config
             .agents
             .commands
@@ -598,6 +613,15 @@ mod tests {
             types
                 .iter()
                 .any(|entry| entry.name == "mytool" && entry.source == "command")
+        );
+        assert_eq!(
+            types.iter().filter(|entry| entry.name == "claude").count(),
+            1
+        );
+        assert!(
+            types
+                .iter()
+                .any(|entry| entry.name == "claude" && entry.source == "profile")
         );
         assert!(!types.iter().any(|entry| entry.name == "review"));
     }

--- a/crates/rimz/src/cli/subagents/mod.rs
+++ b/crates/rimz/src/cli/subagents/mod.rs
@@ -9,7 +9,6 @@ use serde::Serialize;
 
 use super::{Ctx, GlobalFlags, agents_cmd, render};
 use rimz::agents::AgentState;
-use rimz::harness::budget::BudgetSpec;
 
 #[derive(Debug, Args)]
 #[command(args_conflicts_with_subcommands = true)]
@@ -30,6 +29,12 @@ enum SubagentsSubcmd {
     /// List this agent's children.
     #[command(alias = "ls")]
     List {
+        /// Emit JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// List agent types available to launch.
+    Types {
         /// Emit JSON.
         #[arg(long)]
         json: bool,
@@ -88,18 +93,12 @@ struct SubagentLaunchArgs {
     /// Reasoning effort for the child.
     #[arg(long, value_name = "LEVEL")]
     effort: Option<String>,
-    /// Let the child ask before tool use where supported.
-    #[arg(long, conflicts_with = "yolo")]
-    ask: bool,
-    /// Skip provider permission prompts where supported.
-    #[arg(long)]
-    yolo: bool,
-    /// Cap this child's spend.
-    #[arg(long, value_name = "AMOUNT[/day]")]
-    budget: Option<BudgetSpec>,
     /// Stop the child after this duration.
     #[arg(long, value_parser = crate::cli::supervised::parse_timeout)]
     timeout: Option<Duration>,
+    /// Block until the child finishes and print its result.
+    #[arg(long)]
+    fg: bool,
     /// Leave the child pane open after completion.
     #[arg(long)]
     keep: bool,
@@ -119,6 +118,7 @@ pub fn run(args: SubagentsArgs, globals: &GlobalFlags) -> Result<()> {
     match args.command {
         Some(SubagentsSubcmd::Launch(launch)) => launch_child(launch, globals),
         Some(SubagentsSubcmd::List { json }) => list_children(json, globals),
+        Some(SubagentsSubcmd::Types { json }) => list_types(json),
         Some(SubagentsSubcmd::Wait {
             names,
             any,
@@ -171,27 +171,15 @@ impl SubagentLaunchArgs {
             .unwrap_or_else(|| crate::cli::supervised::parse_timeout(&defaults.timeout))
             .map_err(anyhow::Error::msg)
             .context("parsing agents.subagents.timeout")?;
-        let budget = match self.budget {
-            Some(budget) => Some(budget),
-            None => defaults
-                .budget
-                .as_deref()
-                .map(str::parse)
-                .transpose()
-                .context("parsing agents.subagents.budget")?,
-        };
         Ok(agents_cmd::AgentLaunchArgs {
             spec: Some(spec),
             prompt: Some(prompt),
             cohort: agents_cmd::CohortLaunchArgs {
                 description: self.description,
-                budget,
-                bg: true,
+                bg: !self.fg,
                 ..Default::default()
             },
             name: self.name,
-            ask: self.ask,
-            yolo: self.yolo,
             model: self.model,
             agent: self.agent,
             effort: self.effort,
@@ -211,10 +199,8 @@ fn reject_launch_flags_without_spec(args: &SubagentLaunchArgs) -> Result<()> {
         || args.model.is_some()
         || args.agent.is_some()
         || args.effort.is_some()
-        || args.ask
-        || args.yolo
-        || args.budget.is_some()
         || args.timeout.is_some()
+        || args.fg
         || args.keep
         || args.description.is_some()
         || args.max_turns.is_some()
@@ -237,6 +223,8 @@ struct ChildReport {
     handle: String,
     kind: String,
     status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     run_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -264,6 +252,7 @@ fn list_children(json: bool, globals: &GlobalFlags) -> Result<()> {
                 name,
                 kind: child.kind.to_string(),
                 status: child.status.as_str().to_owned(),
+                description: child.activity_line(),
                 run_id: run.map(|run| run.run_id.to_string()),
                 run_status: run.map(|run| run.status.as_str().to_owned()),
             }
@@ -277,11 +266,96 @@ fn list_children(json: bool, globals: &GlobalFlags) -> Result<()> {
     }
     let mut table = render::Table::new(["SUBAGENT", "KIND", "STATUS", "RUN"]);
     for child in reports {
+        let detail = child
+            .description
+            .map(|line| render::cell(line).fg(render::palette::muted()));
+        table.card(
+            [
+                render::cell(child.handle),
+                render::cell(child.kind),
+                render::cell(child.status),
+                render::cell(child.run_status.unwrap_or_else(|| "-".to_owned())).dash(),
+            ],
+            detail,
+        );
+    }
+    table.render(&mut render::out()).map_err(Into::into)
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize)]
+struct AgentTypeReport {
+    name: String,
+    source: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    agent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    effort: Option<String>,
+}
+
+impl AgentTypeReport {
+    fn detail(&self) -> String {
+        let Some(agent) = &self.agent else {
+            return "-".to_owned();
+        };
+        let posture = match (self.model.as_deref(), self.effort.as_deref()) {
+            (Some(model), Some(effort)) => Some(format!("{model}@{effort}")),
+            (Some(model), None) => Some(model.to_owned()),
+            (None, Some(effort)) => Some(format!("@{effort}")),
+            (None, None) => None,
+        };
+        posture.map_or_else(|| agent.clone(), |posture| format!("{agent} · {posture}"))
+    }
+}
+
+fn available_types(config: &rimz::config::MachineConfig) -> Vec<AgentTypeReport> {
+    let mut types = rimz::agents::known_kinds()
+        .map(|kind| AgentTypeReport {
+            name: kind.to_owned(),
+            source: "kind",
+            agent: None,
+            model: None,
+            effort: None,
+        })
+        .collect::<Vec<_>>();
+    types.extend(
+        config
+            .agents
+            .profiles
+            .0
+            .iter()
+            .map(|(name, profile)| AgentTypeReport {
+                name: name.clone(),
+                source: "profile",
+                agent: Some(profile.agent.clone()),
+                model: profile.model.clone(),
+                effort: profile.effort.clone(),
+            }),
+    );
+    types.extend(config.agents.commands.0.keys().map(|name| AgentTypeReport {
+        name: name.clone(),
+        source: "command",
+        agent: None,
+        model: None,
+        effort: None,
+    }));
+    types
+}
+
+fn list_types(json: bool) -> Result<()> {
+    let config = rimz::config::MachineConfig::load().context("loading machine config")?;
+    let types = available_types(&config);
+    if json {
+        return render::json_pretty(&types);
+    }
+    let mut table = render::Table::new(["TYPE", "SOURCE", "DETAIL"]);
+    for agent_type in types {
+        let detail = agent_type.detail();
         table.row([
-            render::cell(child.handle),
-            render::cell(child.kind),
-            render::cell(child.status),
-            render::cell(child.run_status.unwrap_or_else(|| "-".to_owned())).dash(),
+            render::cell(agent_type.name),
+            render::cell(agent_type.source),
+            render::cell(detail).dash(),
         ]);
     }
     table.render(&mut render::out()).map_err(Into::into)
@@ -448,6 +522,84 @@ mod tests {
         .args;
 
         assert_eq!(launch, agents.launch);
+    }
+
+    #[test]
+    fn foreground_launch_uses_the_supervised_blocking_path() {
+        let args = parse(&["rimz", "claude", "review this", "--fg"]);
+        let launch = args
+            .launch
+            .into_agent_launch(&rimz::config::SubagentsConfig::default())
+            .expect("launch payload");
+        let agents = AgentsHarness::try_parse_from([
+            "rimz",
+            "claude",
+            "review this",
+            "-p",
+            "--timeout",
+            "30m",
+        ])
+        .expect("parse equivalent agents launch")
+        .args;
+
+        assert_eq!(launch, agents.launch);
+    }
+
+    #[test]
+    fn unattended_launch_flags_are_rejected() {
+        for args in [
+            &["rimz", "claude", "review this", "--ask"][..],
+            &["rimz", "claude", "review this", "--yolo"],
+            &["rimz", "claude", "review this", "--budget", "5"],
+        ] {
+            assert!(
+                Harness::try_parse_from(args).is_err(),
+                "{args:?} must not be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn available_types_include_kinds_profiles_and_commands_but_not_teams() {
+        let mut config = rimz::config::MachineConfig::default();
+        config.agents.profiles.0.insert(
+            "planner".to_owned(),
+            rimz::config::Profile {
+                agent: "claude".to_owned(),
+                mode: None,
+                model: Some("fable".to_owned()),
+                effort: Some("high".to_owned()),
+                budget: None,
+                system_prompt_file: None,
+                append_system_prompt_files: Vec::new(),
+                args: None,
+            },
+        );
+        config
+            .agents
+            .commands
+            .0
+            .insert("mytool".to_owned(), "mytool --chat".to_owned());
+        config
+            .agents
+            .teams
+            .0
+            .insert("review".to_owned(), rimz::config::Team::default());
+
+        let types = available_types(&config);
+
+        assert!(types.iter().any(|entry| entry.source == "kind"));
+        assert!(types.iter().any(|entry| {
+            entry.name == "planner"
+                && entry.source == "profile"
+                && entry.detail() == "claude · fable@high"
+        }));
+        assert!(
+            types
+                .iter()
+                .any(|entry| entry.name == "mytool" && entry.source == "command")
+        );
+        assert!(!types.iter().any(|entry| entry.name == "review"));
     }
 
     #[test]

--- a/crates/rimz/src/config/agents.rs
+++ b/crates/rimz/src/config/agents.rs
@@ -57,16 +57,12 @@ const fn default_max_launch_depth() -> u8 {
 pub struct SubagentsConfig {
     /// Supervised-run deadline in the CLI duration syntax (`30m`, `2h`).
     pub timeout: String,
-    /// Optional per-child spend cap (`5` or `20/day`).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub budget: Option<String>,
 }
 
 impl Default for SubagentsConfig {
     fn default() -> Self {
         Self {
             timeout: "30m".to_owned(),
-            budget: None,
         }
     }
 }

--- a/crates/rimz/src/config/templates/agents.template.toml
+++ b/crates/rimz/src/config/templates/agents.template.toml
@@ -29,7 +29,6 @@
 
 [agents.subagents]
 # timeout = "30m"                      # wall-clock deadline for supervised child runs
-# Add `budget = "5"` for an optional child cap; `"20/day"` makes it a daily cap.
 
 [agents.profiles]
 # Profiles are named main agents addressed as `@<profile>`. `agent` names a

--- a/crates/rimz/src/config/tests.rs
+++ b/crates/rimz/src/config/tests.rs
@@ -736,22 +736,23 @@ fn agent_launch_depth_defaults_and_parses_machine_override() {
 fn subagent_launch_defaults_parse_and_round_trip() {
     let defaulted: AgentsConfig = toml::from_str("").expect("parse defaults");
     assert_eq!(defaulted.subagents.timeout, "30m");
-    assert_eq!(defaulted.subagents.budget, None);
 
     let parsed: AgentsConfig = toml::from_str(
         "[subagents]\n\
-         timeout = \"45m\"\n\
-         budget = \"5/day\"\n",
+         timeout = \"45m\"\n",
     )
     .expect("parse subagent defaults");
     assert_eq!(parsed.subagents.timeout, "45m");
-    assert_eq!(parsed.subagents.budget.as_deref(), Some("5/day"));
 
     let encoded = toml::to_string(&parsed).expect("serialize agents");
     assert_eq!(
         toml::from_str::<AgentsConfig>(&encoded).expect("round-trip agents"),
         parsed
     );
+
+    let error = toml::from_str::<AgentsConfig>("[subagents]\nbudget = \"5/day\"\n")
+        .expect_err("removed subagent budget");
+    assert!(error.to_string().contains("unknown field `budget`"));
 }
 
 #[test]

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -442,10 +442,9 @@ An agent that runs `rimz agents` or [`rimz subagents`](../reference/cli/subagent
 ```toml
 [agents.subagents]
 timeout = "30m"
-# budget = "5"       # optional per-child cap; "20/day" also works
 ```
 
-These defaults apply only to the agent-only `rimz subagents` doorway. `timeout` is the wall-clock limit for each supervised child and defaults to 30 minutes; the producer enforces it even when no process is waiting on the result. No budget cap is set by default. Per-launch `--timeout` and `--budget` flags override this table.
+These defaults apply only to the agent-only `rimz subagents` doorway. `timeout` is the wall-clock limit for each supervised child and defaults to 30 minutes; the producer enforces it even when no process is waiting on the result. Per-launch `--timeout` overrides this table.
 
 ### Worktrees
 

--- a/docs/guide/scripting.md
+++ b/docs/guide/scripting.md
@@ -141,7 +141,7 @@ A reference is the printed name, a run id, or any [agent address](./messaging.md
 
 ## Agents scripting agents
 
-`rimz agents -p` is a plain shell command, and agents have shell tools — so the caller does not have to be you. `rimz subagents` packages that path for a RimZ-launched agent: it supplies supervised print mode and background execution, inherits the caller's checkout, and prints a petname for the later join. Claude can hand its diff to Codex for a second opinion, Codex can hand a stubborn bug to Claude, and a planner can fan an audit across three runs. The calling agent sees only commands and durable answers, so subagents mix providers freely; pairing model strengths this way is the same economics that makes [teams](./teams.md) work.
+`rimz agents -p` is a plain shell command, and agents have shell tools — so the caller does not have to be you. `rimz subagents` packages that path for a RimZ-launched agent: it supplies supervised print mode, runs in the background by default or waits with `--fg`, inherits the caller's checkout, and prints a petname for a later join after a background launch. Claude can hand its diff to Codex for a second opinion, Codex can hand a stubborn bug to Claude, and a planner can fan an audit across three runs. The calling agent sees only commands and durable answers, so subagents mix providers freely; pairing model strengths this way is the same economics that makes [teams](./teams.md) work.
 
 ```sh
 # inside a Claude turn, via its shell tool: a cross-provider review

--- a/docs/reference/cli/subagents.md
+++ b/docs/reference/cli/subagents.md
@@ -12,22 +12,30 @@ rimz subagents codex "find the smallest safe fix"
 rimz subagents launch reviewer "review the proposed API"
 ```
 
-Each launch is equivalent to a one-cell `rimz agents <spec> <prompt> -p --bg` run with a timeout. It prints the minted petname immediately, so a parent can start several children without waiting between launches.
+Each launch is equivalent to a one-cell `rimz agents <spec> <prompt> -p --bg` run with a timeout. It prints the minted petname immediately, so a parent can start several children without waiting between launches. Pass `--fg` to block until the child finishes and print its result instead.
 
 The bare form and `launch` verb are equivalent. A prompt is mandatory: the parent must supply the whole assignment as the second positional argument. The child inherits the parent's current checkout and lane.
 
 | Behavior | Default | Override |
 | --- | --- | --- |
-| Execution | supervised print mode, background | fixed |
+| Execution | supervised print mode, background | `--fg` blocks and prints the result |
 | Checkout | caller's current checkout | fixed |
 | Deadline | 30 minutes | `--timeout`, then `[agents.subagents] timeout` |
-| Spend cap | none | `--budget`, then `[agents.subagents] budget` |
 | Pane after completion | close | `--keep` |
 | Address | minted petname | `--name/-n` |
 
 The launch surface deliberately omits `--worktree`, `--from-pr`, `--channel`, `--stdin`, `--top-level`, `--resume`, placement flags, output/input formats, retries, and verification. Use `rimz agents` when the launch needs those controls; use `rimz teams` when the workers are peers rather than children.
 
-Model, provider/profile rebasing, effort, permission posture, description, turn cap, and raw provider arguments remain available. Run `rimz subagents launch --help` for their exact spellings.
+Model, provider/profile rebasing, effort, description, turn cap, and raw provider arguments remain available. Run `rimz subagents launch --help` for their exact spellings.
+
+## Discover agent types
+
+```sh
+rimz subagents types
+rimz subagents types --json
+```
+
+`types` lists every agent kind, configured profile, and configured launch command available for one child. Team names are excluded because a subagent launch creates one agent, not a cohort.
 
 ## Join results
 
@@ -52,7 +60,7 @@ rimz subagents stop calm-fox
 rimz subagents stop --all
 ```
 
-Bare `rimz subagents` lists the caller's children, including retained completed children, with live status and the newest supervised-run outcome. `stop` accepts only live children of the caller.
+Bare `rimz subagents` lists the caller's children, including retained completed children, with live status, the newest supervised-run outcome, and each child's current one-line description. `stop` accepts only live children of the caller.
 
 `restart` and `resume` are deliberately absent in v1: the durable run record does not yet retain every launch argument needed to reproduce the supervised deadline, wait, and self-close contracts. Relaunch the same spec and prompt to start a fresh child, matching the Agent-tool model.
 
@@ -73,7 +81,6 @@ Provider-native children and RimZ-launched pane-backed children share the produc
 ```toml
 [agents.subagents]
 timeout = "30m"
-# budget = "5"
 ```
 
-`timeout` uses the CLI duration syntax (`s`, `m`, `h`, `d`). The deadline is stored on each run and enforced by the room producer even if the parent never calls `wait`. `budget` accepts a session cap such as `"5"` or a daily cap such as `"20/day"`; leaving it unset means no child-specific cap. Launch flags win over this table.
+`timeout` uses the CLI duration syntax (`s`, `m`, `h`, `d`). The deadline is stored on each run and enforced by the room producer even if the parent never calls `wait`. A stale `budget` key in this table is rejected at config load; spend limits belong to the parent.


### PR DESCRIPTION
## Context

`rimz subagents` is the agent-only doorway over `rimz agents <spec> <prompt> -p --bg`. Its children are unattended, so per-child permission flags and spend caps never fit the model: there is nobody in the child's pane to answer a prompt, and a spend cap belongs to the parent that owns the budget. Three gaps sat alongside that: a parent sometimes wants a synchronous child rather than a petname to join later, the seeded `--description` never reached the children listing, and an agent had no way to ask which specs it may launch.

## Design choices

- The agent-type catalog is a new verb, `rimz subagents types`; bare `rimz subagents` and `list` keep meaning "my children".
- The foreground flag is `--fg`, symmetric with `rimz agents --bg`. It reuses the supervised runner's existing blocking path instead of introducing a second wait implementation.
- Removing `--ask`/`--yolo` removes only the per-launch flags. A child's posture still defaults to `PermissionMode::Auto`, and a spec suffix (`codex-yolo`) or a profile `mode` field still applies through spec compilation.
- The `[agents.subagents] budget` config field goes with the flag. `SubagentsConfig` is `deny_unknown_fields`, so a stale key fails loudly at config load rather than being silently ignored — fail-fast per the house contract, and documented on the reference page.
- `types` lists what one child cell can name: built-in and plugin kinds, profiles, and configured launch commands. Teams are excluded because a subagent launch creates one agent, not a cohort.
- Type enumeration stays local to the subagents command rather than sharing the shell-completion source. The output types genuinely differ, and three small loops beat coupling command output to `CompletionCandidate`.

## Implementation

Breaking surface change: `--ask`, `--yolo`, and `--budget` no longer parse on `rimz subagents`, and `[agents.subagents] budget` is rejected at config load. The pinned CLI surface snapshot records the removals.

`--fg` composes to `bg: !fg` and changes nothing downstream: the supervised runner already binds a run waiter and blocks to the terminal record when a run is not backgrounded, closes the child pane unless `--keep`, prints the child's final message, and propagates the run's exit code. `--timeout` applies unchanged, since the deadline rides on the run record either way.

The `--description` write side was already durable on both `rimz agents` and `rimz subagents`, so the delta is the read side. Children now carry their current one-line activity description — the same selection chain the `rimz agents` cards use, so a child that has named its own session shows that instead of the seed — as a muted card detail bounded to terminal width, and as a field in the `--json` report.

`rimz subagents types [--json]` sits behind the same agent-only gate as the rest of the command. A kind shadowed by a same-named profile lists once, as the profile that actually resolves, so the catalog never advertises a resolution that will not happen.

No deviations from the plan. Verified with the full gate (5567 tests), the regenerated CLI surface snapshot, `docs-links`, and `invariants`.

## Advisories

- `--fg` was not smoke-tested against a live provider in a real multiplexer. Its argument composition is covered by unit tests and the foreground runner it delegates to is unchanged, but the end-to-end path is untried on this branch.
- Any existing config carrying `[agents.subagents] budget` will fail to load until the key is removed. That is the intended fail-fast behavior, not an oversight.
- The children-listing render path has no test of its own; the change there is a builder call and a card detail, and the underlying wrap-and-clip behavior is covered by the render layer's own tests.