### PR TITLE
`rimz subagents fanout`: launch a JSON group of children and join them

### DIFF
--- a/crates/rimz/src/cli/agents_cmd/mod.rs
+++ b/crates/rimz/src/cli/agents_cmd/mod.rs
@@ -50,7 +50,7 @@ use rimz::harness::plan::{
     resolve_fork_placement, resolve_placement, validate_agent_name,
 };
 use rimz::harness::resume::{PostureDegrade, ResumePosture};
-use rimz::harness::run::{PermissionMode, RunRecord, RunStatus};
+use rimz::harness::run::{PermissionMode, RunRecord, RunStatus, SupervisedRunOutcome};
 use rimz::harness::spec::{AgentCell, Cell, LayoutSpec};
 use rimz::ids::{AgentKind, AgentSessionId};
 use rimz::message::{DeliveryGate, gate_open};
@@ -89,9 +89,9 @@ pub(in crate::cli) use stop::StopTracker;
 use stop::stop_agent;
 pub(in crate::cli) use stop::stop_resolved;
 use supervised::OutputFormat;
-use supervised::run::run_print;
+use supervised::run::{run_print, run_supervised};
 use top::{TopArgs, run_top};
-pub(in crate::cli) use wait::wait_agent;
+pub(in crate::cli) use wait::{wait_agent, wait_agent_batch};
 
 const CHILD_SIGNAL_GRACE: Duration = Duration::from_millis(300);
 const CHILD_WAIT_POLL: Duration = Duration::from_millis(25);
@@ -658,6 +658,38 @@ fn dispatch_launch(launch: AgentLaunchArgs, json: bool, globals: &GlobalFlags) -
         );
     }
     launch_layout(args, globals, true)
