### PR TITLE
Discard stale terminal-protocol replies on supervised remote reconnect

### DIFF
--- a/crates/rimz/src/cli/remote/supervisor.rs
+++ b/crates/rimz/src/cli/remote/supervisor.rs
@@ -183,6 +183,7 @@ pub(super) fn supervise_remote(
             outage = None;
         }
         let retry_cause = if outcome.killed_zombie {
+            guard.discard_pending_input();
             guard.reset_emulator();
             let _ = writeln!(
                 std::io::stderr().lock(),
@@ -206,6 +207,7 @@ pub(super) fn supervise_remote(
                     )
                 }
                 Verdict::Retry => {
+                    guard.discard_pending_input();
                     guard.reset_emulator();
                     RetryCause::Dropped
                 }

--- a/crates/rimz/src/cli/remote/tty.rs
+++ b/crates/rimz/src/cli/remote/tty.rs
@@ -1,6 +1,6 @@
 use std::io::{self, IsTerminal, Write};
 
-use nix::sys::termios::{self, SetArg, Termios};
+use nix::sys::termios::{self, FlushArg, SetArg, Termios};
 
 use rimz::remote::tty::{EMULATOR_RESET, sanitize_flags, termios_damaged};
 
@@ -22,6 +22,20 @@ impl TtyGuard {
         let stdin = io::stdin();
         if let Err(err) = termios::tcsetattr(&stdin, SetArg::TCSADRAIN, saved) {
             tracing::debug!(error = %err, "local tty restore failed");
+        }
+    }
+
+    /// Discards terminal replies addressed to a dead SSH generation.
+    ///
+    /// Callers must only use this while reconnecting: exit paths preserve
+    /// pending input for the shell that regains the terminal.
+    pub(super) fn discard_pending_input(&self) {
+        if self.saved.is_none() {
+            return;
+        }
+        let stdin = io::stdin();
+        if let Err(err) = termios::tcflush(&stdin, FlushArg::TCIFLUSH) {
+            tracing::debug!(error = %err, "local tty input flush failed");
         }
     }
 

--- a/crates/rimz/tests/fixtures/ssh-trace/main.rs
+++ b/crates/rimz/tests/fixtures/ssh-trace/main.rs
@@ -9,6 +9,8 @@
 //! `$RIMZ_TEST_SSH_RAW_TTY` simulates OpenSSH leaving the controlling tty raw;
 //! `$RIMZ_TEST_SSH_TTY_STATE_LOG` records whether each attach inherited sane
 //! shell flags before that transition.
+//! `$RIMZ_TEST_SSH_STDIN_PLAN` chooses whether each visible attach ignores or
+//! records stdin, and `$RIMZ_TEST_SSH_STDIN_LOG` receives the recorded bytes.
 //! `$RIMZ_TEST_SSH_SUSPEND` stops the visible client until its process group
 //! receives `SIGCONT`, exercising the launcher's job-control mirror.
 //! `$RIMZ_TEST_SSH_STDERR` supplies the visible attach's diagnostic output.
@@ -84,7 +86,9 @@ fn main() {
 
     suspend_if_requested();
 
-    if let Ok(ms) = env::var("RIMZ_TEST_SSH_SLEEP_MS")
+    let recorded_stdin = record_stdin_if_requested();
+    if !recorded_stdin
+        && let Ok(ms) = env::var("RIMZ_TEST_SSH_SLEEP_MS")
         && let Ok(ms) = ms.parse::<u64>()
     {
         std::thread::sleep(std::time::Duration::from_millis(ms));
@@ -288,18 +292,79 @@ fn exit_from_plan(key: &str) -> ! {
 }
 
 fn pop_exit_plan(key: &str) -> Option<i32> {
+    pop_plan_line(key).map(|line| {
+        if line.is_empty() {
+            0
+        } else {
+            line.parse().expect("plan line is an exit code")
+        }
+    })
+}
+
+fn pop_plan_line(key: &str) -> Option<String> {
     let plan_path = env::var_os(key)?;
-    let plan = std::fs::read_to_string(&plan_path).expect("read exit plan");
+    let plan = std::fs::read_to_string(&plan_path).expect("read plan");
     let mut lines = plan.lines();
-    let code: i32 = lines
-        .next()
-        .unwrap_or("0")
-        .trim()
-        .parse()
-        .expect("plan line is an exit code");
+    let line = lines.next().unwrap_or_default().trim().to_owned();
     let rest = lines.collect::<Vec<_>>().join("\n");
-    std::fs::write(&plan_path, rest).expect("rewrite exit plan");
-    Some(code)
+    std::fs::write(&plan_path, rest).expect("rewrite plan");
+    Some(line)
+}
+
+fn record_stdin_if_requested() -> bool {
+    match pop_plan_line("RIMZ_TEST_SSH_STDIN_PLAN").as_deref() {
+        None | Some("ignore") => false,
+        Some("record") => {
+            record_stdin_until_sentinel();
+            true
+        }
+        Some(mode) => panic!("unknown stdin plan mode: {mode}"),
+    }
+}
+
+fn record_stdin_until_sentinel() {
+    use std::os::fd::AsFd as _;
+
+    use nix::poll::{PollFd, PollFlags, poll};
+
+    let log_path = env::var_os("RIMZ_TEST_SSH_STDIN_LOG")
+        .expect("RIMZ_TEST_SSH_STDIN_LOG unset for record mode");
+    let sentinel = env::var("RIMZ_TEST_SSH_STDIN_UNTIL")
+        .expect("RIMZ_TEST_SSH_STDIN_UNTIL unset for record mode")
+        .into_bytes();
+    assert!(!sentinel.is_empty(), "stdin sentinel must not be empty");
+
+    let stdin = std::io::stdin();
+    let mut log = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .expect("open ssh trace stdin log");
+    let mut recorded = Vec::new();
+    let mut buffer = [0u8; 256];
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        let mut fds = [PollFd::new(stdin.as_fd(), PollFlags::POLLIN)];
+        if poll(&mut fds, 50u16).expect("poll ssh trace stdin") == 0 {
+            continue;
+        }
+        let count = stdin
+            .lock()
+            .read(&mut buffer)
+            .expect("read ssh trace stdin");
+        assert_ne!(count, 0, "ssh trace stdin closed before sentinel");
+        log.write_all(&buffer[..count])
+            .expect("write ssh trace stdin log");
+        log.flush().expect("flush ssh trace stdin log");
+        recorded.extend_from_slice(&buffer[..count]);
+        if recorded
+            .windows(sentinel.len())
+            .any(|window| window == sentinel)
+        {
+            return;
+        }
+    }
+    panic!("ssh trace stdin sentinel was not received before deadline");
 }
 
 fn is_config_query(argv: &[String]) -> bool {

--- a/crates/rimz/tests/integration/remote_attach.rs
+++ b/crates/rimz/tests/integration/remote_attach.rs
@@ -914,6 +914,103 @@ fn supervised_connect_restores_tty_and_resets_emulator_after_retry() {
 }
 
 #[test]
+fn supervised_reconnect_discards_stale_terminal_replies_and_preserves_user_input() {
+    const TERMINAL_REPLIES: &[u8] = b"\x1b[?62;22;52c\x1b[>1;10;0c\x1bP>|ghostty 1.3.1\x1b\\";
+    const USER_MARKER: &[u8] = b"RIMZ-USER-MARKER\r";
+
+    let env = Env::new();
+    let log = env.project_root.join("ssh-trace.log");
+    let exit_plan = env.project_root.join("ssh-trace.plan");
+    let stdin_plan = env.project_root.join("ssh-stdin.plan");
+    let stdin_log = env.project_root.join("ssh-stdin.log");
+    std::fs::write(&exit_plan, "255\n0\n").expect("write ssh plan");
+    std::fs::write(&stdin_plan, "ignore\nrecord\n").expect("write ssh stdin plan");
+
+    let pair = remote_connect_pty();
+    let mut cmd = remote_connect_pty_command(&env, &log);
+    cmd.env("RIMZ_TEST_SSH_PLAN", &exit_plan);
+    cmd.env("RIMZ_TEST_SSH_RAW_TTY", "1");
+    cmd.env("RIMZ_TEST_SSH_SLEEP_MS", "1000");
+    cmd.env("RIMZ_TEST_SSH_STDIN_PLAN", &stdin_plan);
+    cmd.env("RIMZ_TEST_SSH_STDIN_LOG", &stdin_log);
+    cmd.env("RIMZ_TEST_SSH_STDIN_UNTIL", "RIMZ-USER-MARKER");
+    cmd.env("RIMZ_REMOTE_GATETIME_MS", "0");
+
+    let mut child = pair.slave.spawn_command(cmd).expect("spawn remote connect");
+    drop(pair.slave);
+    let mut reader = pair.master.try_clone_reader().expect("clone pty reader");
+    let reader_thread = std::thread::spawn(move || {
+        let mut output = Vec::new();
+        let _ = reader.read_to_end(&mut output);
+        output
+    });
+    let mut writer = pair.master.take_writer().expect("take pty writer");
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    while main_invocation_count(&log) < 1 && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert_eq!(main_invocation_count(&log), 1, "first attach did not start");
+    writer
+        .write_all(TERMINAL_REPLIES)
+        .expect("queue terminal replies");
+    writer.flush().expect("flush terminal replies");
+
+    while main_invocation_count(&log) < 2 && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert_eq!(
+        main_invocation_count(&log),
+        2,
+        "replacement attach did not start"
+    );
+    writer.write_all(USER_MARKER).expect("write user marker");
+    writer.flush().expect("flush user marker");
+    drop(writer);
+
+    let status = loop {
+        if let Some(status) = child.try_wait().expect("poll remote connect") {
+            break Some(status);
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            break None;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    };
+    drop(pair.master);
+    let output =
+        String::from_utf8_lossy(&reader_thread.join().expect("join pty reader")).into_owned();
+    let status = status.unwrap_or_else(|| panic!("remote connect timed out; output:\n{output}"));
+    assert!(
+        status.success(),
+        "remote connect failed with {status:?}; output:\n{output}"
+    );
+    assert_eq!(main_invocation_count(&log), 2, "one retry: {output}");
+
+    let recorded = std::fs::read(&stdin_log).expect("read replacement attach stdin");
+    assert!(
+        recorded
+            .windows(b"RIMZ-USER-MARKER".len())
+            .any(|window| window == b"RIMZ-USER-MARKER"),
+        "post-handoff user input was not delivered: {recorded:?}"
+    );
+    for stale_token in [
+        b"62;22;52".as_slice(),
+        b"1;10;0c".as_slice(),
+        b"ghostty".as_slice(),
+    ] {
+        assert!(
+            !recorded
+                .windows(stale_token.len())
+                .any(|window| window == stale_token),
+            "stale terminal reply reached replacement attach: {recorded:?}"
+        );
+    }
+}
+
+#[test]
 fn recovery_panel_checks_the_configured_http_204_endpoint() {
     let env = Env::new();
     let log = env.project_root.join("ssh-trace.log");

--- a/crates/rimz/tests/integration/remote_attach.rs
+++ b/crates/rimz/tests/integration/remote_attach.rs
@@ -914,6 +914,56 @@ fn supervised_connect_restores_tty_and_resets_emulator_after_retry() {
 }
 
 #[test]
+fn supervised_clean_exit_preserves_shell_typeahead() {
+    const TYPEAHEAD: &[u8] = b"rimz-shell-typeahead\n";
+
+    let env = Env::new();
+    let log = env.project_root.join("ssh-trace.log");
+    let pair = remote_connect_pty();
+    let tty_name = pair.master.tty_name().expect("remote connect pty name");
+    let mut cmd = remote_connect_pty_command(&env, &log);
+    cmd.env("RIMZ_TEST_SSH_RAW_TTY", "1");
+    cmd.env("RIMZ_TEST_SSH_SLEEP_MS", "500");
+
+    let mut child = pair.slave.spawn_command(cmd).expect("spawn remote connect");
+    drop(pair.slave);
+    let mut writer = pair.master.take_writer().expect("take pty writer");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while main_invocation_count(&log) < 1 && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert_eq!(main_invocation_count(&log), 1, "attach did not start");
+    writer.write_all(TYPEAHEAD).expect("queue shell typeahead");
+    writer.flush().expect("flush shell typeahead");
+    drop(writer);
+
+    let status = loop {
+        if let Some(status) = child.try_wait().expect("poll remote connect") {
+            break Some(status);
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            break None;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    .expect("remote connect timed out");
+    assert!(status.success(), "remote connect failed with {status:?}");
+
+    let mut tty = std::fs::File::open(tty_name).expect("reopen remote connect pty");
+    nix::fcntl::fcntl(
+        &tty,
+        nix::fcntl::FcntlArg::F_SETFL(nix::fcntl::OFlag::O_NONBLOCK),
+    )
+    .expect("set remote connect pty nonblocking");
+    let mut queued = vec![0u8; TYPEAHEAD.len()];
+    tty.read_exact(&mut queued)
+        .expect("read queued shell typeahead");
+    assert_eq!(queued, TYPEAHEAD);
+}
+
+#[test]
 fn supervised_reconnect_discards_stale_terminal_replies_and_preserves_user_input() {
     const TERMINAL_REPLIES: &[u8] = b"\x1b[?62;22;52c\x1b[>1;10;0c\x1bP>|ghostty 1.3.1\x1b\\";
     const USER_MARKER: &[u8] = b"RIMZ-USER-MARKER\r";

--- a/docs/internals/remote.md
+++ b/docs/internals/remote.md
@@ -185,7 +185,7 @@ An attach over a confirmed master pipes and drains SSH stderr instead of letting
 
 A session counts as established once its link probe receives the first ack, once its initial master is confirmed, or once it lives past the gatetime (30 seconds by default). `ReconnectState` folds establishment and consecutive failures across sessions; `settle_zombie_kill` records an intentional kill without classifying its signal exit as fatal.
 
-**Terminal hygiene** wraps every session. `TtyGuard` snapshots local termios at connect, repairs a leftover raw tty at entry, and restores the snapshot after each SSH session. An unclean end also writes the emulator reset string, because `ssh -t` mirrors local tty modes onto the remote pty and a `SIGKILL`ed transport cannot restore terminal-emulator state itself.
+**Terminal hygiene** wraps every session. `TtyGuard` snapshots local termios at connect, repairs a leftover raw tty at entry, and restores the snapshot after each SSH session. Before a retry or zombie replacement, it discards pending tty input so terminal-protocol replies addressed to the dead SSH generation cannot reach the next attach; exit paths never flush, preserving type-ahead for the shell that regains the terminal. An unclean end also writes the emulator reset string, because `ssh -t` mirrors local tty modes onto the remote pty and a `SIGKILL`ed transport cannot restore terminal-emulator state itself.
 
 ## Reconnect pacing and reachability
 


### PR DESCRIPTION
## Context

After a supervised `rimz remote` reconnect, terminal-protocol replies leaked into the focused pane as if the user had typed them. The remote tmux client queries the terminal on attach; Ghostty answers within milliseconds with its DA1/DA2/XTVERSION group (`ESC[?62;22;52c` `ESC[>1;10;0c` `ESC P>|ghostty 1.3.1 ESC \`), and a dying SSH client never drains it. Nothing in the death→respawn sequence invalidated pending input — `TtyGuard::restore()` uses `TCSADRAIN`, which preserves the input queue, and the crate had no `tcflush` anywhere — so the replacement SSH child inherited the bytes and the remote tmux client forwarded them to the focused pane.

The mechanism was verified before any code was written: a toggle probe against tmux 3.7b produced pane input 0/10 with one queued reply group and 10/10 with two. The sub-grace recovery path is where this bites — a recovery that completes inside the 500 ms grace never opens the outage panel, whose `poll_interrupt` would otherwise drain stdin incidentally.

## Design choices

**Flush at death, not parse.** `tcflush(TCIFLUSH)` on supervisor stdin, only on the two branches that loop back to a new visible child. Placement rather than parsing is what makes the discard precise: at the instant the dead child is reaped, the queue holds exactly the bytes addressed to the dead session — stale replies plus any keystrokes doomed with it — while everything typed afterwards during the outage stays queued for the replacement. A reply parser was considered and rejected: it needs no tty peek but gives a weaker guarantee and adds a new grammar surface. A flush+parser hybrid was rejected because the race it closes is already closed by the attach-time queuing fact, reinforced by the 200 ms session poll, which means any in-flight reply has landed well before the reap.

**Exit paths never flush.** `CleanExit`, `Fatal`, and the `attach_interrupted` early return hand the terminal back to the shell, where pending input is legitimate type-ahead. `TtyGuard::restore()` and `Drop` stay flush-free for the same reason. This asymmetry is the safety property of the change, so it is pinned by a test rather than left to call-site placement alone.

**No per-backend variant.** The supervisor and tty path never branch on tmux vs Zellij — `mux` only alters the remote-side snippet argv — so parity holds by construction and a duplicated test would prove nothing.

## Implementation

`TtyGuard::discard_pending_input` (`cli/remote/tty.rs`) is a fail-soft `tcflush(TCIFLUSH)` gated on a captured tty snapshot, matching the debug-log-and-continue idiom already used by `restore` and `reset_emulator`: a platform tty error stays diagnostic rather than becoming a new reconnect failure mode. The supervisor calls it from the zombie branch and from `Verdict::Retry` (`cli/remote/supervisor.rs`), both after the dead child is reaped — `run_ssh_session` returns only once `try_wait` yields a status, and `verify_zombie` kills then waits.

Two regressions, both driving a real PTY:

- `supervised_reconnect_discards_stale_terminal_replies_and_preserves_user_input` queues the exact 41-byte Ghostty reply group behind a dying first attach, then proves the replacement child's stdin carries fresh user input and none of the stale reply's tokens. It deliberately leaves the default 500 ms grace intact so the outage panel cannot mask a missing flush. Demonstrated red before the fix landed.
- `supervised_clean_exit_preserves_shell_typeahead` pins the other half: type-ahead queued behind a clean-exiting attach is still in the tty queue after the supervisor returns. It fails if the flush is ever moved into `restore()`, `Drop`, or an exit branch.

Supporting the first test, the `ssh-trace` fixture gained an opt-in, generation-aligned stdin plan (`ignore | record`) and a bounded sentinel recorder, so an otherwise opaque replacement SSH child can expose the bytes it actually inherited. Normal shim invocations keep their previous non-reading behaviour. `docs/internals/remote.md` records the reconnect-only flush and the exit-path preservation rule.

No deviations from the agreed plan.

## Advisories

- The regression exercises the `Verdict::Retry` call site; the zombie call site is held by inspection rather than a dedicated timing test. Both call the same primitive at the same post-reap seam, and a zombie-path test would need a dial plan, a reachable host, and a blacked-out probe — disproportionate machinery for a second call to an already-covered primitive.
- No physical Ghostty/tmux journey was run in this branch. The PTY test injects the verified causal state at the replacement child's real stdin consumer, and the live tmux 3.7b toggle probe covers the real-world half.
- Input typed while the *post-grace* outage panel is visible is still swallowed by the panel, which drains stdin and acts only on Ctrl-C. That is pre-existing and intentional — it stops scroll momentum reaching the new pane — and untouched here.
- Input typed while an SSH generation is dying — after the reply group is queued but before the child is reaped — is discarded along with it. That is the deliberate consequence of flushing at the reap point rather than parsing: those keystrokes were addressed to a session that no longer exists.

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>forge</code> team · 3 agents · 48m active · $17.19 · 5 messages (1 from you)</summary>

- **planner** — Claude `claude-fable-5@high`
  - effort: 11m active · $6.24 incl. subagents
  - calls: 1 ask · 26 tool calls
  - messages: 1 from you · 1 to teammates
  - tokens: 650 input, 65.3k output, 268.1k cache write, 4.3m cache read
  - subagents: 2 × explore ($1.35)
- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 16m active · $4.90
  - calls: 40 tool calls
  - messages: 2 from teammates · 2 to teammates
  - tokens: 154.6k input, 18.5k output, 7.1m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 21m active · $6.05
  - calls: 75 tool calls
  - messages: 2 from teammates · 1 to teammates
  - tokens: 122 input, 62k output, 139k cache write, 6.2m cache read

</details>