### PR TITLE
fix(xtask): atlas tuning pass 2 — churn-weighted rank, live pins, complete-linkage shapes, directory stranglers, honest api occ, deduped seams

### DIFF
--- a/xtask/src/atlas/api.rs
+++ b/xtask/src/atlas/api.rs
@@ -285,8 +285,24 @@ impl OccurrenceCorpus {
         Self { modules }
     }
 
-    pub(super) fn count(&self, defining_path: &Path, symbol: &str) -> (usize, usize) {
-        self.count_from_module(&crate_module_for_path(defining_path), symbol)
+    pub(super) fn count_in_module(&self, module: &str, symbol: &str) -> usize {
+        self.modules
+            .get(module)
+            .and_then(|counts| counts.get(symbol))
+            .copied()
+            .unwrap_or(0)
+    }
+
+    pub(super) fn count_under(&self, module_prefix: &str, symbol: &str) -> usize {
+        self.modules
+            .iter()
+            .filter(|(module, _)| {
+                module_prefix.is_empty()
+                    || *module == module_prefix
+                    || module.starts_with(&format!("{module_prefix}::"))
+            })
+            .map(|(_, counts)| counts.get(symbol).copied().unwrap_or(0))
+            .sum()
     }
 
     fn count_from_module(&self, defining_module: &str, symbol: &str) -> (usize, usize) {
@@ -402,7 +418,7 @@ mod tests {
             text: "run(); rerun(); run_again(); run".to_owned(),
         }];
         assert_eq!(
-            OccurrenceCorpus::new(&sources).count(Path::new("src/lib.rs"), "run"),
+            OccurrenceCorpus::new(&sources).count_from_module("", "run"),
             (2, 1)
         );
     }
@@ -425,9 +441,32 @@ mod tests {
             },
         ];
         assert_eq!(
-            OccurrenceCorpus::new(&sources).count(Path::new("src/lib.rs"), "target"),
+            OccurrenceCorpus::new(&sources).count_from_module("", "target"),
             (1, 1)
         );
+    }
+
+    #[test]
+    fn occurrence_scope_distinguishes_files_directories_and_prefix_collisions() {
+        let sources = vec![
+            Source {
+                path: PathBuf::from("src/cli/render.rs"),
+                text: "target();".to_owned(),
+            },
+            Source {
+                path: PathBuf::from("src/cli/render/table.rs"),
+                text: "target(); target();".to_owned(),
+            },
+            Source {
+                path: PathBuf::from("src/cli/renderer.rs"),
+                text: "target(); target(); target();".to_owned(),
+            },
+        ];
+        let corpus = OccurrenceCorpus::new(&sources);
+
+        assert_eq!(corpus.count_in_module("cli::render", "target"), 1);
+        assert_eq!(corpus.count_under("cli::render", "target"), 3);
+        assert_eq!(corpus.count_under("", "target"), 6);
     }
 
     #[test]

--- a/xtask/src/atlas/api.rs
+++ b/xtask/src/atlas/api.rs
@@ -69,6 +69,8 @@ struct Report {
     version: u8,
     verb: &'static str,
     path: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    requested_module: Option<String>,
     total_modules: usize,
     modules: Vec<ModuleApi>,
     total_single_caller_items: usize,
@@ -254,6 +256,7 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
         version: 1,
         verb: "api",
         path: args.path.clone(),
+        requested_module: args.module.clone(),
         total_modules,
         modules,
         total_single_caller_items,
@@ -642,5 +645,26 @@ mod tests {
         assert!(validate_requested_module(&modules, Some("agents_cmd")).is_ok());
         let error = validate_requested_module(&modules, Some("missing")).unwrap_err();
         assert!(error.to_string().contains("module table"));
+    }
+
+    #[test]
+    fn api_json_identifies_a_filtered_module_drilldown() {
+        let report = Report {
+            version: 1,
+            verb: "api",
+            path: PathBuf::from("src"),
+            requested_module: Some("room".to_owned()),
+            total_modules: 1,
+            modules: Vec::new(),
+            total_single_caller_items: 10,
+            single_caller_modules: Vec::new(),
+            single_caller_items: vec![item("filtered", 1)],
+            parse_failures: 0,
+        };
+
+        let payload = serde_json::to_value(report).unwrap();
+        assert_eq!(payload["requested_module"], "room");
+        assert_eq!(payload["single_caller_items"].as_array().unwrap().len(), 1);
+        assert_eq!(payload["total_single_caller_items"], 10);
     }
 }

--- a/xtask/src/atlas/api.rs
+++ b/xtask/src/atlas/api.rs
@@ -366,23 +366,11 @@ impl OccurrenceCorpus {
         Self { modules }
     }
 