+}
+
+pub(in crate::cli) struct BackgroundLaunch {
+    pub name: String,
+    pub run_id: rimz::RunId,
+}
+
+pub(in crate::cli) enum BackgroundLaunchOutcome {
+    Launched(BackgroundLaunch),
+    BudgetExceeded { reason: String },
+}
+
+pub(in crate::cli) fn launch_supervised_background(
+    launch: AgentLaunchArgs,
+    globals: &GlobalFlags,
+) -> Result<BackgroundLaunchOutcome> {
+    let args = AgentsArgs::from_launch(launch);
+    let (request, presentation) = into_supervised_request(args)?;
+    match run_supervised(request, presentation, globals)? {
+        SupervisedRunOutcome::Background { agent_name, run_id } => {
+            Ok(BackgroundLaunchOutcome::Launched(BackgroundLaunch {
+                name: agent_name,
+                run_id,
+            }))
+        }
+        SupervisedRunOutcome::BudgetExceeded { reason } => {
+            Ok(BackgroundLaunchOutcome::BudgetExceeded { reason })
+        }
+        SupervisedRunOutcome::Record(_) => {
+            bail!("background supervised launch returned a blocking run record")
+        }
+    }
 }
 
 fn into_supervised_request(

--- a/crates/rimz/src/cli/agents_cmd/tests.rs
+++ b/crates/rimz/src/cli/agents_cmd/tests.rs
@@ -1381,6 +1381,22 @@ fn provider_binding_debug_redacts_account_key() {
     assert!(!format!("{expected:?}").contains("owner"));
 }
 
+#[test]
+fn batch_wait_keeps_labeled_output_for_one_target() {
+    assert!(matches!(
+        wait::WaitStyle::new(1, false, true),
+        wait::WaitStyle::Single { json: true }
+    ));
+    assert_eq!(
+        wait::WaitStyle::batch(true),
+        wait::WaitStyle::All { json: true }
+    );
+    assert_eq!(
+        wait::WaitStyle::batch(false),
+        wait::WaitStyle::All { json: false }
+    );
+}
+
 fn bare_exec_args() -> ExecRequest {
     ExecRequest {
         kind: AgentKind::new_unchecked("codex"),

--- a/crates/rimz/src/cli/agents_cmd/wait.rs
+++ b/crates/rimz/src/cli/agents_cmd/wait.rs
@@ -15,11 +15,11 @@ pub(in crate::cli) fn wait_agent(
     if stream_output && references.len() > 1 {
         bail!("--stream tails one target; wait on a single reference");
     }
-    let ctx = Ctx::open(globals)?;
-    let store = &ctx.store;
-    let snapshot = ctx.cached_snapshot()?;
-    let current_channel = ctx.channel();
     if stream_output {
+        let ctx = Ctx::open(globals)?;
+        let store = &ctx.store;
+        let snapshot = ctx.cached_snapshot()?;
+        let current_channel = ctx.channel();
         let options = WaitStreamOptions {
             timeout,
             from_start,
@@ -34,13 +34,36 @@ pub(in crate::cli) fn wait_agent(
         );
     }
 
+    let style = WaitStyle::new(references.len(), any, json);
+    wait_non_stream_request(references, any, timeout, style, globals)
+}
+
+pub(in crate::cli) fn wait_agent_batch(
+    references: Vec<String>,
+    json: bool,
+    globals: &GlobalFlags,
+) -> Result<()> {
+    wait_non_stream_request(references, false, None, WaitStyle::batch(json), globals)
+}
+
+fn wait_non_stream_request(
+    references: Vec<String>,
+    any: bool,
+    timeout: Option<Duration>,
+    style: WaitStyle,
+    globals: &GlobalFlags,
+) -> Result<()> {
+    let ctx = Ctx::open(globals)?;
+    let store = &ctx.store;
+    let snapshot = ctx.cached_snapshot()?;
+    let current_channel = ctx.channel();
     wait_non_stream(
         store,
         &snapshot,
         references,
         any,
         timeout,
-        json,
+        style,
         current_channel,
     )
 }
@@ -81,14 +104,13 @@ fn wait_non_stream(
     references: Vec<String>,
     any: bool,
     timeout: Option<Duration>,
-    json: bool,
+    style: WaitStyle,
     current_channel: Option<&str>,
 ) -> Result<()> {
     let targets = references
         .iter()
         .map(|reference| resolve_wait_target(store, snapshot, reference, current_channel))
         .collect::<Result<Vec<_>>>()?;
-    let style = WaitStyle::new(targets.len(), any, json);
     let mut waits = WaitSet::new(
         targets,
         if any { JoinMode::Any } else { JoinMode::All },
@@ -112,15 +134,15 @@ fn wait_non_stream(
     }
 }
 
-#[derive(Clone, Copy)]
-enum WaitStyle {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum WaitStyle {
     Single { json: bool },
     Any { json: bool },
     All { json: bool },
 }
 
 impl WaitStyle {
-    fn new(target_count: usize, any: bool, json: bool) -> Self {
+    pub(super) fn new(target_count: usize, any: bool, json: bool) -> Self {
         if target_count == 1 && !any {
             Self::Single { json }
         } else if any {
@@ -128,6 +150,10 @@ impl WaitStyle {
         } else {
             Self::All { json }
         }
+    }
+
+    pub(super) const fn batch(json: bool) -> Self {
+        Self::All { json }
     }
 
     fn report_progress(self, waits: &WaitSet, settled: &[usize]) -> Result<()> {

--- a/crates/rimz/src/cli/snapshots/rimz__cli__surface_tests__cli_surface.snap
+++ b/crates/rimz/src/cli/snapshots/rimz__cli__surface_tests__cli_surface.snap
@@ -991,6 +991,8 @@ rimz help statusline feed [hidden]
 
 rimz help subagents
 
+rimz help subagents fanout
+
 rimz help subagents launch
 
 rimz help subagents list
@@ -2100,7 +2102,22 @@ rimz subagents
     --tmux  [action=set-true takes=0..=0 global]
     --zellij  [action=set-true takes=0..=0 global]
 
+rimz subagents fanout
+    <file>  [action=set takes=1..=1]
+    --bg  [action=set-true takes=0..=0]
+    --color <COLOR>  [action=set takes=1..=1 global default=auto values=auto|always|never]
+    -h, --help  [action=help takes=0..=0]
+    --json  [action=set-true takes=0..=0]
+    --keep  [action=set-true takes=0..=0]
+    --mux <MUX>  [action=set takes=1..=1 global]
+    --root <ROOT>  [action=set takes=1..=1 global]
+    --timeout <TIMEOUT>  [action=set takes=1..=1]
+    --tmux  [action=set-true takes=0..=0 global]
+    --zellij  [action=set-true takes=0..=0 global]
+
 rimz subagents help
+
+rimz subagents help fanout
 
 rimz subagents help help
 

--- a/crates/rimz/src/cli/subagents/mod.rs
+++ b/crates/rimz/src/cli/subagents/mod.rs
@@ -1,11 +1,14 @@
 //! `rimz subagents` — agent-only supervised child launch and lifecycle sugar.
 
-use std::io::Write;
+use std::collections::{BTreeMap, HashSet};
+use std::fs;
+use std::io::{Read, Write};
+use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use clap::{Args, Subcommand};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::{Ctx, GlobalFlags, agents_cmd, render};
 use rimz::agents::AgentState;
@@ -26,6 +29,8 @@ pub struct SubagentsArgs {
 enum SubagentsSubcmd {
     /// Launch one supervised child agent.
     Launch(SubagentLaunchArgs),
+    /// Launch children from a JSON task list and join them.
+    Fanout(FanoutArgs),
     /// List this agent's children.
     #[command(alias = "ls")]
     List {
@@ -65,6 +70,38 @@ enum SubagentsSubcmd {
         #[arg(long, conflicts_with = "names")]
         all: bool,
     },
+}
+
+#[derive(Debug, Args)]
+struct FanoutArgs {
+    /// Tasks JSON; stdin when omitted.
+    #[arg(value_name = "FILE")]
+    file: Option<PathBuf>,
+    /// Launch the children without joining them.
+    #[arg(long)]
+    bg: bool,
+    /// Stop each child after this duration.
+    #[arg(long, value_parser = crate::cli::supervised::parse_timeout)]
+    timeout: Option<Duration>,
+    /// Leave child panes open after completion.
+    #[arg(long)]
+    keep: bool,
+    /// Emit JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct FanoutTask {
+    spec: Option<String>,
+    prompt: Option<String>,
+    name: Option<String>,
+    model: Option<String>,
+    agent: Option<String>,
+    effort: Option<String>,
+    timeout: Option<String>,
+    max_turns: Option<u32>,
+    description: Option<String>,
 }
 
 #[derive(Debug, Default, PartialEq, Args)]
@@ -117,6 +154,7 @@ pub fn run(args: SubagentsArgs, globals: &GlobalFlags) -> Result<()> {
     require_agent_caller(crate::cli::send::agent_caller())?;
     match args.command {
         Some(SubagentsSubcmd::Launch(launch)) => launch_child(launch, globals),
+        Some(SubagentsSubcmd::Fanout(fanout)) => fanout_children(fanout, globals),
         Some(SubagentsSubcmd::List { json }) => list_children(json, globals),
         Some(SubagentsSubcmd::Types { json }) => list_types(json),
         Some(SubagentsSubcmd::Wait {
@@ -153,6 +191,152 @@ fn launch_child(args: SubagentLaunchArgs, globals: &GlobalFlags) -> Result<()> {
     let config = rimz::config::MachineConfig::load().context("loading machine config")?;
     let launch = args.into_agent_launch(&config.agents.subagents)?;
     agents_cmd::run(agents_cmd::AgentsArgs::from_launch(launch), globals)
+}
+
+fn fanout_children(args: FanoutArgs, globals: &GlobalFlags) -> Result<()> {
+    let (raw, source) = match args.file.as_deref() {
+        Some(path) => (
+            fs::read_to_string(path)
+                .with_context(|| format!("reading fanout tasks from `{}`", path.display()))?,
+            format!("`{}`", path.display()),
+        ),
+        None => {
+            let mut raw = String::new();
+            std::io::stdin()
+                .read_to_string(&mut raw)
+                .context("reading fanout tasks from stdin")?;
+            (raw, "stdin".to_owned())
+        }
+    };
+    let config = rimz::config::MachineConfig::load().context("loading machine config")?;
+    let launches = parse_fanout_launches(&raw, &args, &config.agents.subagents)
+        .with_context(|| format!("validating fanout tasks from {source}"))?;
+    let mut launched = Vec::with_capacity(launches.len());
+    for (index, launch) in launches.into_iter().enumerate() {
+        match agents_cmd::launch_supervised_background(launch, globals) {
+            Ok(agents_cmd::BackgroundLaunchOutcome::Launched(child)) => {
+                if !args.json {
+                    writeln!(render::out(), "{}", child.name)?;
+                }
+                launched.push(child);
+            }
+            Ok(agents_cmd::BackgroundLaunchOutcome::BudgetExceeded { reason }) => {
+                let err = anyhow::Error::msg(reason)
+                    .context(fanout_launch_error_context(index, &launched));
+                render::report(&err);
+                std::process::exit(rimz::harness::run::RunStatus::BudgetExceeded.exit_code());
+            }
+            Err(err) => {
+                return Err(err).context(fanout_launch_error_context(index, &launched));
+            }
+        }
+    }
+    if args.bg {
+        if args.json {
+            #[derive(Serialize)]
+            struct BackgroundReport<'a> {
+                run_id: &'a rimz::RunId,
+            }
+
+            let report = launched
+                .iter()
+                .map(|child| {
+                    (
+                        child.name.as_str(),
+                        BackgroundReport {
+                            run_id: &child.run_id,
+                        },
+                    )
+                })
+                .collect::<BTreeMap<_, _>>();
+            render::json(&report)?;
+        }
+        return Ok(());
+    }
+    let names = launched.into_iter().map(|child| child.name).collect();
+    agents_cmd::wait_agent_batch(names, args.json, globals)
+}
+
+fn fanout_launch_error_context(index: usize, launched: &[agents_cmd::BackgroundLaunch]) -> String {
+    if launched.is_empty() {
+        return format!("launching fanout task {}", index + 1);
+    }
+    let names = launched
+        .iter()
+        .map(|child| child.name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "launching fanout task {} after starting {names}; the launched children keep running, so join or stop them with `rimz subagents wait` or `rimz subagents stop --all`",
+        index + 1
+    )
+}
+
+fn parse_fanout_launches(
+    raw: &str,
+    args: &FanoutArgs,
+    defaults: &rimz::config::SubagentsConfig,
+) -> Result<Vec<agents_cmd::AgentLaunchArgs>> {
+    let tasks: Vec<FanoutTask> =
+        serde_json::from_str(raw).context("fanout input must be a JSON task array")?;
+    if tasks.is_empty() {
+        bail!("fanout needs at least one task");
+    }
+    let mut names = HashSet::new();
+    for (index, task) in tasks.iter().enumerate() {
+        if let Some(name) = task.name.as_deref() {
+            rimz::harness::plan::validate_agent_name(name)
+                .with_context(|| format!("task {} ({name})", index + 1))?;
+            if !names.insert(name) {
+                bail!("task {} repeats child name `{name}`", index + 1);
+            }
+        }
+    }
+    tasks
+        .into_iter()
+        .enumerate()
+        .map(|(index, task)| {
+            let label = task
+                .name
+                .as_deref()
+                .map(|name| format!(" ({name})"))
+                .unwrap_or_default();
+            task.into_agent_launch(args, defaults)
+                .with_context(|| format!("task {}{label}", index + 1))
+        })
+        .collect()
+}
+
+impl FanoutTask {
+    fn into_agent_launch(
+        self,
+        fanout: &FanoutArgs,
+        defaults: &rimz::config::SubagentsConfig,
+    ) -> Result<agents_cmd::AgentLaunchArgs> {
+        let timeout = self
+            .timeout
+            .as_deref()
+            .map(crate::cli::supervised::parse_timeout)
+            .transpose()
+            .map_err(anyhow::Error::msg)
+            .context("parsing timeout")?
+            .or(fanout.timeout);
+        SubagentLaunchArgs {
+            spec: self.spec,
+            prompt: self.prompt,
+            name: self.name,
+            model: self.model,
+            agent: self.agent,
+            effort: self.effort,
+            timeout,
+            bg: true,
+            keep: fanout.keep,
+            description: self.description,
+            max_turns: self.max_turns,
+            passthrough: Vec::new(),
+        }
+        .into_agent_launch(defaults)
+    }
 }
 
 impl SubagentLaunchArgs {
@@ -554,6 +738,138 @@ mod tests {
     }
 
     #[test]
+    fn fanout_task_matches_the_single_launch_surface() {
+        let fanout = parse(&[
+            "rimz",
+            "fanout",
+            "tasks.json",
+            "--timeout",
+            "10m",
+            "--keep",
+            "--bg",
+            "--json",
+        ]);
+        let Some(SubagentsSubcmd::Fanout(fanout)) = fanout.command else {
+            panic!("fanout command");
+        };
+        assert_eq!(fanout.file, Some(PathBuf::from("tasks.json")));
+        assert!(fanout.bg);
+        assert!(fanout.json);
+        let launches = parse_fanout_launches(
+            r#"[{
+                "spec": "claude",
+                "prompt": "review this",
+                "name": "auth-review",
+                "model": "opus",
+                "agent": "reviewer",
+                "effort": "high",
+                "timeout": "5m",
+                "max_turns": 4,
+                "description": "checks auth"
+            }]"#,
+            &fanout,
+            &rimz::config::SubagentsConfig::default(),
+        )
+        .expect("fanout launch");
+        let agents = AgentsHarness::try_parse_from([
+            "rimz",
+            "claude",
+            "review this",
+            "--name",
+            "auth-review",
+            "--model",
+            "opus",
+            "--agent",
+            "reviewer",
+            "--effort",
+            "high",
+            "--timeout",
+            "5m",
+            "--max-turns",
+            "4",
+            "--description",
+            "checks auth",
+            "--keep",
+            "-p",
+            "--bg",
+        ])
+        .expect("parse equivalent agents launch")
+        .args;
+        let mut agents = agents;
+        agents.launch.self_cleanup_on_completion = true;
+
+        assert_eq!(launches, vec![agents.launch]);
+    }
+
+    #[test]
+    fn fanout_timeout_precedence_is_task_then_flag_then_config() {
+        let Some(SubagentsSubcmd::Fanout(flagged)) =
+            parse(&["rimz", "fanout", "--timeout", "10m"]).command
+        else {
+            panic!("fanout command");
+        };
+        let defaults = rimz::config::SubagentsConfig {
+            timeout: "20m".to_owned(),
+        };
+
+        let task = parse_fanout_launches(
+            r#"[{"spec":"codex","prompt":"one","timeout":"5m"}]"#,
+            &flagged,
+            &defaults,
+        )
+        .expect("task timeout");
+        assert_eq!(task[0].timeout, Some(Duration::from_secs(5 * 60)));
+
+        let flag =
+            parse_fanout_launches(r#"[{"spec":"codex","prompt":"one"}]"#, &flagged, &defaults)
+                .expect("flag timeout");
+        assert_eq!(flag[0].timeout, Some(Duration::from_secs(10 * 60)));
+
+        let Some(SubagentsSubcmd::Fanout(unflagged)) = parse(&["rimz", "fanout"]).command else {
+            panic!("fanout command");
+        };
+        let config = parse_fanout_launches(
+            r#"[{"spec":"codex","prompt":"one"}]"#,
+            &unflagged,
+            &defaults,
+        )
+        .expect("config timeout");
+        assert_eq!(config[0].timeout, Some(Duration::from_secs(20 * 60)));
+    }
+
+    #[test]
+    fn fanout_validates_the_whole_task_list_before_launch() {
+        let Some(SubagentsSubcmd::Fanout(fanout)) = parse(&["rimz", "fanout"]).command else {
+            panic!("fanout command");
+        };
+        let defaults = rimz::config::SubagentsConfig::default();
+
+        let empty = parse_fanout_launches("[]", &fanout, &defaults).expect_err("empty task list");
+        assert!(empty.to_string().contains("at least one task"));
+
+        let missing_prompt =
+            parse_fanout_launches(r#"[{"spec":"codex","name":"auth"}]"#, &fanout, &defaults)
+                .expect_err("missing prompt");
+        assert!(format!("{missing_prompt:#}").contains("task 1 (auth)"));
+        assert!(format!("{missing_prompt:#}").contains("prompt from the parent"));
+
+        let duplicate = parse_fanout_launches(
+            r#"[
+                {"spec":"codex","prompt":"one","name":"auth"},
+                {"spec":"claude","prompt":"two","name":"auth"}
+            ]"#,
+            &fanout,
+            &defaults,
+        )
+        .expect_err("duplicate name");
+        assert!(
+            duplicate
+                .to_string()
+                .contains("task 2 repeats child name `auth`")
+        );
+    }
+
+    #[test]
     fn unattended_launch_flags_are_rejected() {
         for args in [
             &["rimz", "claude", "review this", "--ask"][..],
@@ -715,6 +1031,14 @@ mod tests {
 
     #[test]
     fn lifecycle_verbs_parse() {
+        assert!(matches!(
+            parse(&["rimz", "fanout", "tasks.json", "--bg"]).command,
+            Some(SubagentsSubcmd::Fanout(FanoutArgs {
+                bg: true,
+                file: Some(_),
+                ..
+            }))
+        ));
         assert!(matches!(
             parse(&["rimz", "wait", "swift-otter", "--any"]).command,
             Some(SubagentsSubcmd::Wait { any: true, .. })

--- a/crates/rimz/src/cli/supervised/run.rs
+++ b/crates/rimz/src/cli/supervised/run.rs
@@ -103,7 +103,10 @@ pub(in crate::cli) fn run_print(
     let output_format = presentation.output_format;
     let record = match run_supervised(request, presentation, globals)? {
         SupervisedRunOutcome::Record(record) => Some(*record),
-        SupervisedRunOutcome::Background => None,
+        SupervisedRunOutcome::Background { agent_name, .. } => {
+            writeln!(render::out(), "{agent_name}")?;
+            None
+        }
         SupervisedRunOutcome::BudgetExceeded { reason } => {
             render::report(&anyhow::anyhow!(reason));
             std::process::exit(RunStatus::BudgetExceeded.exit_code());
@@ -145,6 +148,14 @@ struct PreparedRun {
 struct PresentationWaiter {
     waiter: run_wake::RunWaiter,
     stream_cursor: Option<TranscriptCursor>,
+}
+
+enum AttemptOutcome {
+    Background {
+        agent_name: String,
+        run_id: rimz::RunId,
+    },
+    Blocking(Box<BlockingAttempt>),
 }
 
 impl PresentationWaiter {
@@ -429,7 +440,7 @@ fn execute_attempt(
     retry_of: Option<&rimz::RunId>,
     attempt: u32,
     retries: u32,
-) -> Result<Option<BlockingAttempt>> {
+) -> Result<AttemptOutcome> {
     let agent_cell = prepared
         .layout
         .agent_cells()
@@ -518,11 +529,10 @@ fn execute_attempt(
     rimz::harness::run::create(prepared.store.paths(), &record).context("recording run")?;
     open_attempt_pane(prepared, room, request, &run_id, &launch_batch, &pane)?;
     if request.background {
-        #[expect(clippy::print_stdout, reason = "command result is the agent name")]
-        {
-            println!("{}", launch_identity.name);
-        }
-        return Ok(None);
+        return Ok(AttemptOutcome::Background {
+            agent_name: launch_identity.name.clone(),
+            run_id,
+        });
     }
     let Some(waiter) = waiter else {
         bail!("blocking run did not bind its completion waiter");
@@ -533,7 +543,10 @@ fn execute_attempt(
             .then(|| TranscriptCursor::new(true)),
     };
     let record = waiter.await_terminal(prepared, room, request)?;
-    Ok(Some(BlockingAttempt { record, waiter }))
+    Ok(AttemptOutcome::Blocking(Box::new(BlockingAttempt {
+        record,
+        waiter,
+    })))
 }
 
 fn verify_phase(
@@ -716,7 +729,7 @@ pub(in crate::cli) fn run_supervised(
         ) {
             return Ok(SupervisedRunOutcome::BudgetExceeded { reason });
         }
-        let Some(blocking) = execute_attempt(
+        let attempt_outcome = execute_attempt(
             &prepared,
             &room,
             &request,
@@ -724,9 +737,12 @@ pub(in crate::cli) fn run_supervised(
             retry_of.as_ref(),
             attempt,
             retries,
-        )?
-        else {
-            return Ok(SupervisedRunOutcome::Background);
+        )?;
+        let blocking = match attempt_outcome {
+            AttemptOutcome::Background { agent_name, run_id } => {
+                return Ok(SupervisedRunOutcome::Background { agent_name, run_id });
+            }
+            AttemptOutcome::Blocking(blocking) => *blocking,
         };
         let (record, verify_error, waiter) = verify_phase(&prepared, &room, &request, blocking)?;
         if !request.keep {

--- a/crates/rimz/src/harness/run.rs
+++ b/crates/rimz/src/harness/run.rs
@@ -110,7 +110,7 @@ pub struct SupervisedRunRequest {
 #[derive(Debug)]
 pub enum SupervisedRunOutcome {
     Record(Box<RunRecord>),
-    Background,
+    Background { agent_name: String, run_id: RunId },
     BudgetExceeded { reason: String },
 }
 

--- a/crates/rimz/src/harness/schedule/runner.rs
+++ b/crates/rimz/src/harness/schedule/runner.rs
@@ -779,7 +779,9 @@ fn finish_spawn_effect(
                 TaskFireNotice::None,
             )
         }
-        SupervisedRunOutcome::Background => (LoopRunPresentation::default(), TaskFireNotice::None),
+        SupervisedRunOutcome::Background { .. } => {
+            (LoopRunPresentation::default(), TaskFireNotice::None)
+        }
         SupervisedRunOutcome::BudgetExceeded { reason } => {
             record.result = LoopRunResult::BudgetSkipped;
             record.error = Some(reason.clone());

--- a/docs/guide/scripting.md
+++ b/docs/guide/scripting.md
@@ -141,14 +141,20 @@ A reference is the printed name, a run id, or any [agent address](./messaging.md
 
 ## Agents scripting agents
 
-`rimz agents -p` is a plain shell command, and agents have shell tools — so the caller does not have to be you. `rimz subagents` packages that path for a RimZ-launched agent: it supplies supervised print mode, waits for the result by default or returns a petname immediately with `--bg`, and inherits the caller's checkout. Claude can hand its diff to Codex for a second opinion, Codex can hand a stubborn bug to Claude, and a planner can fan an audit across three runs. The calling agent sees only commands and durable answers, so subagents mix providers freely; pairing model strengths this way is the same economics that makes [teams](./teams.md) work.
+`rimz agents -p` is a plain shell command, and agents have shell tools — so the caller does not have to be you. `rimz subagents` packages that path for a RimZ-launched agent: a single launch waits for its result by default or returns a petname with `--bg`, while `fanout` launches a JSON task array and joins the whole group by default. Both inherit the caller's checkout. Claude can hand its diff to Codex for a second opinion, Codex can hand a stubborn bug to Claude, and a planner can fan an audit across three runs. The calling agent sees only commands and durable answers, so subagents mix providers freely; pairing model strengths this way is the same economics that makes [teams](./teams.md) work.
 
 ```sh
-# inside a Claude turn, via its shell tool: a cross-provider review
-reviewer=$(rimz subagents codex 'review the current diff; reply SHIP or HOLD, with reasons' --bg)
-# ... do other work or launch more children ...
-rimz subagents wait "$reviewer"
+# inside a planner turn: launch three bounded audits, then join all three
+rimz subagents fanout <<'JSON'
+[
+  {"spec":"codex","prompt":"review correctness; report concrete findings"},
+  {"spec":"claude","prompt":"review the interface; report concrete findings"},
+  {"spec":"codex","prompt":"review test coverage; report concrete findings"}
+]
+JSON
 ```
+
+Each child gets its own deadline and durable run record. Pane opens serialize safely, but the audits run in parallel; the command reports one labeled outcome per child and exits nonzero if any child fails. Add `--bg` to scatter without joining, then use `rimz subagents wait` when the parent is ready for the results. The full task schema and timeout precedence are in the [`subagents` reference](../reference/cli/subagents.md#launch-and-fan-out-work).
 
 Compare that with an agent's built-in subagents, which run headless inside the parent's harness. A RimZ-launched child is a first-class member of your room: its own pane, a nested sidebar row, a transcript that outlives the turn, and a question that routes to you instead of failing silently. Use `rimz agents -p` directly when the child needs controls the tailored doorway omits, such as `--stdin` or a separate worktree. When the task belongs to a teammate that is already running, hand it over with [`rimz message`](./messaging.md) instead of spawning a fresh turn.
 

--- a/docs/internals/harness/subagents.md
+++ b/docs/internals/harness/subagents.md
@@ -48,6 +48,18 @@ The default has the user-visible behavior of `rimz agents <spec> <prompt> -p --t
 
 The doorway deliberately omits `--worktree`, `--from-pr`, `--channel`, `--stdin`, `--top-level`, `--resume`, placement flags, output and input formats, retries, and verification. Each of those needs a decision the delegating agent is not well placed to make, and each is still reachable by calling `rimz agents` directly. `types` lists kinds, profiles, and configured commands but never teams, because one launch produces one agent rather than a cohort.
 
+## Fanout is repeated single-launch plus an exact join
+
+`rimz subagents fanout` accepts a JSON array and desugars every entry through the same `SubagentLaunchArgs::into_agent_launch` path above. Task `timeout` wins over the fanout flag, which wins over the configured default. Fanout-level `keep` applies uniformly; per-task foreground, retention, and passthrough argv are not part of the data format.
+
+Parsing, required fields, timeout syntax, and duplicate explicit names are validated across the entire array before the first side effect. Pane opens then happen sequentially in the caller process. This avoids racing two backend split operations against the same ambient pane, while the child processes themselves run in parallel as soon as each pane opens.
+
+The supervised runner's background outcome carries the minted petname and run ID back to `agents_cmd`; the ordinary single-launch presentation prints the petname there, while fanout collects the identities directly. This avoids rediscovering children from a before/after store snapshot, which could confuse another launch racing in the same family.
+
+Without `--bg`, fanout passes the collected petnames to `agents_cmd::wait_agent_batch` as one explicit set. The normal multi-target wait renderer and aggregate exit code therefore own fanout results too. With `--bg`, the command returns after the launch loop and can render the collected run IDs as JSON.
+
+A runtime failure during that loop aborts the remaining launches and reports every child already started. Those children are not rolled back: their durable run records, deadlines, self-cleanup, and caller-scoped `wait`/`stop` behavior remain the ordinary supervised lifecycle. Validation failures are different — because desugaring completed before the loop, they launch nothing.
+
 ## Ancestry, depth, and flattening
 
 Ancestry resolves in [`plan.rs`](../../../crates/rimz/src/harness/plan.rs) as step 4 of [the compile path](./fleet.md#from-spec-to-panes) — **before** provider preflight, worktree creation, store append, or any mux action, so a refusal leaves nothing behind.
@@ -66,6 +78,8 @@ launch_depth    = current_depth + 1                           ← true
 That third line is the whole flattening rule. A child inherits *its caller's* parent when the caller has one, and only otherwise points at the caller. So a grandchild is stamped with the same top-level parent as its parent, while `launch_depth` keeps counting honestly. True depth stays available for the cap; display ancestry collapses to one level of nesting under the original top-level agent.
 
 `[agents] max-launch-depth` ([`config/agents.rs`](../../../crates/rimz/src/config/agents.rs)) defaults to `1`. With an unstamped top-level agent reading as depth 0, that permits children and refuses grandchildren.
+
+Fanout does not change that accounting: each array entry is one ordinary launch from the same caller. At the default cap, a top-level agent may fan out, but any child attempting its own fanout is refused before the first task launches.
 
 `--top-level` is the escape hatch, and it short-circuits ahead of everything above: no caller resolution, no store projection read, no depth check, no parent stamp. It is a `rimz agents` flag only. `rimz subagents` never sets it, so a child launched through this doorway cannot escape ancestry — which is what makes the depth cap meaningful against an agent that is itself writing the command line.
 

--- a/docs/reference/cli/subagents.md
+++ b/docs/reference/cli/subagents.md
@@ -7,6 +7,37 @@ Run it only from a RimZ-launched agent. A user-shell invocation fails before ope
 ## Launch and fan out work
 
 ```sh
+rimz subagents fanout tasks.json
+printf '%s\n' '[{"spec":"codex","prompt":"find the smallest safe fix"}]' \
+  | rimz subagents fanout
+rimz subagents fanout tasks.json --bg
+```
+
+`fanout` reads a JSON task array from `FILE`, or from stdin when `FILE` is omitted. It validates the whole list, opens each child pane in sequence, and then joins exactly those children. The children run in parallel after their panes open. Each minted petname prints as it launches; the final lines report each child's durable outcome. The command exits nonzero if any child does.
+
+Use `--bg` to return after launching instead of joining. In text mode it prints one petname per line. With `--bg --json`, it emits a map from petname to `run_id`; without `--bg`, `--json` emits the same result map as `rimz subagents wait --json`.
+
+Each array entry has the single-launch fields that make sense for data-driven delegation:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `spec` | yes | Agent kind or configured profile |
+| `prompt` | yes | Complete task supplied by the parent |
+| `name` | no | Durable child petname |
+| `model` | no | Model override |
+| `agent` | no | Profile or provider-kind rebase |
+| `effort` | no | Reasoning effort |
+| `timeout` | no | This child's deadline |
+| `max_turns` | no | Maximum agentic turns |
+| `description` | no | Initial child-card description |
+
+Explicit names must be unique within the list. A task timeout overrides the fanout-level `--timeout`, which overrides `[agents.subagents] timeout` (30 minutes by default). `--keep` applies to every child. Per-task raw argv, foreground mode, and pane retention are deliberately omitted; use profiles for provider arguments or separate single launches when children need different lifecycle controls.
+
+All tasks are validated before the first launch. If a runtime failure occurs after some children have started, the error names them; they keep their normal deadline and cleanup behavior and remain available to `subagents wait` and `subagents stop`.
+
+## Launch one child
+
+```sh
 rimz subagents claude "trace the authentication call path"
 ```
 
@@ -30,7 +61,7 @@ The bare form and `launch` verb are equivalent. A prompt is mandatory: the paren
 
 A finished child's in-pane wrapper closes its pane from the durable terminal record, independently of the parent waiting for the result. `--keep` opts out and leaves the pane for `stop` or `rimz gc`.
 
-The launch surface deliberately omits `--worktree`, `--from-pr`, `--channel`, `--stdin`, `--top-level`, `--resume`, placement flags, output/input formats, retries, and verification. Use `rimz agents` when the launch needs those controls; use `rimz teams` when the workers are peers rather than children.
+The single-launch surface deliberately omits `--worktree`, `--from-pr`, `--channel`, `--stdin`, `--top-level`, `--resume`, placement flags, output/input formats, retries, and verification. Use `rimz agents` when the launch needs those controls; use `rimz teams` when the workers are peers rather than children.
 
 Model, provider/profile rebasing, effort, description, turn cap, and raw provider arguments remain available. Run `rimz subagents launch --help` for their exact spellings.
 


### PR DESCRIPTION
## Context

`rimz subagents` launches one supervised child per invocation. A delegating agent that wants N parallel children has to run the command N times, collect the printed petnames itself, and then call `rimz subagents wait`. This adds `fanout`, which makes scatter–gather one command: read a JSON task list, launch every task as a supervised child, join them all, and report per-child results.

## Design choices

**Input surface.** The spec is a positional `[FILE]` with stdin fallback, mirroring `rimz answer --json [FILE]`, rather than `--file`/`--stdin` flags. The JSON is a plain task array — one object per child, mirroring the single-launch flag surface — with no `{defaults, tasks}` envelope.

**Join by default.** `fanout` launches all and joins all; `--bg` scatters only. This deliberately inverts the single-launch background default, because the join is the point of the verb.

**Sequential launches, parallel runs.** Children launch one at a time in-process so each pane open completes before the next begins, avoiding an unverified race between concurrent backend split operations against the same ambient pane. The children themselves run in parallel as soon as their panes open.

**One meaning for `--timeout`.** It stays the per-child run deadline; there is no separate join deadline, because every child's deadline is enforced by the room producer. Precedence is task `timeout` > `--timeout` > `[agents.subagents] timeout`.

**Validate everything, then launch.** Parsing, required fields, timeout syntax, and explicit-name uniqueness are checked across the whole array before the first side effect, so a bad task list launches nothing. A runtime failure mid-batch aborts the fanout and names the children already started; they are not rolled back and keep their ordinary deadlines and self-cleanup.

**Deliberate omissions.** Per-task passthrough argv, `fg`, and `keep` are not in the data format — raw argv in a data file is a footgun and reachable through configured profiles, while foreground and pane retention are fanout-level concerns.

## Implementation

`SupervisedRunOutcome::Background` now carries the minted `agent_name` and `run_id` instead of discarding them, and the petname print moves out of `execute_attempt` into `run_print`. That keeps every existing caller's stdout byte-for-byte while letting fanout collect identities in-process, rather than diffing a before/after store snapshot — which would race against another launch in the same family. `agents_cmd` publishes two entries for the new verb: `launch_supervised_background`, which reuses the single-launch supervised request path, and `wait_agent_batch`, which pins the multi-target renderer.

That second entry exists because deriving the wait style from target count would make a one-task fanout render as a single-target wait: the child's full result body in text, a bare run record under `--json`. A batch verb's output shape must not depend on its batch size, so `wait_agent_batch` forces the labeled shape at every cardinality while `rimz agents wait` and `rimz subagents wait` keep the count-derived default. A budget gate reaching fanout likewise preserves exit `125` rather than collapsing to a generic failure.

Every task funnels through the existing `SubagentLaunchArgs::into_agent_launch`, so a fanout entry and an equivalent single launch desugar identically by construction — pinned by a parity test against the equivalent `rimz agents … -p --bg` argv.

Docs: the reference page gains the task schema and defaults, the guide's "Agents scripting agents" section teaches the verb, and `docs/internals/harness/subagents.md` is a new internals page owning the launched-child lifecycle end to end — the doorway, the ancestry stamp and its depth cap, the caller-scoped verbs, and the boundary with provider-native subagents.

### Deviations from the plan

- **The tmux journey test is not landed.** It was written and run against the real hook-firing fixture, but repeated runs hung in fixture cleanup after the launched children had exited. Shipping a hanging live-backend test, or mutating the shared shim to accommodate one case, was judged worse than the coverage gap.
- **`AttemptOutcome::Blocking` is boxed.** Clippy rejected the unboxed enum: the waiter-bearing foreground variant is ~688 bytes against 48 for the background identity.

## Advisories

- **No live-multiplexer coverage of the scatter–gather path**, per the deviation above. Validation, desugar parity, timeout precedence, the wait-style seam, and the CLI surface are covered; the launch loop, the mid-batch abort, and the `--bg --json` report are not exercised end to end. Worth a follow-up once the fixture hang is understood.
- **A partial scatter leaves its children running.** No transactional rollback is attempted; the error names them and points at `subagents wait` / `subagents stop`.
- **Loose serde on task objects.** Unknown keys are ignored, matching the existing convention for CLI JSON input, so a misspelled optional field is silently dropped.

## Verification

`cargo xtask gate` passes (5578 tests). Review independently re-ran `wait` (120), `cli::subagents` (12), `agents_cmd` (89), and the CLI surface snapshot (31), and confirmed the pre-existing `wait_single_*` / `wait_multi_*` binary-level tests still pin both wait renderers after the refactor.

<details>
<summary>Implemented by the RimZ <code>forge</code> team — 3 agents · 1h03m active · $29.29 · 7 messages (1 from you)</summary>

- **planner** — Claude `claude-fable-5@high`
  - effort: 9m active · $5.11
  - calls: 1 ask · 24 tool calls
  - messages: 1 from you · 1 to teammates
  - tokens: 598 input, 53.6k output, 229.1k cache write, 3.3m cache read
  - subagents: 2 explore $1.08
- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 40m active · $18.56
  - calls: 113 tool calls
  - messages: 3 from teammates · 3 to teammates
  - tokens: 343.3k input, 42.6k output, 31.1m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 14m active · $5.62
  - calls: 65 tool calls
  - messages: 3 from teammates · 2 to teammates
  - tokens: 126 input, 50.3k output, 133.5k cache write, 6.1m cache read

</details>