### PR TITLE
Show the defining file for every configured agent spec

### DIFF
--- a/crates/rimz/src/cli/agents_cmd/mod.rs
+++ b/crates/rimz/src/cli/agents_cmd/mod.rs
@@ -567,10 +567,13 @@ pub fn run(args: AgentsArgs, globals: &GlobalFlags) -> Result<()> {
         Some(AgentsSubcmd::Check(args)) => return run_check(args),
         Some(AgentsSubcmd::Register(args)) => return run_register(args),
         Some(AgentsSubcmd::Specs { json }) => {
-            let config = rimz::config::MachineConfig::load().context("loading machine config")?;
+            let (config, sources) = rimz::config::MachineConfig::load_with_agent_spec_sources()
+                .context("loading machine config")?;
             return crate::cli::spec_report::list_specs(
                 &config.agents.profiles,
                 &config.agents.commands,
+                &sources,
+                rimz::config::effective::ProfileScope::Agents,
                 json,
             );
         }

--- a/crates/rimz/src/cli/agents_cmd/tests.rs
+++ b/crates/rimz/src/cli/agents_cmd/tests.rs
@@ -93,6 +93,8 @@ fn agent_specs_list_only_agent_profiles_with_descriptions() {
     let specs = crate::cli::spec_report::available_specs(
         &machine.agents.profiles,
         &machine.agents.commands,
+        &rimz::config::AgentSpecSources::default(),
+        rimz::config::effective::ProfileScope::Agents,
     );
     assert!(!specs.iter().any(|entry| entry.source == "kind"));
     assert!(specs.iter().any(|entry| {

--- a/crates/rimz/src/cli/spec_report.rs
+++ b/crates/rimz/src/cli/spec_report.rs
@@ -1,7 +1,10 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 use serde::Serialize;
 
 use super::render;
+use rimz::config::effective::ProfileScope;
 
 #[derive(Debug, PartialEq, Eq, Serialize)]
 pub(crate) struct AgentSpecReport {
@@ -15,6 +18,8 @@ pub(crate) struct AgentSpecReport {
     pub(crate) effort: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) path: Option<PathBuf>,
 }
 
 impl AgentSpecReport {
@@ -35,6 +40,8 @@ impl AgentSpecReport {
 pub(crate) fn available_specs(
     profiles: &rimz::config::ProfilesConfig,
     commands: &rimz::config::CommandsConfig,
+    sources: &rimz::config::AgentSpecSources,
+    scope: ProfileScope,
 ) -> Vec<AgentSpecReport> {
     let mut specs = profiles
         .0
@@ -46,6 +53,7 @@ pub(crate) fn available_specs(
             model: profile.model.clone(),
             effort: profile.effort.clone(),
             description: profile.description.clone(),
+            path: sources.profile(scope, name).map(PathBuf::from),
         })
         .collect::<Vec<_>>();
     specs.extend(commands.0.keys().map(|name| AgentSpecReport {
@@ -55,6 +63,7 @@ pub(crate) fn available_specs(
         model: None,
         effort: None,
         description: None,
+        path: sources.command(name).map(PathBuf::from),
     }));
     specs
 }
@@ -62,13 +71,21 @@ pub(crate) fn available_specs(
 pub(crate) fn list_specs(
     profiles: &rimz::config::ProfilesConfig,
     commands: &rimz::config::CommandsConfig,
+    sources: &rimz::config::AgentSpecSources,
+    scope: ProfileScope,
     json: bool,
 ) -> Result<()> {
-    let specs = available_specs(profiles, commands);
+    let specs = available_specs(profiles, commands, sources, scope);
     if json {
         return render::json_pretty(&specs);
     }
-    let mut table = render::Table::new(["SPEC", "SOURCE", "DETAIL", "DESCRIPTION"]);
+    spec_table(specs)
+        .render(&mut render::out())
+        .map_err(Into::into)
+}
+
+fn spec_table(specs: Vec<AgentSpecReport>) -> render::Table {
+    let mut table = render::Table::new(["SPEC", "SOURCE", "DETAIL", "DESCRIPTION", "PATH"]);
     for agent_spec in specs {
         let detail = agent_spec.detail();
         table.row([
@@ -76,7 +93,54 @@ pub(crate) fn list_specs(
             render::cell(agent_spec.source),
             render::cell(detail).dash(),
             render::cell(agent_spec.description.unwrap_or_else(|| "-".to_owned())).dash(),
+            render::cell(
+                agent_spec
+                    .path
+                    .map(|path| render::home_relative(&path.to_string_lossy()))
+                    .unwrap_or_else(|| "-".to_owned()),
+            )
+            .dash(),
         ]);
     }
-    table.render(&mut render::out()).map_err(Into::into)
+    table
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_is_the_final_spec_table_column() {
+        let specs = vec![
+            AgentSpecReport {
+                name: "planner".to_owned(),
+                source: "profile",
+                agent: Some("codex".to_owned()),
+                model: None,
+                effort: None,
+                description: Some("Plans the work".to_owned()),
+                path: Some(PathBuf::from("/tmp/rimz/agents.toml")),
+            },
+            AgentSpecReport {
+                name: "lint".to_owned(),
+                source: "command",
+                agent: None,
+                model: None,
+                effort: None,
+                description: None,
+                path: Some(PathBuf::from("/tmp/.agents/profiles/lint/agent.toml")),
+            },
+        ];
+        let mut output = Vec::new();
+
+        spec_table(specs)
+            .render(&mut anstream::StripStream::new(&mut output))
+            .expect("render spec table");
+
+        insta::assert_snapshot!(String::from_utf8(output).expect("utf-8"), @r"
+        SPEC     SOURCE   DETAIL  DESCRIPTION     PATH
+        planner  profile  codex   Plans the work  /tmp/rimz/agents.toml
+        lint     command  -       -               /tmp/.agents/profiles/lint/agent.toml
+        ");
+    }
 }

--- a/crates/rimz/src/cli/subagents/mod.rs
+++ b/crates/rimz/src/cli/subagents/mod.rs
@@ -551,8 +551,15 @@ fn list_children(json: bool, globals: &GlobalFlags) -> Result<()> {
 }
 
 fn list_specs(json: bool) -> Result<()> {
-    let config = rimz::config::MachineConfig::load().context("loading machine config")?;
-    crate::cli::spec_report::list_specs(&config.subagents.profiles, &config.agents.commands, json)
+    let (config, sources) = rimz::config::MachineConfig::load_with_agent_spec_sources()
+        .context("loading machine config")?;
+    crate::cli::spec_report::list_specs(
+        &config.subagents.profiles,
+        &config.agents.commands,
+        &sources,
+        rimz::config::effective::ProfileScope::Subagents,
+        json,
+    )
 }
 
 fn newest_run_for_child<'a>(

--- a/crates/rimz/src/cli/subagents/tests.rs
+++ b/crates/rimz/src/cli/subagents/tests.rs
@@ -369,6 +369,8 @@ fn available_specs_include_profiles_and_commands_but_not_kinds_or_teams() {
     let specs = crate::cli::spec_report::available_specs(
         &config.subagents.profiles,
         &config.agents.commands,
+        &rimz::config::AgentSpecSources::default(),
+        rimz::config::effective::ProfileScope::Subagents,
     );
 
     assert!(!specs.iter().any(|entry| entry.source == "kind"));

--- a/crates/rimz/src/config.rs
+++ b/crates/rimz/src/config.rs
@@ -359,6 +359,89 @@ pub struct AgentsFragmentError {
     pub message: String,
 }
 
+/// Definition files for the effective configured agent-spec catalog.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct AgentSpecSources {
+    agent_profiles: BTreeMap<String, PathBuf>,
+    subagent_profiles: BTreeMap<String, PathBuf>,
+    commands: BTreeMap<String, PathBuf>,
+}
+
+impl AgentSpecSources {
+    pub fn profile(&self, scope: effective::ProfileScope, name: &str) -> Option<&Path> {
+        match scope {
+            effective::ProfileScope::Agents => self.agent_profiles.get(name),
+            effective::ProfileScope::Subagents => self.subagent_profiles.get(name),
+        }
+        .map(PathBuf::as_path)
+    }
+
+    pub fn command(&self, name: &str) -> Option<&Path> {
+        self.commands.get(name).map(PathBuf::as_path)
+    }
+
+    fn from_layers(
+        agents: &AgentsConfig,
+        subagents: &SubagentProfilesConfig,
+        fragments: &[LoadedAgentsFragment],
+        agents_path: &Path,
+    ) -> Self {
+        let mut sources = Self::default();
+        for fragment in fragments {
+            let path = &fragment.path;
+            sources.agent_profiles.extend(
+                fragment
+                    .file
+                    .agents
+                    .profiles
+                    .0
+                    .keys()
+                    .map(|name| (name.clone(), path.clone())),
+            );
+            sources.subagent_profiles.extend(
+                fragment
+                    .file
+                    .subagents
+                    .profiles
+                    .0
+                    .keys()
+                    .map(|name| (name.clone(), path.clone())),
+            );
+            sources.commands.extend(
+                fragment
+                    .file
+                    .agents
+                    .commands
+                    .0
+                    .keys()
+                    .map(|name| (name.clone(), path.clone())),
+            );
+        }
+        sources.agent_profiles.extend(
+            agents
+                .profiles
+                .0
+                .keys()
+                .map(|name| (name.clone(), agents_path.to_path_buf())),
+        );
+        sources.subagent_profiles.extend(
+            subagents
+                .profiles
+                .0
+                .keys()
+                .map(|name| (name.clone(), agents_path.to_path_buf())),
+        );
+        sources.commands.extend(
+            agents
+                .commands
+                .0
+                .keys()
+                .map(|name| (name.clone(), agents_path.to_path_buf())),
+        );
+        sources
+    }
+}
+
 impl ConfigNotices {
     fn add_unknown_keys(&mut self, path: &Path, keys: Vec<String>) {
         self.unknown_keys
@@ -445,8 +528,14 @@ impl MachineConfig {
     /// Load from the default per-machine paths. Missing files are defaults —
     /// never an error.
     pub fn load() -> Result<Self> {
+        Self::load_with_agent_spec_sources().map(|(config, _)| config)
+    }
+
+    /// Load the strict per-machine config together with the declaring file for
+    /// every configured agent profile and command.
+    pub fn load_with_agent_spec_sources() -> Result<(Self, AgentSpecSources)> {
         let files = MachineConfigFiles::machine();
-        Self::load_from(files.core_path(), files.agents_home())
+        Self::load_from_with_agent_spec_sources(files.core_path(), files.agents_home())
     }
 
     /// Strictly load only the per-machine loop task file. Missing file is the
@@ -471,6 +560,13 @@ impl MachineConfig {
     /// agents-home root before validation — the test and tooling seam. A
     /// nonexistent fragment root means no fragments.
     pub fn load_from(config_path: &Path, agents_home: &Path) -> Result<Self> {
+        Self::load_from_with_agent_spec_sources(config_path, agents_home).map(|(config, _)| config)
+    }
+
+    fn load_from_with_agent_spec_sources(
+        config_path: &Path,
+        agents_home: &Path,
+    ) -> Result<(Self, AgentSpecSources)> {
         let files = MachineConfigFiles::from_paths(config_path, agents_home);
         let theme_path = files.path(MachineConfigFileKind::Theme);
         let agents_path = files.path(MachineConfigFileKind::Agents);
@@ -489,7 +585,7 @@ impl MachineConfig {
         notices.add_unknown_keys(&loop_path, loop_.unknown_keys);
         let mut config = Self::assemble(core.value, theme.value, agents.value, loop_.value);
         validate_notifications_config(&config.notifications, files.core_path())?;
-        apply_agents_home_collecting(
+        let sources = apply_agents_home_collecting(
             &mut config.agents,
             &mut config.subagents,
             files.agents_home(),
@@ -497,7 +593,7 @@ impl MachineConfig {
             &mut notices,
         )?;
         config.notices = notices;
-        Ok(config)
+        Ok((config, sources))
     }
 
     fn load_lenient_from(config_path: &Path, agents_home: &Path) -> Self {
@@ -595,7 +691,7 @@ impl MachineConfig {
                     file.agents = merged;
                     file.subagents = merged_subagents;
                 } else {
-                    apply_agents_home_collecting(
+                    let _ = apply_agents_home_collecting(
                         &mut file.agents,
                         &mut file.subagents,
                         agents_home,
@@ -1349,6 +1445,7 @@ fn apply_agents_home(
         agents_path,
         &mut ConfigNotices::default(),
     )
+    .map(|_| ())
 }
 
 fn apply_agents_home_collecting(
@@ -1357,9 +1454,11 @@ fn apply_agents_home_collecting(
     root: &Path,
     agents_path: &Path,
     notices: &mut ConfigNotices,
-) -> Result<()> {
+) -> Result<AgentSpecSources> {
     let discovered = discover_agents_home_collecting(root)?;
     notices.unknown_keys.extend(discovered.unknown_keys);
+    let sources =
+        AgentSpecSources::from_layers(agents, subagents, &discovered.fragments, agents_path);
     match fold_agents_fragments(agents, subagents, &discovered.fragments, agents_path) {
         FragmentFoldOutcome::Applied {
             agents: merged,
@@ -1371,7 +1470,7 @@ fn apply_agents_home_collecting(
             }
             *agents = merged;
             *subagents = merged_subagents;
-            Ok(())
+            Ok(sources)
         }
         FragmentFoldOutcome::InvalidBase(err) => Err(err.into_error()),
     }

--- a/crates/rimz/src/config/tests.rs
+++ b/crates/rimz/src/config/tests.rs
@@ -811,6 +811,75 @@ fn agents_home_fragments_merge_profiles_commands_and_teams() {
 }
 
 #[test]
+fn agent_spec_sources_follow_fragment_and_machine_precedence() {
+    let root = tempdir().expect("agents home");
+    let fragment_path = write_agents_home_fragment(
+        root.path(),
+        AGENTS_HOME_PROFILES_SUBDIR,
+        "base",
+        AGENT_FRAGMENT_FILE,
+        "[agents.profiles.fragment]\n\
+             agent = \"codex\"\n\
+         [agents.profiles.shared]\n\
+             agent = \"codex\"\n\
+         [agents.commands]\n\
+             lint = \"cargo check\"\n\
+         [subagents.profiles.child]\n\
+             agent = \"codex\"\n",
+    );
+    let overriding_fragment_path = write_agents_home_fragment(
+        root.path(),
+        AGENTS_HOME_PROFILES_SUBDIR,
+        "override",
+        AGENT_FRAGMENT_FILE,
+        "[agents.commands]\n\
+             lint = \"cargo clippy\"\n",
+    );
+    let config_dir = tempdir().expect("config dir");
+    let config_path = write_named(
+        &config_dir,
+        AGENTS_FILE,
+        "[agents.profiles.shared]\n\
+             agent = \"claude\"\n\
+         [agents.commands]\n\
+             shell = \"bash\"\n\
+         [subagents.profiles.local]\n\
+             agent = \"claude\"\n",
+    );
+    let agents_path = config_dir.path().join(AGENTS_FILE);
+
+    let (config, sources) =
+        MachineConfig::load_from_with_agent_spec_sources(&config_path, root.path())
+            .expect("load config with sources");
+
+    assert_eq!(
+        config.agents.commands.0.get("lint"),
+        Some(&"cargo clippy".to_owned())
+    );
+    assert_eq!(
+        sources.profile(effective::ProfileScope::Agents, "fragment"),
+        Some(fragment_path.as_path())
+    );
+    assert_eq!(
+        sources.profile(effective::ProfileScope::Subagents, "child"),
+        Some(fragment_path.as_path())
+    );
+    assert_eq!(
+        sources.command("lint"),
+        Some(overriding_fragment_path.as_path())
+    );
+    assert_eq!(
+        sources.profile(effective::ProfileScope::Agents, "shared"),
+        Some(agents_path.as_path())
+    );
+    assert_eq!(
+        sources.profile(effective::ProfileScope::Subagents, "local"),
+        Some(agents_path.as_path())
+    );
+    assert_eq!(sources.command("shell"), Some(agents_path.as_path()));
+}
+
+#[test]
 fn agents_home_fragments_merge_subagent_profiles_with_paths_and_machine_precedence() {
     let root = tempdir().expect("tempdir");
     let fragment_path = write_agents_home_fragment(

--- a/docs/reference/cli/agents.md
+++ b/docs/reference/cli/agents.md
@@ -63,7 +63,7 @@ rimz agents specs
 rimz agents types --json
 ```
 
-`specs` lists `[agents.profiles]` profiles and configured launch commands; `types` is an alias. Profile rows include their optional descriptions. Built-in and registered agent kinds remain directly launchable but are omitted from this configured-spec catalog. Teams are excluded because the catalog describes reusable cell types rather than cohort layouts.
+`specs` lists `[agents.profiles]` profiles and configured launch commands; `types` is an alias. Profile rows include their optional descriptions, and the final path column identifies the file that defines each row. Built-in and registered agent kinds remain directly launchable but are omitted from this configured-spec catalog. Teams are excluded because the catalog describes reusable cell types rather than cohort layouts.
 
 ### Register a third-party kind
 

--- a/docs/reference/cli/subagents.md
+++ b/docs/reference/cli/subagents.md
@@ -82,7 +82,7 @@ rimz subagents specs
 rimz subagents specs --json
 ```
 
-`specs` lists `[subagents.profiles]` profiles and configured launch commands available for one child, with a description column for profile metadata. `[agents.profiles]` entries are excluded. Built-in and registered agent kinds remain directly launchable but are omitted from this configured-spec catalog. It also works from a user shell; `types` is an alias. Team names are excluded because a subagent launch creates one agent, not a cohort.
+`specs` lists `[subagents.profiles]` profiles and configured launch commands available for one child, with description and defining-file path columns for profile metadata. `[agents.profiles]` entries are excluded. Built-in and registered agent kinds remain directly launchable but are omitted from this configured-spec catalog. It also works from a user shell; `types` is an alias. Team names are excluded because a subagent launch creates one agent, not a cohort.
 
 ## Join results
 


### PR DESCRIPTION
## Context

`rimz agents types` and `rimz subagents types` list the configured profiles and launch commands, but not where each one is declared. A definition can come from `~/.config/rimz/agents.toml` or from any `~/.agents/profiles/<name>/agent.toml` or `~/.agents/teams/<name>/team.toml` fragment, and when the same name appears in several of them the listing gave no way to tell which file actually won. This adds the final source-path column so a row can be traced back to the file that defines it.

## Implementation

Definition provenance is derived inside the strict machine-config loader (`MachineConfig::load_with_agent_spec_sources`), next to the fragment fold, so a path is selected by exactly the rules that select the effective value: fragments in sorted discovery order with the later one winning, and `agents.toml` overriding every fragment. Deriving it in the loader rather than reparsing files in the CLI avoids a second filesystem view that could disagree with the config the command just loaded. `MachineConfig::load` and `load_from` keep their signatures and drop the extra return.

Both listings render through the shared spec table, which gains a final `PATH` column: human output abbreviates the home directory to `~`, and a row with no known source renders `-`.

Departure from the stated goal: the `--json` form also carries the field, as an absolute `path` on each entry, so the machine-readable catalog says the same thing as the table. No existing field changed. Both CLI reference pages document the new column.

## Advisories

None blocking; all four are take-it-or-leave-it, and detailed in `review-notes.md`.

- `AgentSpecSources::from_layers` repeats the same six-line map-extend shape six times; a small private helper would cut it to six lines.
- The two `available_specs` unit tests pass an empty `AgentSpecSources`, so nothing automated covers the `ProfileScope` wiring at the two call sites — a swapped scope would print the wrong file with every test still green. Confirmed correct by hand against a live config tree.
- `let _ = apply_agents_home_collecting(...)?;` in `config.rs` keeps the `?` and so propagates errors as before, but the `let _ =` is a redundant refactor leftover.
- The root `AGENTS.md` quick reference still glosses both listings as "profiles, commands, and descriptions".

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>spot</code> team · 2 agents · 21m active · $7.29 · 2 messages (1 from you)</summary>

- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 14m active · $4.63
  - calls: 51 tool calls
  - messages: 1 from you · 1 to teammates
  - tokens: 174k input, 19.2k output, 6.4m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 7m active · $2.66
  - calls: 40 tool calls
  - messages: 1 from teammates
  - tokens: 64 input, 26.9k output, 95.5k cache write, 2.1m cache read

</details>