-    pub(super) fn count_in_module(&self, module: &str, symbol: &str) -> usize {
-        self.modules
-            .get(module)
-            .and_then(|counts| counts.get(symbol))
-            .copied()
-            .unwrap_or(0)
-    }
-
-    pub(super) fn count_under(&self, module_prefix: &str, symbol: &str) -> usize {
-        self.modules
-            .iter()
-            .filter(|(module, _)| {
-                module_prefix.is_empty()
-                    || *module == module_prefix
-                    || module.starts_with(&format!("{module_prefix}::"))
-            })
-            .map(|(_, counts)| counts.get(symbol).copied().unwrap_or(0))
+    pub(super) fn count_in_sources(sources: &[Source], symbol: &str) -> usize {
+        Self::new(sources)
+            .modules
+            .values()
+            .map(|counts| counts.get(symbol).copied().unwrap_or(0))
             .sum()
     }
 
@@ -561,7 +549,7 @@ mod tests {
     }
 
     #[test]
-    fn occurrence_scope_distinguishes_files_directories_and_prefix_collisions() {
+    fn occurrence_count_in_sources_sums_only_the_supplied_sources() {
         let sources = vec![
             Source {
                 path: PathBuf::from("src/cli/render.rs"),
@@ -576,11 +564,7 @@ mod tests {
                 text: "target(); target(); target();".to_owned(),
             },
         ];
-        let corpus = OccurrenceCorpus::new(&sources);
-
-        assert_eq!(corpus.count_in_module("cli::render", "target"), 1);
-        assert_eq!(corpus.count_under("cli::render", "target"), 3);
-        assert_eq!(corpus.count_under("", "target"), 6);
+        assert_eq!(OccurrenceCorpus::count_in_sources(&sources, "target"), 6);
     }
 
     #[test]

--- a/xtask/src/atlas/api.rs
+++ b/xtask/src/atlas/api.rs
@@ -12,20 +12,24 @@ use super::{positive_usize, set_once, validate_scope, value};
 const DEFAULT_PATH: &str = "crates/rimz/src";
 const DEFAULT_TOP: usize = 20;
 
-const USAGE: &str = "cargo xtask atlas api [--path <prefix>] [--top N] [--since <ref>] [--json]
+const USAGE: &str =
+    "cargo xtask atlas api [--path <prefix>] [--top N] [--module <name>] [--since <ref>] [--json]
 
 Reports public boundary shape and whole-word identifier occurrences outside each
-defining module. `occ` is a ranking heuristic, not a resolved caller count.
+defining file-module. `occ` excludes tests; 0 may mean unreferenced or test-only.
+Common identifiers can over-count, so `occ` is not a resolved caller count.
 
-  --path <path>  root-relative subtree (default crates/rimz/src)
-  --top N        rows per shortlist (default 20)
-  --since <ref>  add public-item delta against a git revision
-  --json         versioned JSON agent contract (v1)";
+  --path <path>    root-relative subtree (default crates/rimz/src)
+  --top N          rows per section (default 20)
+  --module <name>  drill into one module from the module table
+  --since <ref>    add public-item delta against a git revision
+  --json           versioned JSON agent contract (v1)";
 
 #[derive(Debug, PartialEq, Eq)]
 struct Args {
     path: PathBuf,
     top: usize,
+    module: Option<String>,
     since: Option<String>,
     json: bool,
 }
@@ -48,9 +52,16 @@ struct ModuleApi {
     pub_types: usize,
     pub_items: usize,
     occurrence_median: f64,
+    zero_occurrences: usize,
     params_median: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     delta_pub: Option<isize>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct SingleCallerModule {
+    module: String,
+    items: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -61,6 +72,7 @@ struct Report {
     total_modules: usize,
     modules: Vec<ModuleApi>,
     total_single_caller_items: usize,
+    single_caller_modules: Vec<SingleCallerModule>,
     single_caller_items: Vec<ItemOccurrence>,
     parse_failures: usize,
 }
@@ -81,7 +93,7 @@ pub(super) fn run(root: &Path, args: &[String]) -> Result<()> {
             serde_json::to_string_pretty(&report).context("rendering atlas api JSON")?
         );
     } else {
-        print_report(&report, args.top);
+        print_report(&report, args.top, args.module.as_deref());
     }
     Ok(())
 }
@@ -92,6 +104,7 @@ fn parse_args(args: &[String]) -> Result<Option<Args>> {
     }
     let mut path = None;
     let mut top = None;
+    let mut module = None;
     let mut since = None;
     let mut json = false;
     let mut index = 0;
@@ -105,6 +118,11 @@ fn parse_args(args: &[String]) -> Result<Option<Args>> {
             "--top" => {
                 let parsed = positive_usize(value(args, index, "api", "--top")?, "api", "--top")?;
                 set_once(&mut top, parsed, "api", "--top")?;
+                index += 2;
+            }
+            "--module" => {
+                let parsed = value(args, index, "api", "--module")?.to_owned();
+                set_once(&mut module, parsed, "api", "--module")?;
                 index += 2;
             }
             "--since" => {
@@ -123,6 +141,7 @@ fn parse_args(args: &[String]) -> Result<Option<Args>> {
     Ok(Some(Args {
         path: path.unwrap_or_else(|| PathBuf::from(DEFAULT_PATH)),
         top: top.unwrap_or(DEFAULT_TOP),
+        module,
         since,
         json,
     }))
@@ -169,15 +188,16 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
         }
     }
 
-    let mut single_caller_items = Vec::new();
+    let mut scoped_single_caller_items = Vec::new();
     let mut modules = module_items
         .into_iter()
         .map(|(module, items)| {
-            single_caller_items.extend(
+            scoped_single_caller_items.extend(
                 items
                     .iter()
                     .filter(|item| item.outside_modules == 1)
-                    .cloned(),
+                    .cloned()
+                    .map(|item| (module.clone(), item)),
             );
             let (pub_fns, pub_types) = module_kinds.get(&module).copied().unwrap_or_default();
             let pub_items = items.len();
@@ -187,6 +207,7 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
                     .map(|item| item.occurrences)
                     .collect::<Vec<_>>(),
             );
+            let zero_occurrences = zero_occurrence_count(&items);
             let params_median = module_params
                 .get(&module)
                 .map(|values| median(values.clone()));
@@ -199,6 +220,7 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
                 pub_types,
                 pub_items,
                 occurrence_median,
+                zero_occurrences,
                 params_median,
                 delta_pub,
             }
@@ -211,16 +233,23 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
             .then_with(|| left.occurrence_median.total_cmp(&right.occurrence_median))
             .then_with(|| left.module.cmp(&right.module))
     });
-    single_caller_items.sort_by(|left, right| {
-        left.module
-            .cmp(&right.module)
-            .then_with(|| left.path.cmp(&right.path))
-            .then_with(|| left.line.cmp(&right.line))
+    validate_requested_module(&modules, args.module.as_deref())?;
+    scoped_single_caller_items.sort_by(|left, right| {
+        left.0
+            .cmp(&right.0)
+            .then_with(|| left.1.path.cmp(&right.1.path))
+            .then_with(|| left.1.line.cmp(&right.1.line))
     });
+    let single_caller_modules = single_caller_module_counts(&scoped_single_caller_items);
     let total_modules = modules.len();
-    let total_single_caller_items = single_caller_items.len();
+    let total_single_caller_items = scoped_single_caller_items.len();
+    let single_caller_items = select_single_caller_items(
+        scoped_single_caller_items,
+        args.module.as_deref(),
+        args.top,
+        args.json,
+    );
     modules.truncate(args.top);
-    single_caller_items.truncate(args.top);
     Ok(Report {
         version: 1,
         verb: "api",
@@ -228,9 +257,61 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
         total_modules,
         modules,
         total_single_caller_items,
+        single_caller_modules,
         single_caller_items,
         parse_failures: syntax.parse_failures.len(),
     })
+}
+
+fn zero_occurrence_count(items: &[ItemOccurrence]) -> usize {
+    items.iter().filter(|item| item.occurrences == 0).count()
+}
+
+fn validate_requested_module(modules: &[ModuleApi], requested: Option<&str>) -> Result<()> {
+    let Some(requested) = requested else {
+        return Ok(());
+    };
+    if modules.iter().any(|module| module.module == requested) {
+        return Ok(());
+    }
+    bail!(
+        "atlas api --module `{requested}` is not in the module table; choose a module from `cargo xtask atlas api`"
+    )
+}
+
+fn single_caller_module_counts(items: &[(String, ItemOccurrence)]) -> Vec<SingleCallerModule> {
+    let mut counts = BTreeMap::<String, usize>::new();
+    for (module, _) in items {
+        *counts.entry(module.clone()).or_default() += 1;
+    }
+    let mut counts = counts
+        .into_iter()
+        .map(|(module, items)| SingleCallerModule { module, items })
+        .collect::<Vec<_>>();
+    counts.sort_by(|left, right| {
+        right
+            .items
+            .cmp(&left.items)
+            .then_with(|| left.module.cmp(&right.module))
+    });
+    counts
+}
+
+fn select_single_caller_items(
+    items: Vec<(String, ItemOccurrence)>,
+    requested_module: Option<&str>,
+    top: usize,
+    json: bool,
+) -> Vec<ItemOccurrence> {
+    let mut selected = items
+        .into_iter()
+        .filter(|(module, _)| requested_module.is_none_or(|requested| module == requested))
+        .map(|(_, item)| item)
+        .collect::<Vec<_>>();
+    if !json {
+        selected.truncate(top);
+    }
+    selected
 }
 
 fn public_counts(files: &[FileSyntax], scope: &Path) -> BTreeMap<String, usize> {
@@ -357,9 +438,9 @@ fn median(mut values: Vec<usize>) -> f64 {
     clippy::print_stdout,
     reason = "xtask atlas api report is the command's stdout contract"
 )]
-fn print_report(report: &Report, top: usize) {
+fn print_report(report: &Report, top: usize, requested_module: Option<&str>) {
     println!("Atlas api — {}", report.path.display());
-    println!("module                    pub fn  pub type  occ/item  params/fn  Δpub");
+    println!("module                    pub fn  pub type  occ/item  occ0  params/fn  Δpub");
     for module in report.modules.iter().take(top) {
         let params = module
             .params_median
@@ -368,11 +449,12 @@ fn print_report(report: &Report, top: usize) {
             .delta_pub
             .map_or_else(|| "—".to_owned(), |value| format!("{value:+}"));
         println!(
-            "{:<25} {:>6}  {:>8}  {:>8.1}  {:>9}  {:>4}",
+            "{:<25} {:>6}  {:>8}  {:>8.1}  {:>4}  {:>9}  {:>4}",
             module.module,
             module.pub_fns,
             module.pub_types,
             module.occurrence_median,
+            module.zero_occurrences,
             params,
             delta
         );
@@ -384,22 +466,42 @@ fn print_report(report: &Report, top: usize) {
         );
     }
     println!();
-    println!("Single-outside-module public items (`occ` is identifier occurrences)");
-    for item in report.single_caller_items.iter().take(top) {
+    if let Some(module) = requested_module {
         println!(
-            "{}::{} {}:{} occ {}",
-            item.module,
-            item.name,
-            item.path.display(),
-            item.line,
-            item.occurrences
+            "Single-outside-module public items in {module} (`occ` is identifier occurrences)"
         );
-    }
-    if report.total_single_caller_items > report.single_caller_items.len() {
-        println!(
-            "… and {} more single-outside-module items",
-            report.total_single_caller_items - report.single_caller_items.len()
-        );
+        for item in report.single_caller_items.iter().take(top) {
+            println!(
+                "{}::{} {}:{} occ {}",
+                item.module,
+                item.name,
+                item.path.display(),
+                item.line,
+                item.occurrences
+            );
+        }
+        let module_total = report
+            .single_caller_modules
+            .iter()
+            .find(|row| row.module == module)
+            .map_or(0, |row| row.items);
+        if module_total > report.single_caller_items.len() {
+            println!(
+                "… and {} more single-outside-module items",
+                module_total - report.single_caller_items.len()
+            );
+        }
+    } else {
+        println!("Single-outside-module public items by module");
+        for module in report.single_caller_modules.iter().take(top) {
+            println!("{}: {} items", module.module, module.items);
+        }
+        if report.single_caller_modules.len() > top {
+            println!(
+                "… and {} more modules",
+                report.single_caller_modules.len() - top
+            );
+        }
     }
     println!(
         "total: {} modules, {} shortlist items, {} parse failures",
@@ -410,6 +512,18 @@ fn print_report(report: &Report, top: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn item(name: &str, occurrences: usize) -> ItemOccurrence {
+        ItemOccurrence {
+            module: "crate_module".to_owned(),
+            name: name.to_owned(),
+            kind: "fn".to_owned(),
+            path: PathBuf::from(format!("src/{name}.rs")),
+            line: 1,
+            occurrences,
+            outside_modules: 1,
+        }
+    }
 
     #[test]
     fn occurrence_scan_uses_identifier_boundaries() {
@@ -472,12 +586,77 @@ mod tests {
     #[test]
     fn api_args_reject_duplicates() {
         assert!(parse_args(&["--json".into(), "--json".into()]).is_err());
-        assert_eq!(
-            parse_args(&["--top".into(), "7".into()])
-                .unwrap()
-                .unwrap()
-                .top,
-            7
+        let args = parse_args(&[
+            "--top".into(),
+            "7".into(),
+            "--module".into(),
+            "agents_cmd".into(),
+        ])
+        .unwrap()
+        .unwrap();
+        assert_eq!(args.top, 7);
+        assert_eq!(args.module.as_deref(), Some("agents_cmd"));
+        assert!(
+            parse_args(&[
+                "--module".into(),
+                "agents_cmd".into(),
+                "--module".into(),
+                "stats".into(),
+            ])
+            .is_err()
         );
+    }
+
+    #[test]
+    fn api_shortlist_aggregates_by_scope_module() {
+        let items = vec![
+            ("stats".to_owned(), item("one", 1)),
+            ("agents_cmd".to_owned(), item("two", 2)),
+            ("stats".to_owned(), item("three", 3)),
+        ];
+
+        assert_eq!(
+            single_caller_module_counts(&items),
+            [
+                SingleCallerModule {
+                    module: "stats".to_owned(),
+                    items: 2,
+                },
+                SingleCallerModule {
+                    module: "agents_cmd".to_owned(),
+                    items: 1,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn api_occurrence_zeros_and_json_shortlist_are_untruncated() {
+        let items = vec![item("zero", 0), item("used", 2), item("also-zero", 0)];
+        assert_eq!(zero_occurrence_count(&items), 2);
+
+        let scoped = items
+            .into_iter()
+            .map(|item| ("stats".to_owned(), item))
+            .collect();
+        assert_eq!(select_single_caller_items(scoped, None, 1, true).len(), 3);
+    }
+
+    #[test]
+    fn api_module_drilldown_rejects_names_outside_the_table() {
+        let modules = vec![ModuleApi {
+            module: "agents_cmd".to_owned(),
+            pub_fns: 1,
+            pub_types: 0,
+            pub_items: 1,
+            occurrence_median: 1.0,
+            zero_occurrences: 0,
+            params_median: Some(0.0),
+            delta_pub: None,
+        }];
+
+        assert!(validate_requested_module(&modules, Some("agents_cmd")).is_ok());
+        let error = validate_requested_module(&modules, Some("missing")).unwrap_err();
+        assert!(error.to_string().contains("module table"));
     }
 }

--- a/xtask/src/atlas/conform.rs
+++ b/xtask/src/atlas/conform.rs
@@ -143,7 +143,6 @@ fn evaluate(root: &Path, target: &Target) -> Result<Report> {
         .map(|source| crate_module_for_path(&source.path))
         .collect::<BTreeSet<_>>();
     let workspace_crates = workspace_crate_names(root)?;
-    let occurrence_corpus = OccurrenceCorpus::new(&all_sources);
     let mut rules = Vec::new();
     let mut parse_failures = 0;
     for module in &target.modules {
@@ -208,17 +207,8 @@ fn evaluate(root: &Path, target: &Target) -> Result<Report> {
                 strangler.path.display()
             );
         }
-        let scope_entry = if absolute.is_dir() {
-            strangler.path.join("mod.rs")
-        } else {
-            strangler.path.clone()
-        };
-        let scope_module = crate_module_for_path(&scope_entry);
-        let current = if absolute.is_dir() {
-            occurrence_corpus.count_under(&scope_module, &strangler.symbol)
-        } else {
-            occurrence_corpus.count_in_module(&scope_module, &strangler.symbol)
-        };
+        let scoped_sources = sources_for_path(&all_sources, &strangler.path, absolute.is_file());
+        let current = OccurrenceCorpus::count_in_sources(&scoped_sources, &strangler.symbol);
         rules.push(RuleResult {
             kind: "strangler",
             path: strangler.path.clone(),
@@ -426,5 +416,83 @@ baseline = 5
         assert_eq!(tightened.modules[0].pub_budget, 1);
         assert_eq!(tightened.strangler[0].baseline, 1);
         assert_eq!(tightened.strangler[1].baseline, 2);
+    }
+
+    #[test]
+    fn strangler_paths_do_not_count_matching_modules_from_other_crates() {
+        let root = tempfile::tempdir().unwrap();
+        for path in ["app/src/legacy", "tool/src/legacy"] {
+            fs::create_dir_all(root.path().join(path)).unwrap();
+        }
+        fs::write(
+            root.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"app\", \"tool\"]\nresolver = \"2\"\n",
+        )
+        .unwrap();
+        for member in ["app", "tool"] {
+            fs::write(
+                root.path().join(member).join("Cargo.toml"),
+                format!(
+                    "[package]\nname = \"{member}\"\nversion = \"0.0.0\"\nedition = \"2024\"\n"
+                ),
+            )
+            .unwrap();
+        }
+        fs::write(root.path().join("app/src/lib.rs"), "pub mod legacy;\n").unwrap();
+        fs::write(
+            root.path().join("app/src/legacy/mod.rs"),
+            "fn doomed() {}\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("app/src/legacy/caller.rs"),
+            "fn call() { doomed(); }\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("tool/src/lib.rs"),
+            "fn doomed() { doomed(); doomed(); }\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("tool/src/legacy/mod.rs"),
+            "fn doomed() { doomed(); }\n",
+        )
+        .unwrap();
+
+        let target = Target {
+            version: 1,
+            modules: Vec::new(),
+            strangler: vec![
+                target::StranglerRule {
+                    symbol: "doomed".to_owned(),
+                    path: PathBuf::from("app/src"),
+                    baseline: 10,
+                    config_line: 1,
+                },
+                target::StranglerRule {
+                    symbol: "doomed".to_owned(),
+                    path: PathBuf::from("app/src/legacy"),
+                    baseline: 10,
+                    config_line: 2,
+                },
+                target::StranglerRule {
+                    symbol: "doomed".to_owned(),
+                    path: PathBuf::from("app/src/lib.rs"),
+                    baseline: 10,
+                    config_line: 3,
+                },
+            ],
+        };
+
+        let report = evaluate(root.path(), &target).unwrap();
+        assert_eq!(
+            report
+                .rules
+                .iter()
+                .map(|rule| rule.current)
+                .collect::<Vec<_>>(),
+            [2, 2, 0]
+        );
     }
 }

--- a/xtask/src/atlas/conform.rs
+++ b/xtask/src/atlas/conform.rs
@@ -15,7 +15,8 @@ const USAGE: &str = "cargo xtask atlas conform [--ratchet|--tighten] [--json]
 Compares the working tree with root refactor-target.toml. `--ratchet` fails only
 when current values exceed budgets/baselines or an import is outside its allow
 list. `--tighten` atomically lowers budgets/baselines to current values; it
-never raises them. A missing target file passes.
+never raises them. A strangler counts whole-word occurrences of its symbol in
+non-test Rust under its path (a file or directory). A missing target file passes.
 
   --ratchet  fail on regressions (the checks/gate mode)
   --tighten  lower budgets and baselines to current values
@@ -199,14 +200,25 @@ fn evaluate(root: &Path, target: &Target) -> Result<Report> {
         });
     }
     for strangler in &target.strangler {
-        if !root.join(&strangler.path).is_file() {
+        let absolute = root.join(&strangler.path);
+        if !absolute.exists() {
             bail!(
-                "{TARGET_FILE}:{}: configured strangler path `{}` is not a file",
+                "{TARGET_FILE}:{}: configured strangler path `{}` does not exist",
                 strangler.config_line,
                 strangler.path.display()
             );
         }
-        let (current, _) = occurrence_corpus.count(&strangler.path, &strangler.symbol);
+        let scope_entry = if absolute.is_dir() {
+            strangler.path.join("mod.rs")
+        } else {
+            strangler.path.clone()
+        };
+        let scope_module = crate_module_for_path(&scope_entry);
+        let current = if absolute.is_dir() {
+            occurrence_corpus.count_under(&scope_module, &strangler.symbol)
+        } else {
+            occurrence_corpus.count_in_module(&scope_module, &strangler.symbol)
+        };
         rules.push(RuleResult {
             kind: "strangler",
             path: strangler.path.clone(),
@@ -390,6 +402,10 @@ pub-budget = 5
 symbol = "run"
 path = "src/lib.rs"
 baseline = 5
+[[strangler]]
+symbol = "run"
+path = "src"
+baseline = 5
 "#,
         )
         .unwrap();
@@ -409,5 +425,6 @@ baseline = 5
         let tightened = target::load(root.path()).unwrap().unwrap();
         assert_eq!(tightened.modules[0].pub_budget, 1);
         assert_eq!(tightened.strangler[0].baseline, 1);
+        assert_eq!(tightened.strangler[1].baseline, 2);
     }
 }

--- a/xtask/src/atlas/rank.rs
+++ b/xtask/src/atlas/rank.rs
@@ -17,7 +17,7 @@ const DEFAULT_PATH: &str = "crates/rimz/src";
 
 const USAGE: &str = "cargo xtask atlas rank [--path <prefix>] [--top N] [--window <pct>] [--since <ref>] [--verbose] [--json]
 
-Ranks modules by size, interface, history, and calibrated complexity.
+Ranks modules by churn-weighted size (code × churn%); cx breaks ties.
 Flags: pin = churn% >= threshold and test/code below threshold; hot = non-noisy
 pace >= threshold; shallow = wide public surface with low lines/public item.
 Requires rust-code-analysis-cli (`cargo install rust-code-analysis-cli --locked`).
@@ -27,8 +27,8 @@ Requires rust-code-analysis-cli (`cargo install rust-code-analysis-cli --locked`
   --window <pct>         recent history window (default 25)
   --noise-lifetime N     minimum lifetime commits for pace (default 20)
   --noise-window N       minimum window commits for pace (default 5)
-  --pin-churn N          pin churn-percent threshold (default 5)
-  --pin-tc N             pin test/code ceiling (default 0.2)
+  --pin-churn N          pin churn-percent threshold (default 3)
+  --pin-tc N             pin test/code ceiling (default 0.30)
   --hot-pace N           hot pace threshold (default 1.5)
   --shallow-pub N        shallow public-item threshold (default 20)
   --shallow-locpub N     shallow lines/public ceiling (default 30)
@@ -59,7 +59,7 @@ struct Size {
     tests: u64,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Default, Serialize)]
 struct Row {
     module: String,
     code: u64,
@@ -241,8 +241,8 @@ fn parse_args(args: &[String]) -> Result<Option<Args>> {
         window: window.unwrap_or(25),
         noise_lifetime: noise_lifetime.unwrap_or(20),
         noise_window: noise_window.unwrap_or(5),
-        pin_churn: pin_churn.unwrap_or(5.0),
-        pin_tc: pin_tc.unwrap_or(0.2),
+        pin_churn: pin_churn.unwrap_or(3.0),
+        pin_tc: pin_tc.unwrap_or(0.30),
         hot_pace: hot_pace.unwrap_or(1.5),
         shallow_pub: shallow_pub.unwrap_or(20),
         shallow_locpub: shallow_locpub.unwrap_or(30.0),
@@ -285,9 +285,7 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
             let complexity = metrics.module_scores.get(module).copied().unwrap_or(0.0);
             let test_code_ratio = (size.code > 0).then_some(size.tests as f64 / size.code as f64);
             let mut flags = Vec::new();
-            if churn_pct >= args.pin_churn
-                && test_code_ratio.is_some_and(|ratio| ratio < args.pin_tc)
-            {
+            if is_pinned(churn_pct, test_code_ratio, args.pin_churn, args.pin_tc) {
                 flags.push("pin");
             }
             if history.pace.is_some_and(|pace| pace >= args.hot_pace) {
@@ -318,13 +316,7 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
             }
         })
         .collect::<Vec<_>>();
-    rows.sort_by(|left, right| {
-        right
-            .complexity
-            .total_cmp(&left.complexity)
-            .then_with(|| right.code.cmp(&left.code))
-            .then_with(|| left.module.cmp(&right.module))
-    });
+    sort_rows(&mut rows);
     let total_modules = rows.len();
     let total_code = rows.iter().map(|row| row.code).sum();
     let total_tests = rows.iter().map(|row| row.tests).sum();
@@ -359,6 +351,22 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
         offenders,
         parse_failures: syntax.parse_failures.len(),
     })
+}
+
+fn is_pinned(churn_pct: f64, test_code_ratio: Option<f64>, pin_churn: f64, pin_tc: f64) -> bool {
+    churn_pct >= pin_churn && test_code_ratio.is_some_and(|ratio| ratio < pin_tc)
+}
+
+fn sort_rows(rows: &mut [Row]) {
+    rows.sort_by(|left, right| {
+        let left_value = left.code as f64 * left.churn_pct;
+        let right_value = right.code as f64 * right.churn_pct;
+        right_value
+            .total_cmp(&left_value)
+            .then_with(|| right.complexity.total_cmp(&left.complexity))
+            .then_with(|| right.code.cmp(&left.code))
+            .then_with(|| left.module.cmp(&right.module))
+    });
 }
 
 fn sizes(source_list: &[sources::Source], scope: &Path) -> BTreeMap<String, Size> {

--- a/xtask/src/atlas/rank/tests.rs
+++ b/xtask/src/atlas/rank/tests.rs
@@ -16,3 +16,36 @@ fn rank_flags_are_parsed_and_window_is_bounded() {
     assert!(args.verbose);
     assert_eq!(args.pin_tc, 0.4);
 }
+
+#[test]
+fn rows_are_ranked_by_churn_weighted_size() {
+    let row = |module: &str, code, churn_pct, complexity| Row {
+        module: module.to_owned(),
+        code,
+        churn_pct,
+        complexity,
+        ..Row::default()
+    };
+    let mut rows = vec![
+        row("cold", 1_000, 0.0, 100.0),
+        row("small-hot", 100, 20.0, 1.0),
+        row("large-warm", 500, 5.0, 2.0),
+        row("cold-low-cx", 2_000, 0.0, 1.0),
+    ];
+
+    sort_rows(&mut rows);
+
+    assert_eq!(
+        rows.iter()
+            .map(|row| row.module.as_str())
+            .collect::<Vec<_>>(),
+        ["large-warm", "small-hot", "cold", "cold-low-cx"]
+    );
+}
+
+#[test]
+fn pin_thresholds_match_the_documented_boundaries() {
+    assert!(is_pinned(3.4, Some(0.15), 3.0, 0.30));
+    assert!(!is_pinned(19.3, Some(0.30), 3.0, 0.30));
+    assert!(!is_pinned(2.9, Some(0.10), 3.0, 0.30));
+}

--- a/xtask/src/atlas/seams.rs
+++ b/xtask/src/atlas/seams.rs
@@ -250,21 +250,15 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
         .iter()
         .map(|edge| (ordered_pair(&edge.left, &edge.right), edge.commits))
         .collect::<BTreeMap<_, _>>();
+    let (cochange_edges, import_free_cochange_edges) =
+        partition_cochange_edges(cochange_edges, &import_lookup);
     let mut divergence = Vec::new();
-    for edge in &cochange_edges {
-        let imports = import_lookup
-            .get(&(edge.left.clone(), edge.right.clone()))
-            .copied()
-            .unwrap_or(0)
-            + import_lookup
-                .get(&(edge.right.clone(), edge.left.clone()))
-                .copied()
-                .unwrap_or(0);
-        if edge.commits >= args.min_cochange && imports == 0 {
+    for edge in import_free_cochange_edges {
+        if edge.commits >= args.min_cochange {
             divergence.push(Divergence {
                 kind: "cochange-without-import",
-                left: edge.left.clone(),
-                right: edge.right.clone(),
+                left: edge.left,
+                right: edge.right,
                 imports: 0,
                 cochanges: edge.commits,
             });
@@ -315,6 +309,16 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
         total_divergence,
         divergence,
         parse_failures: syntax.parse_failures.len(),
+    })
+}
+
+fn partition_cochange_edges(
+    edges: Vec<CochangeEdge>,
+    imports: &BTreeMap<(String, String), usize>,
+) -> (Vec<CochangeEdge>, Vec<CochangeEdge>) {
+    edges.into_iter().partition(|edge| {
+        imports.contains_key(&(edge.left.clone(), edge.right.clone()))
+            || imports.contains_key(&(edge.right.clone(), edge.left.clone()))
     })
 }
 
@@ -383,7 +387,7 @@ fn print_report(report: &Report, top: usize) {
         "surface rows",
     );
     println!();
-    println!("Co-change edges");
+    println!("Co-change edges (pairs with import edges)");
     for edge in report.cochange_edges.iter().take(top) {
         println!("{} <> {}: {} commits", edge.left, edge.right, edge.commits);
     }
@@ -432,5 +436,39 @@ mod tests {
     fn endpoints_follow_scope_granularity() {
         assert_eq!(endpoint("cli::agents_cmd::show", "cli"), "agents_cmd");
         assert_eq!(endpoint("store::event", "cli"), "store");
+    }
+
+    #[test]
+    fn cochange_sections_partition_pairs_by_import_presence() {
+        let edges = vec![
+            CochangeEdge {
+                left: "agents".to_owned(),
+                right: "hooks".to_owned(),
+                commits: 40,
+            },
+            CochangeEdge {
+                left: "agents".to_owned(),
+                right: "store".to_owned(),
+                commits: 20,
+            },
+        ];
+        let imports = BTreeMap::from([(("store".to_owned(), "agents".to_owned()), 2)]);
+
+        let (with_imports, without_imports) = partition_cochange_edges(edges, &imports);
+
+        assert_eq!(
+            with_imports
+                .iter()
+                .map(|edge| ordered_pair(&edge.left, &edge.right))
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([("agents".to_owned(), "store".to_owned())])
+        );
+        assert_eq!(
+            without_imports
+                .iter()
+                .map(|edge| ordered_pair(&edge.left, &edge.right))
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([("agents".to_owned(), "hooks".to_owned())])
+        );
     }
 }

--- a/xtask/src/atlas/shapes.rs
+++ b/xtask/src/atlas/shapes.rs
@@ -17,9 +17,9 @@ Clusters large functions by Jaccard similarity over normalized control-flow
 4-grams. Identifiers and literals do not enter the skeleton.
 
   --path <path>   root-relative subtree (default crates/rimz/src)
-  --top N         clusters to report (default 15)
+  --top N         clusters to report (default 10)
   --min-sloc N    minimum function source lines (default 40)
-  --similarity S  Jaccard threshold from 0 through 1 (default 0.53)
+  --similarity S  Jaccard threshold from 0 through 1 (default 0.65)
   --json          versioned JSON agent contract (v1)";
 
 #[derive(Debug)]
@@ -133,9 +133,9 @@ fn parse_args(args: &[String]) -> Result<Option<Args>> {
     }
     Ok(Some(Args {
         path: path.unwrap_or_else(|| PathBuf::from(DEFAULT_PATH)),
-        top: top.unwrap_or(15),
+        top: top.unwrap_or(10),
         min_sloc: min_sloc.unwrap_or(40),
-        similarity: similarity.unwrap_or(0.53),
+        similarity: similarity.unwrap_or(0.65),
         json,
     }))
 }

--- a/xtask/src/atlas/shapes.rs
+++ b/xtask/src/atlas/shapes.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
@@ -19,7 +19,7 @@ Clusters large functions by Jaccard similarity over normalized control-flow
   --path <path>   root-relative subtree (default crates/rimz/src)
   --top N         clusters to report (default 15)
   --min-sloc N    minimum function source lines (default 40)
-  --similarity S  Jaccard threshold from 0 through 1 (default 0.75)
+  --similarity S  Jaccard threshold from 0 through 1 (default 0.53)
   --json          versioned JSON agent contract (v1)";
 
 #[derive(Debug)]
@@ -135,7 +135,7 @@ fn parse_args(args: &[String]) -> Result<Option<Args>> {
         path: path.unwrap_or_else(|| PathBuf::from(DEFAULT_PATH)),
         top: top.unwrap_or(15),
         min_sloc: min_sloc.unwrap_or(40),
-        similarity: similarity.unwrap_or(0.75),
+        similarity: similarity.unwrap_or(0.53),
         json,
     }))
 }
@@ -154,21 +154,16 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
         .iter()
         .map(|function| shingle_set(&function.skeleton))
         .collect::<Vec<_>>();
-    let mut union = UnionFind::new(functions.len());
+    let mut similarities = vec![vec![0.0; functions.len()]; functions.len()];
     for left in 0..functions.len() {
         for right in left + 1..functions.len() {
             let similarity = jaccard(&shingles[left], &shingles[right]);
-            if similarity >= args.similarity {
-                union.join(left, right);
-            }
+            similarities[left][right] = similarity;
+            similarities[right][left] = similarity;
         }
     }
-    let mut groups = BTreeMap::<usize, Vec<usize>>::new();
-    for index in 0..functions.len() {
-        groups.entry(union.find(index)).or_default().push(index);
-    }
-    let mut clusters = groups
-        .into_values()
+    let mut clusters = complete_linkage_groups(&similarities, args.similarity)
+        .into_iter()
         .filter(|members| members.len() > 1)
         .map(|members| cluster(&functions, &shingles, members))
         .collect::<Vec<_>>();
@@ -254,31 +249,53 @@ fn jaccard(left: &BTreeSet<Vec<String>>, right: &BTreeSet<Vec<String>>) -> f64 {
     intersection as f64 / union as f64
 }
 
-struct UnionFind {
-    parents: Vec<usize>,
-}
+fn complete_linkage_groups(similarities: &[Vec<f64>], threshold: f64) -> Vec<Vec<usize>> {
+    let mut pairs = (0..similarities.len())
+        .flat_map(|left| {
+            (left + 1..similarities.len())
+                .map(move |right| (similarities[left][right], left, right))
+        })
+        .filter(|(similarity, _, _)| *similarity >= threshold)
+        .collect::<Vec<_>>();
+    pairs.sort_by(|left, right| {
+        right
+            .0
+            .total_cmp(&left.0)
+            .then_with(|| left.1.cmp(&right.1))
+            .then_with(|| left.2.cmp(&right.2))
+    });
 
-impl UnionFind {
-    fn new(len: usize) -> Self {
-        Self {
-            parents: (0..len).collect(),
+    let mut groups = (0..similarities.len())
+        .map(|index| vec![index])
+        .collect::<Vec<_>>();
+    for (_, left, right) in pairs {
+        let left_group = groups
+            .iter()
+            .position(|group| group.contains(&left))
+            .expect("each function remains in exactly one complete-linkage group");
+        let right_group = groups
+            .iter()
+            .position(|group| group.contains(&right))
+            .expect("each function remains in exactly one complete-linkage group");
+        if left_group == right_group
+            || !groups[left_group].iter().all(|left| {
+                groups[right_group]
+                    .iter()
+                    .all(|right| similarities[*left][*right] >= threshold)
+            })
+        {
+            continue;
         }
+        let (keep, remove) = if left_group < right_group {
+            (left_group, right_group)
+        } else {
+            (right_group, left_group)
+        };
+        let removed = groups.remove(remove);
+        groups[keep].extend(removed);
+        groups[keep].sort_unstable();
     }
-
-    fn find(&mut self, index: usize) -> usize {
-        if self.parents[index] != index {
-            self.parents[index] = self.find(self.parents[index]);
-        }
-        self.parents[index]
-    }
-
-    fn join(&mut self, left: usize, right: usize) {
-        let left = self.find(left);
-        let right = self.find(right);
-        if left != right {
-            self.parents[right] = left;
-        }
-    }
+    groups
 }
 
 #[expect(
@@ -332,15 +349,31 @@ mod tests {
     }
 
     #[test]
-    fn jaccard_and_union_find_cluster_shapes() {
+    fn jaccard_scores_shape_similarity() {
         assert_eq!(jaccard(&set(&["A B C D"]), &set(&["A B C D"])), 1.0);
         assert_eq!(
             jaccard(&set(&["A B C D", "B C D E"]), &set(&["A B C D"])),
             0.5
         );
-        let mut union = UnionFind::new(3);
-        union.join(0, 1);
-        assert_eq!(union.find(0), union.find(1));
-        assert_ne!(union.find(0), union.find(2));
+    }
+
+    #[test]
+    fn complete_linkage_does_not_chain_dissimilar_members() {
+        let similarities = vec![
+            vec![1.0, 0.8, 0.6],
+            vec![0.8, 1.0, 0.8],
+            vec![0.6, 0.8, 1.0],
+        ];
+
+        let groups = complete_linkage_groups(&similarities, 0.7);
+
+        assert_eq!(groups, [vec![0, 1], vec![2]]);
+        assert!(groups.iter().all(|group| {
+            group.iter().enumerate().all(|(position, left)| {
+                group[position + 1..]
+                    .iter()
+                    .all(|right| similarities[*left][*right] >= 0.7)
+            })
+        }));
     }
 }


### PR DESCRIPTION
## Context

`cargo xtask atlas` was field-tested by its consumer — an architecture-review agent — against `crates/rimz/src/cli`. The report raised six defects: `rank` ordered by raw complexity so cold-but-gnarly modules outranked the churning ones, `pin` never fired at its thresholds, `conform` stranglers rejected directory paths, `shapes` chained clusters through single linkage so a printed cluster's members could sit below the requested threshold, `api`'s single-outside shortlist was a flat unaggregated list with a misleading `occ/item` median, and `seams` printed the same import-free co-change pairs in two sections. All six reproduced in code and on fresh runs, and all six are fixed here. No behaviour outside `xtask/src/atlas/` changes; the measurement verbs stay outside every gate, and only `conform --ratchet` runs in `gate`/`checks` (inert while no `refactor-target.toml` exists).

## Design choices

- **`rank` orders by churn-weighted size.** The sort key is `code × churn%`; complexity stays a column and drops to first tiebreak. Size alone ranks dead code, complexity alone ranks stable code — the product is what a refactor program should read first. Pin thresholds move to 3% churn and a strict 0.30 test/code ceiling, so the flag identifies large, actively-edited, under-tested modules instead of never firing.
- **`shapes` moves to complete linkage.** Every member pair in a printed cluster meets the threshold by construction, so `similarity_floor` becomes a witness of that invariant rather than a warning that chaining dragged a cluster below it. Average linkage would still admit sub-threshold pairs; complete linkage cannot.
- **A strangler `path` means "where occurrences are counted"**, uniformly for a file or a directory. The old exclude-the-defining-module semantics is dropped for stranglers: a definition inside the scope counts, and the rule ratchets to zero exactly when the symbol is gone — the strangler end state. `api`'s own `occ` column keeps its outside-the-defining-module counting.
- **`api`'s `occ` is fixed by output honesty, not by counting changes.** The counting was verified sound (dispatch through `cli/mod.rs` does register; word boundaries are covered by test). The `0.0` medians were real: most `stats`, `transcript` and `message` public items have no non-test reference outside their defining file-module, and the median hid the split. An `occ0` column surfaces it (`stats` 104 public items, 61 of them at zero) and the USAGE says plainly what the number is and is not.
- **`seams` co-change section carries only import-backed pairs.** The import-free ones already print as `cochange-without-import` divergence rows, which is the more informative framing.
- Every `--json` payload stays atlas v1; new fields are additive only.

## Implementation

Five fixes, one commit each, plus three review-fix commits. Two departures from the plan, both deliberate:

**`shapes` default is `--similarity 0.65`, not the 0.53 that first satisfied acceptance.** The plan asked for the launch-family cluster (`launch_layout`, `restart_resolved`, `run_fork`, `launch_resume_layout`) to appear at defaults, and it only does at 0.53 — because that is genuinely where those functions sit. Measured over `crates/rimz/src`:

| `--similarity` | clusters | eligible fns clustered | default-path lines |
| --- | --- | --- | --- |
| 0.75 (old) | 6 | 5% | 55 |
| **0.65 (shipped)** | **96** | **22%** | **46** |
| 0.53 | 196 | 58% | 102 |

At 0.53 the family's floor is 0.5341 against a 0.53 threshold — one edit from breaking — and the verb prints 102 lines against a ~24–74 budget while clustering more than half of all eligible functions, which is no longer a shortlist. The acceptance criterion was relaxed rather than the default bent to meet it; the family stays one flag away via `--similarity 0.53`. `--top` also drops 15 → 10, which bounds the print structurally at any threshold.

**Strangler scopes resolve by filesystem path, not by module key.** The first implementation derived the scope with `crate_module_for_path`, which discards everything up to the first `src` component — and the crate name with it. That made `crates/rimz/src/theme` collide with `xtask/src/theme.rs`, and mapped every crate root to `""`, which counted the entire workspace. Review caught it with a two-crate reproduction: a rule scoped to `app/src` reported 7 occurrences where 2 existed, and a rule pinned to a file containing none reported 4. Counting now runs over `sources_for_path(...)` — the same helper the module rules already use, with component-wise path matching — through a shared `count_in_sources` that reuses the corpus tokenizer, so the test-file and inline `#[cfg(test)]` exclusions stay in one place. A two-crate regression test covers directory, nested-directory, and file scopes.

Also here: `api --module <name>` drills into one module's single-outside items, `--json` carries the full shortlist untruncated (its point) alongside per-module counts, and a filtered drill-down records `requested_module` in the payload so a consumer cannot mistake filtering for truncation.

## Advisories

- **`pin` fires on 8 of 52 `cli` modules** at the shipped defaults — sidebar, remote, room, message, gc, worktree, config, codex — against the 5 forecast when the thresholds were chosen. The thresholds are exactly as specified; the extra three surfaced as history moved and because the top-20 view hid config (rank 21) and codex (rank 37). Worth knowing before treating `pin` as a scarce signal.
- **`occ` over-counts common identifiers** — `render` 81.0, `ctx` 40.0 — because it counts whole-word identifiers, not resolved references. Documented in USAGE, not fixed: resolved-reference counting is a different instrument.
- **`seams` `(root) ⇄ *` row separation was skipped.** It was a "consider" ask, and the import-backed filter already changes that section's composition.
- **A strangler whose `path` matches no tracked Rust file counts 0 silently**, so the rule can never regress. Pre-existing and not touched here, but it is a quiet way to hold a dead budget.

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>forge</code> team · 3 agents · 1h03m active · $26.28 · 10 messages (1 from you)</summary>

- **planner** — Claude `claude-fable-5@high`
  - effort: 12m active · $7.40 incl. subagents
  - calls: 1 ask · 35 tool calls
  - messages: 1 from you · 2 from teammates · 3 to teammates
  - tokens: 89 input, 48.4k output, 202.7k cache write, 3.2m cache read
  - subagents: 1 × explore ($0.41)
- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 33m active · $11.94
  - calls: 91 tool calls
  - messages: 4 from teammates · 3 to teammates
  - tokens: 258.4k input, 37.2k output, 19.1m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 16m active · $6.94
  - calls: 68 tool calls
  - messages: 3 from teammates · 3 to teammates
  - tokens: 132 input, 59.2k output, 169.1k cache write, 7.5m cache read

</details>