### PR TITLE
Correct atlas production inputs and sharpen its refactor diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,4 +133,5 @@ Every other document is a leaf from here, grouped by purpose: **interface** (see
 **Contributing** — `docs/contributing/`
 - [rust-conventions.md](./docs/contributing/rust-conventions.md) — Rust shape: CLI, errors, stdout discipline, actor pattern, test taxonomy, toolchain, quality gates.
 - [agent-adapters.md](./docs/contributing/agent-adapters.md) — the built-in adapter integration playbook: protocol reference to landed adapter, step by step, with the deliverables checklist.
+- [atlas.md](./docs/contributing/atlas.md) — operating guide for `cargo xtask atlas` refactor analysis: reading each verb, the target-driven program shape, and the `refactor-target.toml` convergence loop.
 - [sidebar-screenshots.md](./docs/contributing/sidebar-screenshots.md) — contributor PNG capture workflow for sidebar frames.

--- a/docs/contributing/atlas.md
+++ b/docs/contributing/atlas.md
@@ -1,0 +1,81 @@
+# Atlas: refactor analysis
+
+`cargo xtask atlas` is the instrument for architecture-refactor programs: it locates where accretion cost concentrates, measures how deep each boundary really is, and turns "is this module done?" into a machine-checked answer. This page is the operating guide for agents running such a program; the command reference lives in [rust-conventions.md](./rust-conventions.md).
+
+The premise: opportunity-driven refactoring never terminates. Atlas exists to run **target-driven** refactoring — a written target design fixed up front, passes measured as diffs against it, and `refactor-target.toml` ratcheting each landed pass so a finished module never needs re-review. A module is done when `conform` reports it clean and a ratchet guards it; reopening one requires a deliberate edit to the target file in its own commit.
+
+## Program shape
+
+1. **Round 0 — evidence and target.** Run `rank`, `seams`, `api`, and `shapes` over the scope. Write the from-scratch target (a page: modules, seams, what each hides from callers) plus the pass list with prerequisites and line budgets. Seed `refactor-target.toml` with `conform --init`, then narrow it to encode the target: shrink allow-lists, lower pub budgets, add stranglers for paths that must die.
+2. **Each pass — one seam or one submodule.** Verticals take a submodule to its target shape; horizontals collapse one piece of knowledge repeated across many files (`shapes` clusters and `seams` divergence rows are the horizontal detectors). Horizontals usually go first: they fix the shape every vertical then conforms to. A pass exits when its `conform` rules are clean, net source lines fell, and behavior held.
+3. **Ratchet.** `conform --ratchet` runs inside `gate`/`checks`; after improvement, `conform --tighten` locks the gains. Pace and delta columns (`--since`) are the burn-down chart between passes.
+
+Modules flagged `pin` get characterization tests before their pass touches them — that is schedulable prerequisite work, visible from `rank` on day one.
+
+## Reading the verbs
+
+Every verb follows `--path`, prints top-N tables plus a totals line so truncation never hides mass, and emits versioned JSON with `--json`. Text output is bounded (~25–100 lines) and safe to print; route `--json` to a file under `/tmp` and narrow with `jq`.
+
+### `rank` — where should I look?
+
+One row per module: `code`, `pub`, `loc/pub`, `churn%`, `pace`, `cx`, `t/c`, `flags`. Sort order is churn-weighted size — accretion cost paid daily, not raw bulk.
+
+- `loc/pub` is the depth proxy: implementation hidden per public item. High is deep; low with a wide `pub` count is over-publication.
+- Flags are facts, not verdicts: `pin` (churny and under-tested — pin tests first), `hot` (pace ≥ 1.5×), `shallow` (wide, thin, low-use surface — deepen or fold into the caller), `hub` (wide, thin, high-use — a shared surface to treat deliberately).
+- `—` in pace means too few commits to trust; the tail row aggregates everything below the fold.
+- `--verbose` lists top offender functions — where several large entry points share a shape that `shapes` cannot see (see its blind spot below).
+
+### `seams` — where are the seams, really?
+
+Four sections, in rising value:
+
+- **Import edges** and **external surface**: what each module must know from outside. A command module importing 100+ items from eight providers is the measurement of the missing context seam.
+- **External providers**: fan-in ranking — which outside surfaces every pass will touch.
+- **Co-change edges**: files that change together (window-scoped, commits touching more than `--max-commit-files` Rust sources omitted as merge noise).
+- **Divergence** is the payload: `cochange-without-import` pairs are hidden knowledge duplication — two modules that must change together with no declared dependency. These are rehome candidates located for free; read the top rows before believing any target design.
+
+Imports come from `use` items only; inline qualified paths are invisible here (they still count in `conform` stranglers and `api` occurrences).
+
+### `api` — how deep is each boundary?
+
+Per module: `pub fn`, `pub type`, `occ/item` (median outside-file identifier occurrences, tests excluded), `occ0` (items with zero such occurrences), `params/fn`. Then the shortlist of public items used by exactly one outside module — interface that arguably shouldn't be interface. `--module <name>` drills into one module's items with file:line.
+
+`occ` is heuristic whole-word counting, not resolved callers: common names over-count, and `occ0` conflates dead with test-only. Treat a large `occ0` as a demote-or-delete *shortlist to read*, never a deletion list to execute.
+
+### `shapes` — what repeats?
+
+Clusters large functions by Jaccard similarity over shared domain callees (generic iterator/conversion/error methods excluded, three shared callees minimum). A cluster is a collapse candidate: the member list is the exact scope of a horizontal pass. Several small clusters sharing one provider's helpers usually indicate a single missing seam, not several — read them together.
+
+Blind spot: functions with the same control flow but different callees (parallel command entry points, each orchestrating its own domain) never cluster here. Find those through `rank --verbose` cx offenders.
+
+### `conform` — am I done?
+
+Compares the tree against `refactor-target.toml`: per-module import allow-lists, pub budgets, and strangler symbol counts that must trend to zero. `--init` seeds a truthful baseline from the current tree and never overwrites; `--tighten` only lowers; `--ratchet` fails only on regression and is inert without a target file. Loosening any rule is a hand edit to the toml — that friction is the point.
+
+Strangler entries make stalled migrations impossible to ignore: add one when a pass leaves old and new paths coexisting, with the old symbol's count as the baseline, and tighten it toward zero as callers migrate.
+
+## Recipes
+
+Round 0 evidence sweep over a scope:
+
+```sh
+cargo xtask atlas rank   --path crates/rimz/src/cli
+cargo xtask atlas seams  --path crates/rimz/src/cli
+cargo xtask atlas api    --path crates/rimz/src/cli
+cargo xtask atlas shapes --path crates/rimz/src/cli
+cargo xtask atlas conform --init --path crates/rimz/src/cli   # then narrow the toml to the target
+```
+
+Per-pass loop:
+
+```sh
+cargo xtask atlas conform                          # burn-down before planning
+cargo xtask atlas api --path <scope> --module <m>  # item-level ground truth for the pass
+# ... pass lands, gate passes ...
+cargo xtask atlas conform --tighten                # lock the gains
+cargo xtask atlas rank --path <scope> --since <baseline-ref>   # verify net-subtractive
+```
+
+## Judgment stays with the reader
+
+Atlas locates; it does not decide. A `shallow` flag can be a module mid-migration, a divergence pair can be a legitimate product coupling, an `occ0` item can be a public contract used downstream. Before acting on any row, read the code and its history (`git log -S`), and let the finding earn its verb — collapse, delete, deepen, or rehome — from evidence, not from the table alone.

--- a/docs/contributing/atlas.md
+++ b/docs/contributing/atlas.md
@@ -14,11 +14,11 @@ Modules flagged `pin` get characterization tests before their pass touches them 
 
 ## Reading the verbs
 
-Every verb follows `--path`, prints top-N tables plus a totals line so truncation never hides mass, and emits versioned JSON with `--json`. Text output is bounded (~25–100 lines) and safe to print; route `--json` to a file under `/tmp` and narrow with `jq`.
+Every verb follows `--path`, prints top-N tables plus a totals line so truncation never hides mass, and emits versioned JSON with `--json`. Text output is bounded by default and safe to print; explicit drill-downs can be longer. Route `--json` to a file under `/tmp` and narrow with `jq`. Modules compiled only for `test` or the `testkit` feature are excluded from production measurements; test modules still contribute to `rank`'s `t/c` ratio, while `testkit` support does not.
 
 ### `rank` — where should I look?
 
-One row per module: `code`, `pub`, `loc/pub`, `churn%`, `pace`, `cx`, `t/c`, `flags`. Sort order is churn-weighted size — accretion cost paid daily, not raw bulk.
+One row per module: `code`, `pub`, `loc/pub`, `churn%`, `pace`, `cx`, `t/c`, `flags`. Sort order is churn-weighted size — accretion cost paid daily, not raw bulk. `cx` is the sum of severity-weighted cognitive, cyclomatic, and source-line threshold overruns for the module's functions.
 
 - `loc/pub` is the depth proxy: implementation hidden per public item. High is deep; low with a wide `pub` count is over-publication.
 - Flags are facts, not verdicts: `pin` (churny and under-tested — pin tests first), `hot` (pace ≥ 1.5×), `shallow` (wide, thin, low-use surface — deepen or fold into the caller), `hub` (wide, thin, high-use — a shared surface to treat deliberately).
@@ -31,14 +31,15 @@ Four sections, in rising value:
 
 - **Import edges** and **external surface**: what each module must know from outside. A command module importing 100+ items from eight providers is the measurement of the missing context seam.
 - **External providers**: fan-in ranking — which outside surfaces every pass will touch.
-- **Co-change edges**: files that change together (window-scoped, commits touching more than `--max-commit-files` Rust sources omitted as merge noise).
+- **Co-change edges**: files that change together (window-scoped, commits touching more than `--max-commit-files` Rust sources omitted as merge noise, and pairs below `--min-cochange` hidden).
 - **Divergence** is the payload: `cochange-without-import` pairs are hidden knowledge duplication — two modules that must change together with no declared dependency. These are rehome candidates located for free; read the top rows before believing any target design.
 
 Imports come from `use` items only; inline qualified paths are invisible here (they still count in `conform` stranglers and `api` occurrences).
+Use `--module <name>` to expand every import edge touching one scoped module into its distinct imported item names.
 
 ### `api` — how deep is each boundary?
 
-Per module: `pub fn`, `pub type`, `occ/item` (median outside-file identifier occurrences, tests excluded), `occ0` (items with zero such occurrences), `params/fn`. Then the shortlist of public items used by exactly one outside module — interface that arguably shouldn't be interface. `--module <name>` drills into one module's items with file:line.
+Per module: `pub fn`, `pub type`, `occ/item` (median outside-file identifier occurrences, tests excluded), `occ0` (items with zero such occurrences), `params/fn`. Then the shortlist of public items used by exactly one outside module — interface that arguably shouldn't be interface. `--module <name>` prints every public item in that module with kind, occurrences, outside-module count, and file:line, followed by the single-outside-module shortlist.
 
 `occ` is heuristic whole-word counting, not resolved callers: common names over-count, and `occ0` conflates dead with test-only. Treat a large `occ0` as a demote-or-delete *shortlist to read*, never a deletion list to execute.
 
@@ -50,9 +51,46 @@ Blind spot: functions with the same control flow but different callees (parallel
 
 ### `conform` — am I done?
 
-Compares the tree against `refactor-target.toml`: per-module import allow-lists, pub budgets, and strangler symbol counts that must trend to zero. `--init` seeds a truthful baseline from the current tree and never overwrites; `--tighten` only lowers; `--ratchet` fails only on regression and is inert without a target file. Loosening any rule is a hand edit to the toml — that friction is the point.
+Compares the tree against `refactor-target.toml`: per-module import allow-lists, pub budgets, and strangler symbol counts that must trend to zero. `--init` seeds a truthful baseline from the current tree and never overwrites; `--tighten` only lowers; `--ratchet` fails only on regression and is inert without a target file. The default report shows regressions and budget headroom, folding unchanged rules; `--verbose` restores the full table. Import violations include their source locations. Loosening any rule is a hand edit to the toml — that friction is the point.
 
 Strangler entries make stalled migrations impossible to ignore: add one when a pass leaves old and new paths coexisting, with the old symbol's count as the baseline, and tighten it toward zero as callers migrate.
+
+## From baseline to target
+
+Suppose `conform --init --path crates/rimz/src/cli` records the current legacy command at 12 public items with two providers:
+
+```toml
+[[module]]
+path = "crates/rimz/src/cli/legacy"
+allowed-imports = ["agents", "store"]
+pub-budget = 12
+```
+
+For the pass that moves store knowledge behind the agents seam, edit that rule to the completed shape and make removal of the old bridge explicit:
+
+```toml
+[[module]]
+path = "crates/rimz/src/cli/legacy"
+allowed-imports = ["agents"]
+pub-budget = 8
+
+[[strangler]]
+symbol = "LegacyStoreBridge"
+path = "crates/rimz/src/cli"
+baseline = 0
+```
+
+Before the implementation, `conform` reports the excess public-item count, forbidden import locations, and remaining bridge occurrences. After the pass, a clean `conform --ratchet` proves the target shape, `conform --tighten` preserves any improvement beyond the written budgets, and `rank --since <pre-pass-ref>` proves the pass was net-subtractive. Narrow only the rules owned by the current pass; untouched seeded rules remain a status-quo ratchet until their turn.
+
+## JSON v1 contracts
+
+JSON field names are stable snake_case. All reports carry `version` and `verb`; analysis verbs also carry `path` and `parse_failures`. Top-N truncation applies to text-oriented report arrays unless noted, while totals describe the complete result.
+
+- `rank`: `history_commits`, `total_modules`, `total_code`, `total_tests`, `total_pub_items`, `total_complexity`, `rows`, and optional `offenders`. Each row exposes the named text columns plus `tests`, `occurrence_median`, and optional deltas.
+- `seams`: history bounds; totals and arrays for `import_edges`, `external_surface`, `external_providers`, `cochange_edges`, and `divergence`; optional `cochange_hub`; per-kind divergence totals; and, with `--module`, `requested_module` plus untruncated `import_items` per edge.
+- `api`: `total_modules`, `modules`, `total_single_caller_items`, `single_caller_modules`, and `single_caller_items`. With `--module`, `requested_module` and untruncated `module_items` contain item kind, defining path/line, occurrences, and outside-module count.
+- `shapes`: `eligible_functions`, `total_clusters`, and `clusters`; each cluster includes similarity, score, breadth, shared callees, and member locations/SLOC.
+- `conform`: `target`, `rules`, `regressions`, and `parse_failures`. Module rules include `unallowed_imports` and `unallowed_import_sites`; an absent default target instead returns `configured: false` with its target path.
 
 ## Recipes
 

--- a/docs/contributing/atlas.md
+++ b/docs/contributing/atlas.md
@@ -14,7 +14,7 @@ Modules flagged `pin` get characterization tests before their pass touches them 
 
 ## Reading the verbs
 
-Every verb follows `--path`, prints top-N tables plus a totals line so truncation never hides mass, and emits versioned JSON with `--json`. Text output is bounded by default and safe to print; explicit drill-downs can be longer. Route `--json` to a file under `/tmp` and narrow with `jq`. Modules compiled only for `test` or the `testkit` feature are excluded from production measurements; test modules still contribute to `rank`'s `t/c` ratio, while `testkit` support does not.
+Every verb follows `--path`, prints top-N tables plus a totals line so truncation never hides mass, and emits versioned JSON with `--json`. Text output is bounded and safe to print; route `--json` to a file under `/tmp` and narrow with `jq`. External modules reached through `cfg(test)` or `cfg(feature = "testkit")` declarations are excluded from production measurements; test modules still contribute to `rank`'s `t/c` ratio, while testkit support does not.
 
 ### `rank` — where should I look?
 
@@ -39,7 +39,7 @@ Use `--module <name>` to expand every import edge touching one scoped module int
 
 ### `api` — how deep is each boundary?
 
-Per module: `pub fn`, `pub type`, `occ/item` (median outside-file identifier occurrences, tests excluded), `occ0` (items with zero such occurrences), `params/fn`. Then the shortlist of public items used by exactly one outside module — interface that arguably shouldn't be interface. `--module <name>` prints every public item in that module with kind, occurrences, outside-module count, and file:line, followed by the single-outside-module shortlist.
+Per module: `pub fn`, `pub type`, `occ/item` (median outside-file identifier occurrences, tests excluded), `occ0` (items with zero such occurrences), `params/fn`. Then the shortlist of public items used by exactly one outside module — interface that arguably shouldn't be interface. `--module <name>` prints the top public items in that module with kind, occurrences, outside-module count, and file:line, followed by the single-outside-module shortlist; `--json` carries the complete item list.
 
 `occ` is heuristic whole-word counting, not resolved callers: common names over-count, and `occ0` conflates dead with test-only. Treat a large `occ0` as a demote-or-delete *shortlist to read*, never a deletion list to execute.
 
@@ -88,7 +88,7 @@ JSON field names are stable snake_case. All reports carry `version` and `verb`; 
 
 - `rank`: `history_commits`, `total_modules`, `total_code`, `total_tests`, `total_pub_items`, `total_complexity`, `rows`, and optional `offenders`. Each row exposes the named text columns plus `tests`, `occurrence_median`, and optional deltas.
 - `seams`: history bounds; totals and arrays for `import_edges`, `external_surface`, `external_providers`, `cochange_edges`, and `divergence`; optional `cochange_hub`; per-kind divergence totals; and, with `--module`, `requested_module` plus untruncated `import_items` per edge.
-- `api`: `total_modules`, `modules`, `total_single_caller_items`, `single_caller_modules`, and `single_caller_items`. With `--module`, `requested_module` and untruncated `module_items` contain item kind, defining path/line, occurrences, and outside-module count.
+- `api`: `total_modules`, `modules`, `total_single_caller_items`, `single_caller_modules`, and `single_caller_items`. With `--module`, `requested_module` and the complete `module_items` array contain item kind, defining path/line, occurrences, and outside-module count; text still follows `--top`.
 - `shapes`: `eligible_functions`, `total_clusters`, and `clusters`; each cluster includes similarity, score, breadth, shared callees, and member locations/SLOC.
 - `conform`: `target`, `rules`, `regressions`, and `parse_failures`. Module rules include `unallowed_imports` and `unallowed_import_sites`; an absent default target instead returns `configured: false` with its target path.
 

--- a/xtask/src/atlas/api.rs
+++ b/xtask/src/atlas/api.rs
@@ -158,14 +158,17 @@ fn parse_args(args: &[String]) -> Result<Option<Args>> {
 }
 
 fn build_report(root: &Path, args: &Args) -> Result<Report> {
-    let scoped_sources = sources::scope_sources(root, &args.path, None)?;
-    let all_sources = sources::scope_sources(root, Path::new("."), None)?;
+    let all_sources = sources::all_sources(root, None)?;
+    let scoped_sources = sources::sources_in_scope(&all_sources, &args.path)?;
     let occurrence_corpus = OccurrenceCorpus::new(&all_sources);
     let syntax = syntax::analyze_sources(&scoped_sources);
     let previous = args
         .since
         .as_deref()
-        .map(|reference| sources::scope_sources(root, &args.path, Some(reference)))
+        .map(|reference| {
+            let all_sources = sources::all_sources(root, Some(reference))?;
+            sources::sources_in_scope(&all_sources, &args.path)
+        })
         .transpose()?
         .map(|sources| syntax::analyze_sources(&sources));
     let previous_counts = previous
@@ -486,7 +489,7 @@ fn print_report(report: &Report, top: usize, requested_module: Option<&str>, sho
     println!();
     if let Some(module) = requested_module {
         println!("Public items in {module} (`occ` is identifier occurrences)");
-        for item in &report.module_items {
+        for item in report.module_items.iter().take(top) {
             println!(
                 "{}::{} ({}) {}:{} occ {} outside-modules {}",
                 item.module,
@@ -496,6 +499,12 @@ fn print_report(report: &Report, top: usize, requested_module: Option<&str>, sho
                 item.line,
                 item.occurrences,
                 item.outside_modules
+            );
+        }
+        if report.module_items.len() > top {
+            println!(
+                "… and {} more public items (use --json for the complete list)",
+                report.module_items.len() - top
             );
         }
         println!();

--- a/xtask/src/atlas/api.rs
+++ b/xtask/src/atlas/api.rs
@@ -73,6 +73,8 @@ struct Report {
     requested_module: Option<String>,
     total_modules: usize,
     modules: Vec<ModuleApi>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    module_items: Vec<ItemOccurrence>,
     total_single_caller_items: usize,
     single_caller_modules: Vec<SingleCallerModule>,
     single_caller_items: Vec<ItemOccurrence>,
@@ -195,6 +197,18 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
         }
     }
 
+    let mut requested_module_items = args
+        .module
+        .as_ref()
+        .and_then(|module| module_items.get(module))
+        .cloned()
+        .unwrap_or_default();
+    requested_module_items.sort_by(|left, right| {
+        left.path
+            .cmp(&right.path)
+            .then_with(|| left.line.cmp(&right.line))
+            .then_with(|| left.name.cmp(&right.name))
+    });
     let mut scoped_single_caller_items = Vec::new();
     let mut modules = module_items
         .into_iter()
@@ -264,6 +278,7 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
         requested_module: args.module.clone(),
         total_modules,
         modules,
+        module_items: requested_module_items,
         total_single_caller_items,
         single_caller_modules,
         single_caller_items,
@@ -357,10 +372,7 @@ pub(super) struct OccurrenceCorpus {
 impl OccurrenceCorpus {
     pub(super) fn new(sources: &[Source]) -> Self {
         let mut modules = BTreeMap::<String, BTreeMap<String, usize>>::new();
-        for source in sources
-            .iter()
-            .filter(|source| !crate::source_files::is_test_file(&source.path))
-        {
+        for source in sources.iter().filter(|source| source.is_production()) {
             let counts = modules
                 .entry(crate_module_for_path(&source.path))
                 .or_default();
@@ -472,6 +484,20 @@ fn print_report(report: &Report, top: usize, requested_module: Option<&str>, sho
     }
     println!();
     if let Some(module) = requested_module {
+        println!("Public items in {module} (`occ` is identifier occurrences)");
+        for item in &report.module_items {
+            println!(
+                "{}::{} ({}) {}:{} occ {} outside-modules {}",
+                item.module,
+                item.name,
+                item.kind,
+                item.path.display(),
+                item.line,
+                item.occurrences,
+                item.outside_modules
+            );
+        }
+        println!();
         println!(
             "Single-outside-module public items in {module} (`occ` is identifier occurrences)"
         );
@@ -540,10 +566,10 @@ mod tests {
 
     #[test]
     fn occurrence_scan_uses_identifier_boundaries() {
-        let sources = vec![Source {
-            path: PathBuf::from("src/caller.rs"),
-            text: "run(); rerun(); run_again(); run".to_owned(),
-        }];
+        let sources = vec![Source::new(
+            "src/caller.rs",
+            "run(); rerun(); run_again(); run",
+        )];
         assert_eq!(
             OccurrenceCorpus::new(&sources).count_from_module("", "run"),
             (2, 1)
@@ -559,19 +585,12 @@ mod tests {
     #[test]
     fn occurrence_corpus_excludes_test_files_and_inline_test_modules() {
         let sources = vec![
-            Source {
-                path: PathBuf::from("src/lib.rs"),
-                text: "pub fn target() {}\n".to_owned(),
-            },
-            Source {
-                path: PathBuf::from("src/live.rs"),
-                text: "fn caller() { target(); }\n#[cfg(test)]\nmod tests { fn check() { target(); } }\n"
-                    .to_owned(),
-            },
-            Source {
-                path: PathBuf::from("src/tests.rs"),
-                text: "fn check() { target(); }\n".to_owned(),
-            },
+            Source::new("src/lib.rs", "pub fn target() {}\n"),
+            Source::new(
+                "src/live.rs",
+                "fn caller() { target(); }\n#[cfg(test)]\nmod tests { fn check() { target(); } }\n",
+            ),
+            Source::new("src/tests.rs", "fn check() { target(); }\n"),
         ];
         assert_eq!(
             OccurrenceCorpus::new(&sources).count_from_module("", "target"),
@@ -582,18 +601,9 @@ mod tests {
     #[test]
     fn occurrence_count_in_sources_sums_only_the_supplied_sources() {
         let sources = vec![
-            Source {
-                path: PathBuf::from("src/cli/render.rs"),
-                text: "target();".to_owned(),
-            },
-            Source {
-                path: PathBuf::from("src/cli/render/table.rs"),
-                text: "target(); target();".to_owned(),
-            },
-            Source {
-                path: PathBuf::from("src/cli/renderer.rs"),
-                text: "target(); target(); target();".to_owned(),
-            },
+            Source::new("src/cli/render.rs", "target();"),
+            Source::new("src/cli/render/table.rs", "target(); target();"),
+            Source::new("src/cli/renderer.rs", "target(); target(); target();"),
         ];
         assert_eq!(OccurrenceCorpus::count_in_sources(&sources, "target"), 6);
     }
@@ -684,6 +694,7 @@ mod tests {
             requested_module: Some("room".to_owned()),
             total_modules: 1,
             modules: Vec::new(),
+            module_items: vec![item("all-items", 0)],
             total_single_caller_items: 10,
             single_caller_modules: Vec::new(),
             single_caller_items: vec![item("filtered", 1)],
@@ -692,6 +703,7 @@ mod tests {
 
         let payload = serde_json::to_value(report).unwrap();
         assert_eq!(payload["requested_module"], "room");
+        assert_eq!(payload["module_items"].as_array().unwrap().len(), 1);
         assert_eq!(payload["single_caller_items"].as_array().unwrap().len(), 1);
         assert_eq!(payload["total_single_caller_items"], 10);
     }

--- a/xtask/src/atlas/api.rs
+++ b/xtask/src/atlas/api.rs
@@ -17,7 +17,8 @@ const USAGE: &str =
 
 Reports public boundary shape and whole-word identifier occurrences outside each
 defining file-module. `occ` excludes tests; 0 may mean unreferenced or test-only.
-Common identifiers can over-count, so `occ` is not a resolved caller count.
+`occ/item` is the median across a module's public items. Common identifiers can
+over-count, so `occ` is not a resolved caller count.
 
   --path <path>    root-relative subtree (default crates/rimz/src)
   --top N          rows per section (default 20)

--- a/xtask/src/atlas/conform.rs
+++ b/xtask/src/atlas/conform.rs
@@ -268,6 +268,7 @@ fn initialize(root: &Path, scope: &Path) -> Result<Target> {
     let syntax = syntax::analyze_sources(&scoped_sources);
     let known_modules = all_sources
         .iter()
+        .filter(|source| source.is_production())
         .map(|source| crate_module_for_path(&source.path))
         .collect::<BTreeSet<_>>();
     let workspace_crates = workspace_crate_names(root)?;
@@ -343,6 +344,7 @@ fn evaluate(
     let all_sources = sources::working_tree_rust_sources(root)?;
     let known_modules = all_sources
         .iter()
+        .filter(|source| source.is_production())
         .map(|source| crate_module_for_path(&source.path))
         .collect::<BTreeSet<_>>();
     let workspace_crates = workspace_crate_names(root)?;

--- a/xtask/src/atlas/conform.rs
+++ b/xtask/src/atlas/conform.rs
@@ -15,7 +15,7 @@ use super::{set_once, validate_scope, value};
 
 const DEFAULT_PATH: &str = "crates/rimz/src";
 
-const USAGE: &str = "cargo xtask atlas conform [--ratchet|--tighten|--init] [--file <path>] [--path <prefix>] [--json]
+const USAGE: &str = "cargo xtask atlas conform [--ratchet|--tighten|--init] [--file <path>] [--path <prefix>] [--verbose] [--json]
 
 Compares the working tree with a refactor target (root refactor-target.toml by
 default). `--ratchet` fails only when current values exceed budgets/baselines or
@@ -33,6 +33,7 @@ Split Rust modules (`foo.rs` plus `foo/`) remain separate filesystem rules.
   --file <path>  target file (default root refactor-target.toml);
                  absolute as-is, relative from the repository root
   --path <path>  root-relative init subtree (default crates/rimz/src)
+  --verbose      show every rule instead of folding rules exactly at budget
   --json         versioned JSON agent contract (v1)
 
 Schema:
@@ -59,7 +60,15 @@ struct Args {
     mode: Mode,
     file: Option<PathBuf>,
     path: Option<PathBuf>,
+    verbose: bool,
     json: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct ImportSite {
+    module: String,
+    path: PathBuf,
+    line: usize,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -72,6 +81,7 @@ struct RuleResult {
     budget: usize,
     delta: isize,
     unallowed_imports: Vec<String>,
+    unallowed_import_sites: Vec<ImportSite>,
     config_line: usize,
 }
 
@@ -159,7 +169,7 @@ pub(super) fn run(root: &Path, args: &[String]) -> Result<()> {
                         .context("rendering atlas conform JSON")?
                 );
             } else {
-                print_report(&report);
+                print_report(&report, args.verbose);
             }
             Ok(())
         }
@@ -197,6 +207,7 @@ fn parse_args(args: &[String]) -> Result<Option<Args>> {
     let mut mode = Mode::Report;
     let mut file = None;
     let mut path = None;
+    let mut verbose = false;
     let mut json = false;
     let mut index = 0;
     while let Some(arg) = args.get(index) {
@@ -230,6 +241,11 @@ fn parse_args(args: &[String]) -> Result<Option<Args>> {
                 set_once(&mut path, parsed, "conform", "--path")?;
                 index += 2;
             }
+            "--verbose" if !verbose => {
+                verbose = true;
+                index += 1;
+            }
+            "--verbose" => bail!("atlas conform --verbose may only be passed once"),
             "--json" if !json => {
                 json = true;
                 index += 1;
@@ -247,10 +263,17 @@ fn parse_args(args: &[String]) -> Result<Option<Args>> {
     if mode != Mode::Init && path.is_some() {
         bail!("atlas conform --path requires --init");
     }
+    if mode != Mode::Report && verbose {
+        bail!("atlas conform --verbose is only valid for the default report mode");
+    }
+    if json && verbose {
+        bail!("atlas conform --verbose does not combine with --json");
+    }
     Ok(Some(Args {
         mode,
         file,
         path,
+        verbose,
         json,
     }))
 }
@@ -374,23 +397,39 @@ fn evaluate(
             module.path.clone()
         };
         let target_module = crate_module_for_path(&module_entry);
-        let mut unallowed_imports = parsed
-            .files
-            .iter()
-            .flat_map(|file| &file.imports)
-            .filter_map(|import| {
-                syntax::resolved_internal_import(import, &known_modules, &workspace_crates)
+        let mut unallowed = BTreeMap::<String, BTreeSet<(PathBuf, usize)>>::new();
+        for file in &parsed.files {
+            for import in &file.imports {
+                let Some(resolved) =
+                    syntax::resolved_internal_import(import, &known_modules, &workspace_crates)
+                else {
+                    continue;
+                };
+                if is_within(&resolved, &target_module)
+                    || module
+                        .allowed_imports
+                        .iter()
+                        .any(|allowed| is_within(&resolved, allowed))
+                {
+                    continue;
+                }
+                unallowed
+                    .entry(resolved)
+                    .or_default()
+                    .insert((file.path.clone(), import.line));
+            }
+        }
+        let unallowed_imports = unallowed.keys().cloned().collect::<Vec<_>>();
+        let unallowed_import_sites = unallowed
+            .into_iter()
+            .flat_map(|(module, sites)| {
+                sites.into_iter().map(move |(path, line)| ImportSite {
+                    module: module.clone(),
+                    path,
+                    line,
+                })
             })
-            .filter(|import| !is_within(import, &target_module))
-            .filter(|import| {
-                !module
-                    .allowed_imports
-                    .iter()
-                    .any(|allowed| is_within(import, allowed))
-            })
-            .collect::<Vec<_>>();
-        unallowed_imports.sort();
-        unallowed_imports.dedup();
+            .collect();
         let regression = current > module.pub_budget || !unallowed_imports.is_empty();
         rules.push(RuleResult {
             kind: "module",
@@ -401,6 +440,7 @@ fn evaluate(
             budget: module.pub_budget,
             delta: current as isize - module.pub_budget as isize,
             unallowed_imports,
+            unallowed_import_sites,
             config_line: module.config_line,
         });
     }
@@ -429,6 +469,7 @@ fn evaluate(
             budget: strangler.baseline,
             delta: current as isize - strangler.baseline as isize,
             unallowed_imports: Vec::new(),
+            unallowed_import_sites: Vec::new(),
             config_line: strangler.config_line,
         });
     }
@@ -488,12 +529,20 @@ fn enforce(report: &Report) -> Result<()> {
             ));
         }
         if !rule.unallowed_imports.is_empty() {
+            let sites = rule
+                .unallowed_import_sites
+                .iter()
+                .take(5)
+                .map(|site| format!("{}:{} ({})", site.path.display(), site.line, site.module))
+                .collect::<Vec<_>>()
+                .join(", ");
             violations.push(format!(
-                "{}:{}: module `{}` imports outside its allow list: {}",
+                "{}:{}: module `{}` imports outside its allow list: {}\n  source: {}",
                 report.target.display(),
                 rule.config_line,
                 rule.path.display(),
-                rule.unallowed_imports.join(", ")
+                rule.unallowed_imports.join(", "),
+                sites,
             ));
         }
     }
@@ -528,10 +577,11 @@ fn tighten(target: &mut Target, report: &Report) {
     clippy::print_stdout,
     reason = "xtask atlas conform report is the command's stdout contract"
 )]
-fn print_report(report: &Report) {
+fn print_report(report: &Report, verbose: bool) {
     println!("Atlas conform — {}", report.target.display());
     println!("status      kind        current  budget      Δ  rule");
-    for rule in &report.rules {
+    let (rules, folded) = displayed_rules(report, verbose);
+    for rule in rules {
         let label = rule.symbol.as_ref().map_or_else(
             || rule.path.display().to_string(),
             |symbol| format!("{symbol} ({})", rule.path.display()),
@@ -542,7 +592,24 @@ fn print_report(report: &Report) {
         );
         if !rule.unallowed_imports.is_empty() {
             println!("  unallowed imports: {}", rule.unallowed_imports.join(", "));
+            for site in rule.unallowed_import_sites.iter().take(5) {
+                println!(
+                    "    {}:{} imports {}",
+                    site.path.display(),
+                    site.line,
+                    site.module
+                );
+            }
+            if rule.unallowed_import_sites.len() > 5 {
+                println!(
+                    "    … and {} more source locations",
+                    rule.unallowed_import_sites.len() - 5
+                );
+            }
         }
+    }
+    if folded > 0 {
+        println!("… {folded} rules ok at budget (use --verbose to show)");
     }
     println!(
         "summary: {} rules, {} regressions, {} parse failures",
@@ -550,6 +617,25 @@ fn print_report(report: &Report) {
         report.regressions,
         report.parse_failures
     );
+}
+
+fn displayed_rules(report: &Report, verbose: bool) -> (Vec<&RuleResult>, usize) {
+    if verbose {
+        return (report.rules.iter().collect(), 0);
+    }
+    let mut displayed = report
+        .rules
+        .iter()
+        .filter(|rule| rule.status == "regression")
+        .collect::<Vec<_>>();
+    displayed.extend(
+        report
+            .rules
+            .iter()
+            .filter(|rule| rule.status != "regression" && rule.current < rule.budget),
+    );
+    let folded = report.rules.len().saturating_sub(displayed.len());
+    (displayed, folded)
 }
 
 #[cfg(test)]
@@ -565,6 +651,7 @@ mod tests {
                 mode: Mode::Report,
                 file: None,
                 path: None,
+                verbose: false,
                 json: false,
             })
         );
@@ -574,6 +661,7 @@ mod tests {
                 mode: Mode::Ratchet,
                 file: None,
                 path: None,
+                verbose: false,
                 json: false,
             })
         );
@@ -601,6 +689,9 @@ mod tests {
         );
         assert!(parse_args(&["--file".into(), String::new()]).is_err());
         assert!(parse_args(&["--path".into(), "src".into()]).is_err());
+        assert!(parse_args(&["--ratchet".into(), "--verbose".into()]).is_err());
+        assert!(parse_args(&["--json".into(), "--verbose".into()]).is_err());
+        assert!(parse_args(&["--verbose".into()]).unwrap().unwrap().verbose);
         assert_eq!(
             parse_args(&["--init".into(), "--path".into(), "src".into()])
                 .unwrap()
@@ -614,6 +705,46 @@ mod tests {
     fn allow_list_matches_descendants_not_prefix_collisions() {
         assert!(is_within("cli::render::table", "cli::render"));
         assert!(!is_within("cli::renderer", "cli::render"));
+    }
+
+    #[test]
+    fn conform_default_report_prioritizes_regressions_and_headroom() {
+        let rule = |path: &str, status, current, budget| RuleResult {
+            kind: "module",
+            path: PathBuf::from(path),
+            symbol: None,
+            status,
+            current,
+            budget,
+            delta: current as isize - budget as isize,
+            unallowed_imports: Vec::new(),
+            unallowed_import_sites: Vec::new(),
+            config_line: 1,
+        };
+        let report = Report {
+            version: 1,
+            verb: "conform",
+            target: PathBuf::from("target.toml"),
+            default_target: false,
+            rules: vec![
+                rule("at-budget", "ok", 2, 2),
+                rule("headroom", "ok", 1, 3),
+                rule("regression", "regression", 4, 2),
+            ],
+            regressions: 1,
+            parse_failures: 0,
+        };
+
+        let (displayed, folded) = displayed_rules(&report, false);
+        assert_eq!(
+            displayed
+                .iter()
+                .map(|rule| rule.path.as_path())
+                .collect::<Vec<_>>(),
+            [Path::new("regression"), Path::new("headroom")]
+        );
+        assert_eq!(folded, 1);
+        assert_eq!(displayed_rules(&report, true).0.len(), 3);
     }
 
     #[test]
@@ -674,6 +805,14 @@ baseline = 5
         let forbidden_report = evaluate(root.path(), &forbidden, &target_path, true).unwrap();
         assert_eq!(forbidden_report.regressions, 1);
         assert_eq!(forbidden_report.rules[0].unallowed_imports, ["other"]);
+        assert_eq!(
+            forbidden_report.rules[0].unallowed_import_sites,
+            [ImportSite {
+                module: "other".to_owned(),
+                path: PathBuf::from("src/lib.rs"),
+                line: 1,
+            }]
+        );
         assert!(enforce(&forbidden_report).is_err());
 
         let report = evaluate(root.path(), &configured, &target_path, true).unwrap();

--- a/xtask/src/atlas/metrics.rs
+++ b/xtask/src/atlas/metrics.rs
@@ -9,7 +9,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{runner, source_files};
 
-use super::modules::{module_for_path, path_in_scope};
+use super::modules::module_for_path;
+use super::sources::Source;
 
 const OUTPUT_DIR: &str = "target/atlas-complexity";
 
@@ -67,14 +68,12 @@ struct LocMetrics {
     sloc: f64,
 }
 
-pub(super) fn analyze(root: &Path, scope: &Path) -> Result<MetricsReport> {
+pub(super) fn analyze(root: &Path, scope: &Path, sources: &[Source]) -> Result<MetricsReport> {
     ensure_prerequisite()?;
-    let files = source_files::tracked_rust_files(root)?
-        .into_iter()
-        .filter(|file| {
-            file.strip_prefix(root)
-                .is_ok_and(|path| path_in_scope(path, scope))
-        })
+    let files = sources
+        .iter()
+        .filter(|source| source.is_production())
+        .map(|source| root.join(&source.path))
         .collect::<Vec<_>>();
     if files.is_empty() {
         bail!("no tracked Rust files under `{}`", scope.display());

--- a/xtask/src/atlas/rank.rs
+++ b/xtask/src/atlas/rank.rs
@@ -293,7 +293,7 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
         args.noise_lifetime,
         args.noise_window,
     )?;
-    let metrics = metrics::analyze(root, &args.path)?;
+    let metrics = metrics::analyze(root, &args.path, &current_sources)?;
 
     let mut rows = current_sizes
         .iter()
@@ -418,8 +418,10 @@ fn sizes(source_list: &[sources::Source], scope: &Path) -> BTreeMap<String, Size
     let mut sizes = BTreeMap::<String, Size>::new();
     for source in source_list {
         let module = module_for_path(&source.path, scope);
-        let (code, tests) = if source_files::is_test_file(&source.path) {
+        let (code, tests) = if source.is_test() {
             (0, source_files::rust_sloc(&source.text))
+        } else if !source.is_production() {
+            (0, 0)
         } else {
             source_files::split_rust_sloc(&source.text)
         };

--- a/xtask/src/atlas/rank.rs
+++ b/xtask/src/atlas/rank.rs
@@ -19,6 +19,8 @@ const DEFAULT_PATH: &str = "crates/rimz/src";
 const USAGE: &str = "cargo xtask atlas rank [--path <prefix>] [--top N] [--window <pct>] [--since <ref>] [--verbose] [--json]
 
 Ranks modules by churn-weighted size (code × churn%); cx breaks ties.
+`cx` sums severity-weighted cognitive, cyclomatic, and source-line overruns for
+the module's functions; functions below the warning thresholds contribute zero.
 Flags: pin = churn% >= threshold and test/code below threshold; hot = non-noisy
 pace >= threshold; shallow = wide, thin, and low-use public surface; hub = wide,
 thin, and high-use public surface. Occurrence counts are whole-word identifiers

--- a/xtask/src/atlas/rank.rs
+++ b/xtask/src/atlas/rank.rs
@@ -272,8 +272,8 @@ fn parse_args(args: &[String]) -> Result<Option<Args>> {
 }
 
 fn build_report(root: &Path, args: &Args) -> Result<Report> {
-    let current_sources = sources::scope_sources(root, &args.path, None)?;
-    let all_sources = sources::scope_sources(root, Path::new("."), None)?;
+    let all_sources = sources::all_sources(root, None)?;
+    let current_sources = sources::sources_in_scope(&all_sources, &args.path)?;
     let occurrence_corpus = OccurrenceCorpus::new(&all_sources);
     let syntax = syntax::analyze_sources(&current_sources);
     let current_sizes = sizes(&current_sources, &args.path);
@@ -282,7 +282,10 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
     let previous = args
         .since
         .as_deref()
-        .map(|reference| sources::scope_sources(root, &args.path, Some(reference)))
+        .map(|reference| {
+            let all_sources = sources::all_sources(root, Some(reference))?;
+            sources::sources_in_scope(&all_sources, &args.path)
+        })
         .transpose()?;
     let previous_sizes = previous.as_ref().map(|sources| sizes(sources, &args.path));
     let previous_pub = previous
@@ -419,6 +422,9 @@ fn sort_rows(rows: &mut [Row]) {
 fn sizes(source_list: &[sources::Source], scope: &Path) -> BTreeMap<String, Size> {
     let mut sizes = BTreeMap::<String, Size>::new();
     for source in source_list {
+        if !source.is_production() && !source.is_test() {
+            continue;
+        }
         let module = module_for_path(&source.path, scope);
         let (code, tests) = if source.is_test() {
             (0, source_files::rust_sloc(&source.text))

--- a/xtask/src/atlas/seams.rs
+++ b/xtask/src/atlas/seams.rs
@@ -388,7 +388,6 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
     import_edges.truncate(args.top);
     external_surface.truncate(args.top);
     external_providers.truncate(args.top);
-    let mut cochange_edges = cochange_edges;
     cochange_edges.truncate(args.top);
     divergence.truncate(args.top);
     Ok(Report {

--- a/xtask/src/atlas/seams.rs
+++ b/xtask/src/atlas/seams.rs
@@ -227,16 +227,17 @@ fn parse_args(args: &[String]) -> Result<Option<Args>> {
 }
 
 fn build_report(root: &Path, args: &Args) -> Result<Report> {
-    let sources = sources::scope_sources(root, &args.path, None)?;
-    let syntax = syntax::analyze_sources(&sources);
-    let known_modules = sources::scope_sources(root, Path::new("."), None)?
+    let all_sources = sources::all_sources(root, None)?;
+    let scoped_sources = sources::sources_in_scope(&all_sources, &args.path)?;
+    let syntax = syntax::analyze_sources(&scoped_sources);
+    let known_modules = all_sources
         .into_iter()
         .filter(|source| source.is_production())
         .map(|source| crate_module_for_path(&source.path))
         .collect::<BTreeSet<_>>();
     let workspace_crates = workspace_crate_names(root)?;
     let scope_module = crate_module_for_path(&args.path.join("mod.rs"));
-    let mut scope_endpoints = sources
+    let mut scope_endpoints = scoped_sources
         .iter()
         .filter(|source| source.is_production())
         .map(|source| module_for_path(&source.path, &args.path))
@@ -338,19 +339,16 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
         .collect::<BTreeMap<_, _>>();
     let (cochange_edges, cochange_hub) = fold_root_cochange_hub(cochange_edges);
     let (mut cochange_edges, import_free_cochange_edges) =
-        partition_cochange_edges(cochange_edges, &import_lookup);
-    cochange_edges.retain(|edge| edge.commits >= args.min_cochange);
+        partition_cochange_edges(cochange_edges, &import_lookup, args.min_cochange);
     let mut divergence = Vec::new();
     for edge in import_free_cochange_edges {
-        if edge.commits >= args.min_cochange {
-            divergence.push(Divergence {
-                kind: "cochange-without-import",
-                left: edge.left,
-                right: edge.right,
-                imports: 0,
-                cochanges: edge.commits,
-            });
-        }
+        divergence.push(Divergence {
+            kind: "cochange-without-import",
+            left: edge.left,
+            right: edge.right,
+            imports: 0,
+            cochanges: edge.commits,
+        });
     }
     for edge in &import_edges {
         let cochanges = cochange_lookup
@@ -470,11 +468,15 @@ fn external_providers(
 fn partition_cochange_edges(
     edges: Vec<CochangeEdge>,
     imports: &BTreeMap<(String, String), usize>,
+    min_cochange: usize,
 ) -> (Vec<CochangeEdge>, Vec<CochangeEdge>) {
-    edges.into_iter().partition(|edge| {
-        imports.contains_key(&(edge.left.clone(), edge.right.clone()))
-            || imports.contains_key(&(edge.right.clone(), edge.left.clone()))
-    })
+    edges
+        .into_iter()
+        .filter(|edge| edge.commits >= min_cochange)
+        .partition(|edge| {
+            imports.contains_key(&(edge.left.clone(), edge.right.clone()))
+                || imports.contains_key(&(edge.right.clone(), edge.left.clone()))
+        })
 }
 
 fn endpoint(module_path: &str, scope_module: &str) -> String {
@@ -682,10 +684,18 @@ mod tests {
                 right: "store".to_owned(),
                 commits: 20,
             },
+            CochangeEdge {
+                left: "hooks".to_owned(),
+                right: "store".to_owned(),
+                commits: 2,
+            },
         ];
-        let imports = BTreeMap::from([(("store".to_owned(), "agents".to_owned()), 2)]);
+        let imports = BTreeMap::from([
+            (("store".to_owned(), "agents".to_owned()), 2),
+            (("store".to_owned(), "hooks".to_owned()), 1),
+        ]);
 
-        let (with_imports, without_imports) = partition_cochange_edges(edges, &imports);
+        let (with_imports, without_imports) = partition_cochange_edges(edges, &imports, 3);
 
         assert_eq!(
             with_imports

--- a/xtask/src/atlas/seams.rs
+++ b/xtask/src/atlas/seams.rs
@@ -13,7 +13,7 @@ use super::{positive_usize, set_once, validate_scope, value};
 const DEFAULT_PATH: &str = "crates/rimz/src";
 const DEFAULT_TOP: usize = 15;
 
-const USAGE: &str = "cargo xtask atlas seams [--path <prefix>] [--top N] [--window <pct>] [--since <ref>] [--max-commit-files N] [--min-cochange N] [--json]
+const USAGE: &str = "cargo xtask atlas seams [--path <prefix>] [--top N] [--module <name>] [--window <pct>] [--since <ref>] [--max-commit-files N] [--min-cochange N] [--json]
 
 Imports come from Rust `use` items; inline fully-qualified paths are not counted.
 The provider table ranks outside modules by distinct imported item names across
@@ -23,16 +23,18 @@ module's pairwise co-change fanout folds into one annotated hub row.
 
   --path <path>          root-relative subtree (default crates/rimz/src)
   --top N                rows per section (default 15)
+  --module <name>        list imported item names on one scoped module's edges
   --window <pct>         recent co-change history window (default 25)
   --since <ref>          restrict co-change to <ref>..HEAD (excludes --window)
   --max-commit-files N   omit commits broader than N Rust sources (default 10)
-  --min-cochange N       divergence threshold (default 3)
+  --min-cochange N       co-change and divergence threshold (default 3)
   --json                 versioned JSON agent contract (v1)";
 
 #[derive(Debug)]
 struct Args {
     path: PathBuf,
     top: usize,
+    module: Option<String>,
     window: usize,
     since: Option<String>,
     max_commit_files: usize,
@@ -45,6 +47,13 @@ struct ImportEdge {
     from: String,
     to: String,
     items: usize,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ImportItems {
+    from: String,
+    to: String,
+    items: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -81,6 +90,8 @@ struct Report {
     version: u8,
     verb: &'static str,
     path: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    requested_module: Option<String>,
     history_commits: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     history_window_pct: Option<usize>,
@@ -88,6 +99,8 @@ struct Report {
     history_since: Option<String>,
     total_import_edges: usize,
     import_edges: Vec<ImportEdge>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    import_items: Vec<ImportItems>,
     total_external_surface: usize,
     external_surface: Vec<ExternalSurface>,
     total_external_providers: usize,
@@ -97,6 +110,8 @@ struct Report {
     #[serde(skip_serializing_if = "Option::is_none")]
     cochange_hub: Option<CochangeHub>,
     total_divergence: usize,
+    cochange_without_import: usize,
+    import_without_cochange: usize,
     divergence: Vec<Divergence>,
     parse_failures: usize,
 }
@@ -128,6 +143,7 @@ fn parse_args(args: &[String]) -> Result<Option<Args>> {
     }
     let mut path = None;
     let mut top = None;
+    let mut module = None;
     let mut window = None;
     let mut since = None;
     let mut max_commit_files = None;
@@ -145,6 +161,11 @@ fn parse_args(args: &[String]) -> Result<Option<Args>> {
                 let parsed =
                     positive_usize(value(args, index, "seams", "--top")?, "seams", "--top")?;
                 set_once(&mut top, parsed, "seams", "--top")?;
+                index += 2;
+            }
+            "--module" => {
+                let parsed = value(args, index, "seams", "--module")?.to_owned();
+                set_once(&mut module, parsed, "seams", "--module")?;
                 index += 2;
             }
             "--window" => {
@@ -196,6 +217,7 @@ fn parse_args(args: &[String]) -> Result<Option<Args>> {
     Ok(Some(Args {
         path: path.unwrap_or_else(|| PathBuf::from(DEFAULT_PATH)),
         top: top.unwrap_or(DEFAULT_TOP),
+        module,
         window: window.unwrap_or(25),
         since,
         max_commit_files: max_commit_files.unwrap_or(10),
@@ -220,6 +242,13 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
         .map(|source| module_for_path(&source.path, &args.path))
         .collect::<BTreeSet<_>>();
     scope_endpoints.insert("(root)".to_owned());
+    if let Some(requested) = &args.module
+        && !scope_endpoints.contains(requested)
+    {
+        bail!(
+            "atlas seams --module `{requested}` is not in the scoped module set; choose a module from the import or surface tables"
+        );
+    }
     let mut imports = BTreeMap::<(String, String), BTreeSet<String>>::new();
     for file in &syntax.files {
         let from = module_for_path(&file.path, &args.path);
@@ -252,6 +281,17 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
             .cmp(&left.items)
             .then_with(|| left.from.cmp(&right.from))
             .then_with(|| left.to.cmp(&right.to))
+    });
+    let import_items = args.module.as_ref().map_or_else(Vec::new, |requested| {
+        imports
+            .iter()
+            .filter(|((from, to), _)| from == requested || to == requested)
+            .map(|((from, to), items)| ImportItems {
+                from: from.clone(),
+                to: to.clone(),
+                items: items.iter().cloned().collect(),
+            })
+            .collect()
     });
     let mut surfaces = BTreeMap::<String, (BTreeSet<String>, BTreeSet<(String, String)>)>::new();
     for ((from, to), items) in &imports {
@@ -297,8 +337,9 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
         .map(|edge| (ordered_pair(&edge.left, &edge.right), edge.commits))
         .collect::<BTreeMap<_, _>>();
     let (cochange_edges, cochange_hub) = fold_root_cochange_hub(cochange_edges);
-    let (cochange_edges, import_free_cochange_edges) =
+    let (mut cochange_edges, import_free_cochange_edges) =
         partition_cochange_edges(cochange_edges, &import_lookup);
+    cochange_edges.retain(|edge| edge.commits >= args.min_cochange);
     let mut divergence = Vec::new();
     for edge in import_free_cochange_edges {
         if edge.commits >= args.min_cochange {
@@ -334,6 +375,11 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
             .then_with(|| left.left.cmp(&right.left))
             .then_with(|| left.right.cmp(&right.right))
     });
+    let cochange_without_import = divergence
+        .iter()
+        .filter(|row| row.kind == "cochange-without-import")
+        .count();
+    let import_without_cochange = divergence.len() - cochange_without_import;
     let total_import_edges = import_edges.len();
     let total_external_surface = external_surface.len();
     let total_external_providers = external_providers.len();
@@ -349,11 +395,13 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
         version: 1,
         verb: "seams",
         path: args.path.clone(),
+        requested_module: args.module.clone(),
         history_commits: cochange.commits,
         history_window_pct: args.since.is_none().then_some(args.window),
         history_since: args.since.clone(),
         total_import_edges,
         import_edges,
+        import_items,
         total_external_surface,
         external_surface,
         total_external_providers,
@@ -362,6 +410,8 @@ fn build_report(root: &Path, args: &Args) -> Result<Report> {
         cochange_edges,
         cochange_hub,
         total_divergence,
+        cochange_without_import,
+        import_without_cochange,
         divergence,
         parse_failures: syntax.parse_failures.len(),
     })
@@ -477,6 +527,13 @@ fn print_report(report: &Report, top: usize) {
         report.import_edges.len(),
         "import edges",
     );
+    if let Some(module) = &report.requested_module {
+        println!();
+        println!("Imported items on {module} edges");
+        for edge in &report.import_items {
+            println!("{} -> {}: {}", edge.from, edge.to, edge.items.join(", "));
+        }
+    }
     println!();
     println!("External surface");
     for surface in report.external_surface.iter().take(top) {
@@ -550,12 +607,14 @@ fn print_report(report: &Report, top: usize) {
         );
     }
     println!(
-        "total: {} import edges, {} provider rows, {} co-change hubs, {} co-change edges, {} divergence rows, {} parse failures",
+        "total: {} import edges, {} provider rows, {} co-change hubs, {} co-change edges, {} divergence rows ({} cochange-without-import, {} import-without-cochange), {} parse failures",
         report.total_import_edges,
         report.total_external_providers,
         usize::from(report.cochange_hub.is_some()),
         report.total_cochange_edges,
         report.total_divergence,
+        report.cochange_without_import,
+        report.import_without_cochange,
         report.parse_failures
     );
 }
@@ -593,6 +652,14 @@ mod tests {
             .is_err()
         );
         assert_eq!(parse_args(&[]).unwrap().unwrap().window, 25);
+        assert_eq!(
+            parse_args(&["--module".into(), "agents_cmd".into()])
+                .unwrap()
+                .unwrap()
+                .module
+                .as_deref(),
+            Some("agents_cmd")
+        );
         assert_eq!(
             parse_args(&["--since".into(), "main".into()])
                 .unwrap()

--- a/xtask/src/atlas/seams.rs
+++ b/xtask/src/atlas/seams.rs
@@ -4,8 +4,6 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use serde::Serialize;
 
-use crate::source_files;
-
 use super::history::{self, CochangeEdge};
 use super::modules::{crate_module_for_path, module_for_path, workspace_crate_names};
 use super::sources;
@@ -209,14 +207,16 @@ fn parse_args(args: &[String]) -> Result<Option<Args>> {
 fn build_report(root: &Path, args: &Args) -> Result<Report> {
     let sources = sources::scope_sources(root, &args.path, None)?;
     let syntax = syntax::analyze_sources(&sources);
-    let known_modules = source_files::tracked_rust_files(root)?
+    let known_modules = sources::scope_sources(root, Path::new("."), None)?
         .into_iter()
-        .filter_map(|path| path.strip_prefix(root).ok().map(crate_module_for_path))
+        .filter(|source| source.is_production())
+        .map(|source| crate_module_for_path(&source.path))
         .collect::<BTreeSet<_>>();
     let workspace_crates = workspace_crate_names(root)?;
     let scope_module = crate_module_for_path(&args.path.join("mod.rs"));
     let mut scope_endpoints = sources
         .iter()
+        .filter(|source| source.is_production())
         .map(|source| module_for_path(&source.path, &args.path))
         .collect::<BTreeSet<_>>();
     scope_endpoints.insert("(root)".to_owned());

--- a/xtask/src/atlas/shapes.rs
+++ b/xtask/src/atlas/shapes.rs
@@ -19,6 +19,8 @@ Clusters large functions by Jaccard similarity over the functions and methods
 they call. Generic iterator, conversion, and error-context methods are omitted,
 and a pair must share at least three callees, so the report highlights shared
 domain choreography rather than incidental loop shape.
+Functions with parallel control flow but different callees do not cluster;
+use `rank --verbose` to find those large entry points.
 Clusters spanning more modules and files rank before member-count × mean-sloc.
 
   --path <path>   root-relative subtree (default crates/rimz/src)
@@ -356,7 +358,11 @@ fn is_generic_callee(callee: &str) -> bool {
         ".unwrap_or_else",
         ".with_context",
     ];
-    matches!(callee, "Ok" | "Err" | "Some" | "None" | "drop") || GENERIC_METHODS.contains(&callee)
+    matches!(
+        callee,
+        "Ok" | "Err" | "Some" | "None" | "drop" | "render::out" | "render::paint"
+    ) || callee.starts_with("render::palette::")
+        || GENERIC_METHODS.contains(&callee)
 }
 
 fn jaccard(left: &BTreeSet<String>, right: &BTreeSet<String>) -> f64 {
@@ -496,7 +502,17 @@ mod tests {
 
     #[test]
     fn callee_sets_drop_generic_method_noise() {
-        let callees = ["domain::load", ".map", ".context", "Some", ".render"].map(str::to_owned);
+        let callees = [
+            "domain::load",
+            ".map",
+            ".context",
+            "Some",
+            ".render",
+            "render::out",
+            "render::paint",
+            "render::palette::accent",
+        ]
+        .map(str::to_owned);
 
         assert_eq!(callee_set(&callees), set(&["domain::load", ".render"]));
     }

--- a/xtask/src/atlas/shapes.rs
+++ b/xtask/src/atlas/shapes.rs
@@ -358,10 +358,10 @@ fn is_generic_callee(callee: &str) -> bool {
         ".unwrap_or_else",
         ".with_context",
     ];
-    matches!(
-        callee,
-        "Ok" | "Err" | "Some" | "None" | "drop" | "render::out" | "render::paint"
-    ) || callee.starts_with("render::palette::")
+    matches!(callee, "Ok" | "Err" | "Some" | "None" | "drop")
+        || callee.ends_with("::out")
+        || callee.ends_with("::paint")
+        || callee.split("::").any(|segment| segment == "palette")
         || GENERIC_METHODS.contains(&callee)
 }
 
@@ -511,6 +511,12 @@ mod tests {
             "render::out",
             "render::paint",
             "render::palette::accent",
+            "ui::out",
+            "ui::paint",
+            "ui::palette::accent",
+            "crate::cli::render::out",
+            "super::render::paint",
+            "palette::muted",
         ]
         .map(str::to_owned);
 

--- a/xtask/src/atlas/sources.rs
+++ b/xtask/src/atlas/sources.rs
@@ -54,6 +54,11 @@ impl Source {
 }
 
 pub(super) fn scope_sources(root: &Path, scope: &Path, at: Option<&str>) -> Result<Vec<Source>> {
+    let sources = all_sources(root, at)?;
+    sources_in_scope(&sources, scope)
+}
+
+pub(super) fn all_sources(root: &Path, at: Option<&str>) -> Result<Vec<Source>> {
     let mut sources = if let Some(revision) = at {
         revision_sources(root, revision)?
     } else {
@@ -75,7 +80,18 @@ pub(super) fn scope_sources(root: &Path, scope: &Path, at: Option<&str>) -> Resu
             .collect::<Result<Vec<_>>>()?
     };
     classify_sources(&mut sources);
-    sources.retain(|source| path_in_scope(&source.path, scope));
+    if sources.is_empty() {
+        bail!("no tracked Rust files in the repository");
+    }
+    Ok(sources)
+}
+
+pub(super) fn sources_in_scope(sources: &[Source], scope: &Path) -> Result<Vec<Source>> {
+    let sources = sources
+        .iter()
+        .filter(|source| path_in_scope(&source.path, scope))
+        .cloned()
+        .collect::<Vec<_>>();
     if sources.is_empty() {
         bail!("no tracked Rust files under `{}`", scope.display());
     }
@@ -276,7 +292,8 @@ fn conditional_source_kind(attributes: &[syn::Attribute]) -> Option<SourceKind> 
         .iter()
         .filter(|attribute| attribute.path().is_ident("cfg"))
         .filter_map(|attribute| attribute.parse_args::<Meta>().ok())
-        .find_map(|predicate| cfg_predicate_kind(&predicate))
+        .filter_map(|predicate| cfg_predicate_kind(&predicate))
+        .reduce(merge_source_kind)
 }
 
 fn cfg_predicate_kind(predicate: &Meta) -> Option<SourceKind> {
@@ -295,7 +312,8 @@ fn cfg_predicate_kind(predicate: &Meta) -> Option<SourceKind> {
             .parse_args_with(Punctuated::<Meta, Comma>::parse_terminated)
             .ok()?
             .iter()
-            .find_map(cfg_predicate_kind),
+            .filter_map(cfg_predicate_kind)
+            .reduce(merge_source_kind),
         Meta::List(list) if list.path.is_ident("any") => {
             let predicates = list
                 .parse_args_with(Punctuated::<Meta, Comma>::parse_terminated)
@@ -304,11 +322,7 @@ fn cfg_predicate_kind(predicate: &Meta) -> Option<SourceKind> {
                 .iter()
                 .map(cfg_predicate_kind)
                 .collect::<Option<Vec<_>>>()?;
-            kinds
-                .into_iter()
-                .reduce(merge_source_kind)
-                .or(Some(SourceKind::Production))
-                .filter(|kind| *kind != SourceKind::Production)
+            kinds.into_iter().reduce(merge_source_kind)
         }
         _ => None,
     }
@@ -354,5 +368,40 @@ mod tests {
         assert_eq!(sources[1].kind, SourceKind::TestSupport);
         assert_eq!(sources[2].kind, SourceKind::TestSupport);
         assert!(sources[3].is_test());
+    }
+
+    #[test]
+    fn cfg_composition_is_order_independent() {
+        let test_then_support: syn::ItemMod = syn::parse_quote! {
+            #[cfg(all(test, feature = "testkit"))]
+            mod fixture;
+        };
+        let support_then_test: syn::ItemMod = syn::parse_quote! {
+            #[cfg(all(feature = "testkit", test))]
+            mod fixture;
+        };
+        let stacked: syn::ItemMod = syn::parse_quote! {
+            #[cfg(feature = "testkit")]
+            #[cfg(test)]
+            mod fixture;
+        };
+        let production_alternative: syn::ItemMod = syn::parse_quote! {
+            #[cfg(any(test, unix))]
+            mod fixture;
+        };
+
+        assert_eq!(
+            conditional_source_kind(&test_then_support.attrs),
+            Some(SourceKind::Test)
+        );
+        assert_eq!(
+            conditional_source_kind(&support_then_test.attrs),
+            Some(SourceKind::Test)
+        );
+        assert_eq!(
+            conditional_source_kind(&stacked.attrs),
+            Some(SourceKind::Test)
+        );
+        assert_eq!(conditional_source_kind(&production_alternative.attrs), None);
     }
 }

--- a/xtask/src/atlas/sources.rs
+++ b/xtask/src/atlas/sources.rs
@@ -5,6 +5,9 @@ use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result, bail};
 use serde::Serialize;
+use syn::Meta;
+use syn::punctuated::Punctuated;
+use syn::token::Comma;
 
 use crate::source_files;
 
@@ -15,18 +18,46 @@ pub(super) struct Source {
     pub(super) path: PathBuf,
     #[serde(skip)]
     pub(super) text: String,
+    #[serde(skip)]
+    kind: SourceKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SourceKind {
+    Production,
+    Test,
+    TestSupport,
+}
+
+impl Source {
+    #[cfg(test)]
+    pub(super) fn new(path: impl Into<PathBuf>, text: impl Into<String>) -> Self {
+        let path = path.into();
+        Self {
+            kind: if source_files::is_test_file(&path) {
+                SourceKind::Test
+            } else {
+                SourceKind::Production
+            },
+            path,
+            text: text.into(),
+        }
+    }
+
+    pub(super) fn is_production(&self) -> bool {
+        self.kind == SourceKind::Production
+    }
+
+    pub(super) fn is_test(&self) -> bool {
+        self.kind == SourceKind::Test
+    }
 }
 
 pub(super) fn scope_sources(root: &Path, scope: &Path, at: Option<&str>) -> Result<Vec<Source>> {
-    let sources = if let Some(revision) = at {
-        revision_sources(root, scope, revision)?
+    let mut sources = if let Some(revision) = at {
+        revision_sources(root, revision)?
     } else {
-        let mut files = source_files::tracked_rust_files(root)?;
-        files.retain(|path| {
-            path.strip_prefix(root)
-                .is_ok_and(|path| path_in_scope(path, scope))
-        });
-        files
+        source_files::tracked_rust_files(root)?
             .into_iter()
             .map(|path| {
                 let relative = path
@@ -38,20 +69,22 @@ pub(super) fn scope_sources(root: &Path, scope: &Path, at: Option<&str>) -> Resu
                 Ok(Source {
                     path: relative,
                     text,
+                    kind: SourceKind::Production,
                 })
             })
             .collect::<Result<Vec<_>>>()?
     };
+    classify_sources(&mut sources);
+    sources.retain(|source| path_in_scope(&source.path, scope));
     if sources.is_empty() {
         bail!("no tracked Rust files under `{}`", scope.display());
     }
     Ok(sources)
 }
 
-fn revision_sources(root: &Path, scope: &Path, revision: &str) -> Result<Vec<Source>> {
+fn revision_sources(root: &Path, revision: &str) -> Result<Vec<Source>> {
     let output = Command::new("git")
         .args(["ls-tree", "-r", "--name-only", revision, "--"])
-        .arg(scope)
         .current_dir(root)
         .output()
         .with_context(|| format!("listing Rust sources at `{revision}`"))?;
@@ -112,7 +145,11 @@ fn revision_sources(root: &Path, scope: &Path, revision: &str) -> Result<Vec<Sou
             .context("reading git cat-file separator")?;
         let text = String::from_utf8(bytes)
             .with_context(|| format!("{} at `{revision}` is not UTF-8", path.display()))?;
-        sources.push(Source { path, text });
+        sources.push(Source {
+            path,
+            text,
+            kind: SourceKind::Production,
+        });
     }
     let status = child.wait().context("waiting for git cat-file")?;
     if !status.success() {
@@ -124,6 +161,7 @@ fn revision_sources(root: &Path, scope: &Path, revision: &str) -> Result<Vec<Sou
 pub(super) fn working_tree_rust_sources(root: &Path) -> Result<Vec<Source>> {
     let mut sources = Vec::new();
     walk(root, root, &mut sources)?;
+    classify_sources(&mut sources);
     Ok(sources)
 }
 
@@ -147,10 +185,133 @@ fn walk(root: &Path, directory: &Path, sources: &mut Vec<Source>) -> Result<()> 
                     .with_context(|| format!("making {} root-relative", path.display()))?
                     .to_path_buf(),
                 text,
+                kind: SourceKind::Production,
             });
         }
     }
     Ok(())
+}
+
+fn classify_sources(sources: &mut [Source]) {
+    for source in sources.iter_mut() {
+        if source_files::is_test_file(&source.path) {
+            source.kind = SourceKind::Test;
+        }
+    }
+
+    let indexes = sources
+        .iter()
+        .enumerate()
+        .map(|(index, source)| (source.path.clone(), index))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let mut modules = Vec::new();
+    for (parent, source) in sources.iter().enumerate() {
+        let Ok(file) = syn::parse_file(&source.text) else {
+            continue;
+        };
+        for module in file.items.iter().filter_map(|item| match item {
+            syn::Item::Mod(module) if module.content.is_none() => Some(module),
+            _ => None,
+        }) {
+            let declared_kind = conditional_source_kind(&module.attrs);
+            for candidate in module_file_candidates(&source.path, &module.ident.to_string()) {
+                if let Some(child) = indexes.get(&candidate) {
+                    modules.push((parent, *child, declared_kind));
+                    break;
+                }
+            }
+        }
+    }
+
+    loop {
+        let mut changed = false;
+        for &(parent, child, declared_kind) in &modules {
+            let inherited = match sources[parent].kind {
+                SourceKind::Production => declared_kind,
+                kind => Some(kind),
+            };
+            let Some(kind) = inherited else {
+                continue;
+            };
+            let merged = merge_source_kind(sources[child].kind, kind);
+            if merged != sources[child].kind {
+                sources[child].kind = merged;
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+}
+
+fn module_file_candidates(parent: &Path, module: &str) -> [PathBuf; 2] {
+    let directory = match parent.file_name().and_then(std::ffi::OsStr::to_str) {
+        Some("lib.rs" | "main.rs" | "mod.rs") => parent.parent().unwrap_or_else(|| Path::new("")),
+        _ => {
+            let mut directory = parent.to_path_buf();
+            directory.set_extension("");
+            return [
+                directory.join(format!("{module}.rs")),
+                directory.join(module).join("mod.rs"),
+            ];
+        }
+    };
+    [
+        directory.join(format!("{module}.rs")),
+        directory.join(module).join("mod.rs"),
+    ]
+}
+
+fn merge_source_kind(current: SourceKind, declared: SourceKind) -> SourceKind {
+    match (current, declared) {
+        (SourceKind::Test, _) | (_, SourceKind::Test) => SourceKind::Test,
+        (SourceKind::TestSupport, _) | (_, SourceKind::TestSupport) => SourceKind::TestSupport,
+        _ => SourceKind::Production,
+    }
+}
+
+fn conditional_source_kind(attributes: &[syn::Attribute]) -> Option<SourceKind> {
+    attributes
+        .iter()
+        .filter(|attribute| attribute.path().is_ident("cfg"))
+        .filter_map(|attribute| attribute.parse_args::<Meta>().ok())
+        .find_map(|predicate| cfg_predicate_kind(&predicate))
+}
+
+fn cfg_predicate_kind(predicate: &Meta) -> Option<SourceKind> {
+    match predicate {
+        Meta::Path(path) if path.is_ident("test") => Some(SourceKind::Test),
+        Meta::NameValue(value) if value.path.is_ident("feature") => match &value.value {
+            syn::Expr::Lit(value) => match &value.lit {
+                syn::Lit::Str(feature) if feature.value() == "testkit" => {
+                    Some(SourceKind::TestSupport)
+                }
+                _ => None,
+            },
+            _ => None,
+        },
+        Meta::List(list) if list.path.is_ident("all") => list
+            .parse_args_with(Punctuated::<Meta, Comma>::parse_terminated)
+            .ok()?
+            .iter()
+            .find_map(cfg_predicate_kind),
+        Meta::List(list) if list.path.is_ident("any") => {
+            let predicates = list
+                .parse_args_with(Punctuated::<Meta, Comma>::parse_terminated)
+                .ok()?;
+            let kinds = predicates
+                .iter()
+                .map(cfg_predicate_kind)
+                .collect::<Option<Vec<_>>>()?;
+            kinds
+                .into_iter()
+                .reduce(merge_source_kind)
+                .or(Some(SourceKind::Production))
+                .filter(|kind| *kind != SourceKind::Production)
+        }
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -173,5 +334,25 @@ mod tests {
         let sources = working_tree_rust_sources(root.path()).unwrap();
         assert_eq!(sources.len(), 1);
         assert_eq!(sources[0].path, Path::new("src/harness/target/mod.rs"));
+    }
+
+    #[test]
+    fn source_classification_follows_conditional_external_modules() {
+        let mut sources = vec![
+            Source::new(
+                "src/lib.rs",
+                "#[cfg(feature = \"testkit\")]\nmod fixture;\n#[cfg(test)]\nmod checks;\n",
+            ),
+            Source::new("src/fixture.rs", "mod nested;\n"),
+            Source::new("src/fixture/nested.rs", "fn helper() {}\n"),
+            Source::new("src/checks.rs", "fn characterization() {}\n"),
+        ];
+
+        classify_sources(&mut sources);
+
+        assert!(sources[0].is_production());
+        assert_eq!(sources[1].kind, SourceKind::TestSupport);
+        assert_eq!(sources[2].kind, SourceKind::TestSupport);
+        assert!(sources[3].is_test());
     }
 }

--- a/xtask/src/atlas/syntax.rs
+++ b/xtask/src/atlas/syntax.rs
@@ -8,8 +8,6 @@ use syn::{
     UseTree, Visibility,
 };
 
-use crate::source_files;
-
 use super::modules::crate_module_for_path;
 use super::sources::Source;
 
@@ -58,7 +56,7 @@ pub(super) fn analyze_sources(sources: &[Source]) -> SyntaxReport {
     let mut files = Vec::new();
     let mut parse_failures = Vec::new();
     for source in sources {
-        if source_files::is_test_file(&source.path) {
+        if !source.is_production() {
             continue;
         }
         match syn::parse_file(&source.text) {

--- a/xtask/src/atlas/syntax.rs
+++ b/xtask/src/atlas/syntax.rs
@@ -23,6 +23,7 @@ pub(super) struct PubItem {
 pub(super) struct ImportedItem {
     pub(super) module_path: String,
     pub(super) item: String,
+    pub(super) line: usize,
     pub(super) internal: bool,
     #[serde(skip)]
     pub(super) leaf_may_be_module: bool,
@@ -258,7 +259,7 @@ impl<'ast> Visit<'ast> for UseCollector<'_> {
     fn visit_item_use(&mut self, item: &'ast syn::ItemUse) {
         let mut flattened = Vec::new();
         flatten_use(&item.tree, &mut Vec::new(), &mut flattened);
-        for (path, item, grouped) in flattened {
+        for (path, imported_item, grouped) in flattened {
             let internal = path
                 .first()
                 .is_some_and(|segment| matches!(segment.as_str(), "crate" | "self" | "super"));
@@ -270,7 +271,8 @@ impl<'ast> Visit<'ast> for UseCollector<'_> {
             if !module_path.is_empty() {
                 self.imports.push(ImportedItem {
                     module_path,
-                    item,
+                    item: imported_item,
+                    line: item.span().start().line,
                     internal,
                     leaf_may_be_module,
                 });

--- a/xtask/src/atlas/syntax/tests.rs
+++ b/xtask/src/atlas/syntax/tests.rs
@@ -1,10 +1,7 @@
 use super::*;
 
 fn source(text: &str) -> Source {
-    Source {
-        path: PathBuf::from("crates/rimz/src/cli/demo.rs"),
-        text: text.to_owned(),
-    }
+    Source::new("crates/rimz/src/cli/demo.rs", text)
 }
 
 #[test]


### PR DESCRIPTION
## Context

`cargo xtask atlas` is the instrument for the CLI refactor program, but an evaluation of its output found the numbers it feeds that program were wrong in one systematic way and hard to act on in several others. The core defect: Rust sources compiled only under `cfg(test)` or `cfg(feature = "testkit")` were counted as production mass, so a module carrying a testkit fixture read as large, under-tested, and `pin`-flagged when it was neither. `crates/rimz/src/cli/sidebar` was the worst case at `code 3575 / t/c 0.21 / pin`.

The rest were usability: metrics with no stated definition, drill-downs that stopped short of the ground truth a pass needs, a `conform` report where regressions were buried in a wall of at-budget rules, and no written operating guide for running a target-driven refactor program with the tool.

## Implementation

**Source classification.** Atlas now models each Rust file from its declaring `mod` item rather than from its path. `sources.rs` walks the module graph across the whole tracked corpus, propagating `cfg(test)` and `cfg(feature = "testkit")` gates from a declaration to the file it names and onward to that file's own children. Three buckets: production, test, and test support. Test code stays coverage mass and still counts toward `rank`'s `t/c`; testkit support counts toward neither side, because calling its 2,286 lines "tests" would falsely imply characterization coverage that does not exist. `sidebar` now reads `code 1332 / t/c 0.56` with no `pin`. The same classification feeds rank SLOC and complexity, syntax analysis, occurrence counting, `shapes`, `seams`, and `conform`.

This is a departure from the Goal's expected shape, which anticipated a shared path-based classifier. That could not work: `crates/rimz/src/cli/sidebar/fixture.rs` carries no local `cfg` at all — its gate lives on `mod fixture` in `cli/sidebar.rs:35` — so nothing about the file's own path or contents reveals it. Classification had to live on the loaded source graph.

**Drill-downs.** `api --module` reports every public item with kind, occurrences, outside-module count, and source location, so a pass can see the zero-occurrence items that the summary median hides. `seams --module` expands each import edge into its distinct imported item names. Text output stays bounded by `--top` with a tail pointing at `--json`; JSON carries the complete list.

**Reports.** `conform`'s default output puts regressions first, then budget headroom, and folds rules sitting exactly at budget; `--verbose` restores the full table. Forbidden imports now carry source locations in text, in ratchet errors, and in JSON. `seams --min-cochange` filters the co-change table as well as divergence, and the totals line splits both divergence kinds. `shapes` ignores render output and palette helpers — in every spelling, including aliased and fully-qualified — while keeping real table choreography.

**Documentation.** `docs/contributing/atlas.md` is a new operating guide: the target-driven program shape, how to read each verb and what each metric means, the `refactor-target.toml` convergence loop, a worked baseline-to-target example, and the JSON v1 field contracts. Rank and api help text now define the metrics that were ambiguous.

JSON additions are additive at schema version 1; no existing field or meaning changed.

## Verification

`cargo xtask gate` passes: fmt, invariants, conform, docs-links, lint, and 5,738 nextest tests. Review independently confirmed the behavioural claims: `total_modules` 41 → 40 with `total_code` unchanged, `shapes --path crates/rimz/src/cli` 22 → 21 clusters with no render helper left in any shared-callee set, `seams` holding 37 co-change edges at the default threshold and 78 at `--min-cochange 1`, and `api --module agents` down from 2201 lines to 70.

## Advisories

- Atlas reads and classifies the whole tracked Rust corpus before applying `--path`, so parent-`cfg` classification does not depend on the requested scope. Loading is shared within a run (`all_sources` once, `sources_in_scope` per scope), but the whole-corpus read is inherent to the approach.
- Classification follows standard Rust module paths. Today's `#[path = ...]` modules all resolve by their conventional test paths, but a future nonconventional, testkit-gated `#[path]` module would need resolver support.
- Cargo target gating is invisible to a module-graph walk, so a `required-features = ["testkit"]` binary that no `mod` item declares still counts as production — `crates/rimz/src/bin/rimz-test-reaper.rs`, 83 SLOC. The guide's promise is scoped to declaration-reachable modules accordingly.
- `occ` counts remain whole-word identifier heuristics that over-count common method names. `occ0` conflates dead with test-only; splitting the two needs an item-level conditional occurrence corpus and was left out rather than shipped half-done. No deletion decision should rest on these numbers without reading the item.
- `xtask/src/atlas/rank.rs:431-432` carries an unreachable `else if` arm left by the final round, guarded out by the check above it. No behavioural effect; a two-line cleanup for whenever the file is next open.

<details>
<summary>Implemented by <a href="https://github.com/rimio-ai/rimz">RimZ</a> agents · 5 agents · 1h57m active · $50.69 · 17 messages (2 from you)</summary>

**forge team**

- **planner** — Claude `claude-fable-5@high`
  - effort: 13m active · $8.62 incl. subagents
  - calls: 1 ask · 42 tool calls
  - messages: 1 from you · 3 from teammates · 3 to teammates
  - tokens: 100 input, 52.6k output, 212.9k cache write, 4m cache read
  - subagents: 1 × explore ($0.41)
- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 34m active · $12.09
  - calls: 92 tool calls
  - messages: 5 from teammates
  - tokens: 261.9k input, 37.3k output, 19.3m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 17m active · $7.85
  - calls: 76 tool calls
  - messages: 4 from teammates
  - tokens: 150 input, 62k output, 175.4k cache write, 9.1m cache read

**spot team**

- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 33m active · $13.76
  - calls: 1 ask · 114 tool calls
  - messages: 1 from you · 1 from teammates
  - tokens: 587.1k input, 46.8k output, 18.8m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 18m active · $8.36
  - calls: 83 tool calls
  - messages: 2 from teammates
  - tokens: 116 input, 68.7k output, 328.9k cache write, 6.7m cache read

</details>