### PR TITLE
refactor(config): tighten file registry and child interfaces

### DIFF
--- a/crates/rimz/src/config.rs
+++ b/crates/rimz/src/config.rs
@@ -121,10 +121,10 @@ const AGENTS_HOME_PROFILES_SUBDIR: &str = "profiles";
 const AGENTS_HOME_TEAMS_SUBDIR: &str = "teams";
 const AGENT_FRAGMENT_FILE: &str = "agent.toml";
 const TEAM_FRAGMENT_FILE: &str = "team.toml";
-pub const MACHINE_CONFIG_TEMPLATE: &str = include_str!("config/templates/config.template.toml");
-pub const MACHINE_THEME_TEMPLATE: &str = include_str!("config/templates/theme.template.toml");
-pub const MACHINE_AGENTS_TEMPLATE: &str = include_str!("config/templates/agents.template.toml");
-pub const MACHINE_LOOP_TEMPLATE: &str = include_str!("config/templates/loop.template.toml");
+const MACHINE_CONFIG_TEMPLATE: &str = include_str!("config/templates/config.template.toml");
+const MACHINE_THEME_TEMPLATE: &str = include_str!("config/templates/theme.template.toml");
+const MACHINE_AGENTS_TEMPLATE: &str = include_str!("config/templates/agents.template.toml");
+const MACHINE_LOOP_TEMPLATE: &str = include_str!("config/templates/loop.template.toml");
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum MachineConfigFileKind {
@@ -211,10 +211,6 @@ impl MachineConfigFiles {
             path: self.path(kind),
             template: kind.template(),
         })
-    }
-
-    pub fn ordered_paths(&self) -> [PathBuf; 4] {
-        MachineConfigFileKind::ALL.map(|kind| self.path(kind))
     }
 
     fn path(&self, kind: MachineConfigFileKind) -> PathBuf {
@@ -485,21 +481,6 @@ pub struct MachineConfig {
 }
 
 impl MachineConfig {
-    /// The generated core per-machine config reference.
-    pub fn template_core() -> &'static str {
-        MachineConfigFileKind::Core.template()
-    }
-
-    /// The generated theme per-machine config reference.
-    pub fn template_theme() -> &'static str {
-        MachineConfigFileKind::Theme.template()
-    }
-
-    /// The generated agents per-machine config reference.
-    pub fn template_agents() -> &'static str {
-        MachineConfigFileKind::Agents.template()
-    }
-
     /// The generated loop per-machine config reference.
     pub fn template_loop() -> &'static str {
         MachineConfigFileKind::Loop.template()

--- a/crates/rimz/src/config/edit/tests.rs
+++ b/crates/rimz/src/config/edit/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::config::{
-    AGENT_FRAGMENT_FILE, AGENTS_HOME_PROFILES_SUBDIR, AGENTS_HOME_TEAMS_SUBDIR, TEAM_FRAGMENT_FILE,
+    AGENT_FRAGMENT_FILE, AGENTS_HOME_PROFILES_SUBDIR, AGENTS_HOME_TEAMS_SUBDIR,
+    MachineConfigFileKind as Kind, TEAM_FRAGMENT_FILE,
 };
 
 fn test_files() -> MachineConfigFiles {
@@ -17,9 +18,9 @@ fn explicit_file_registry_preserves_path_and_template_order() {
             .map(|file| file.path().file_name().unwrap().to_owned()),
         ["config.toml", "theme.toml", "agents.toml", "loop.toml"].map(std::ffi::OsString::from)
     );
-    assert_eq!(ordered[0].template(), MachineConfig::template_core());
-    assert_eq!(ordered[1].template(), MachineConfig::template_theme());
-    assert_eq!(ordered[2].template(), MachineConfig::template_agents());
+    assert_eq!(ordered[0].template(), Kind::Core.template());
+    assert_eq!(ordered[1].template(), Kind::Theme.template());
+    assert_eq!(ordered[2].template(), Kind::Agents.template());
     assert_eq!(ordered[3].template(), MachineConfig::template_loop());
 }
 
@@ -408,7 +409,8 @@ fn dynamic_profile_and_team_field_lists_match_serialized_schema() {
 
 #[test]
 fn set_top_level_timezone_keeps_core_config_valid() {
-    let mut doc = MachineConfig::template_core()
+    let mut doc = Kind::Core
+        .template()
         .parse::<DocumentMut>()
         .expect("template parses");
     let agents_home = std::path::Path::new("missing-agents-home");
@@ -437,7 +439,8 @@ fn set_top_level_timezone_keeps_core_config_valid() {
 
 #[test]
 fn set_context_meter_log_scale_round_trips_through_scalar_path() {
-    let mut doc = MachineConfig::template_theme()
+    let mut doc = Kind::Theme
+        .template()
         .parse::<DocumentMut>()
         .expect("template parses");
     let agents_home = std::path::Path::new("missing-agents-home");
@@ -463,7 +466,8 @@ fn set_context_meter_log_scale_round_trips_through_scalar_path() {
 
 #[test]
 fn round_trip_validation_reports_the_logical_key_value_and_message() {
-    let mut doc = MachineConfig::template_core()
+    let mut doc = Kind::Core
+        .template()
         .parse::<DocumentMut>()
         .expect("template parses");
     let key = parse_key("remote_control.claude").expect("key");
@@ -533,7 +537,8 @@ nope = "surprise"
 #[test]
 fn merge_key_oracle_accepts_sentry_and_rejects_bogus_keys() {
     let agents_home = std::path::Path::new("missing-agents-home");
-    let mut doc = MachineConfig::template_core()
+    let mut doc = Kind::Core
+        .template()
         .parse::<DocumentMut>()
         .expect("template parses");
     let mut skipped = Vec::new();
@@ -569,7 +574,8 @@ fn merge_key_oracle_accepts_sentry_and_rejects_bogus_keys() {
 
 #[test]
 fn merge_uncomments_section_key_on_its_template_line() {
-    let mut doc = MachineConfig::template_core()
+    let mut doc = Kind::Core
+        .template()
         .parse::<DocumentMut>()
         .expect("template parses");
     let mut skipped = Vec::new();
@@ -607,7 +613,7 @@ fn merge_uncomments_section_key_on_its_template_line() {
 
 #[test]
 fn merge_uncomments_root_scalar_at_its_template_position() {
-    let template = MachineConfig::template_core();
+    let template = Kind::Core.template();
     let mut doc = template.parse::<DocumentMut>().expect("template parses");
     let mut skipped = Vec::new();
     let kept = apply_merge_keys(
@@ -648,7 +654,8 @@ fn merge_uncomments_root_scalar_at_its_template_position() {
 
 #[test]
 fn merge_uncomments_optional_example_under_its_section() {
-    let mut doc = MachineConfig::template_core()
+    let mut doc = Kind::Core
+        .template()
         .parse::<DocumentMut>()
         .expect("template parses");
     let mut skipped = Vec::new();
@@ -675,7 +682,8 @@ fn merge_uncomments_optional_example_under_its_section() {
 
 #[test]
 fn merge_skips_keys_inside_commented_table_examples() {
-    let mut doc = MachineConfig::template_agents()
+    let mut doc = Kind::Agents
+        .template()
         .parse::<DocumentMut>()
         .expect("template parses");
     let mut skipped = Vec::new();
@@ -721,7 +729,8 @@ fn uncomment_accepts_active_header_with_trailing_comment() {
 
 #[test]
 fn failed_merge_keeps_template_default_commented() {
-    let mut doc = MachineConfig::template_core()
+    let mut doc = Kind::Core
+        .template()
         .parse::<DocumentMut>()
         .expect("template parses");
     let mut skipped = Vec::new();
@@ -749,7 +758,8 @@ fn failed_merge_keeps_template_default_commented() {
 
 #[test]
 fn merge_preserves_trailing_comment_on_existing_scalar() {
-    let mut doc = MachineConfig::template_core()
+    let mut doc = Kind::Core
+        .template()
         .parse::<DocumentMut>()
         .expect("template parses");
     let mut skipped = Vec::new();

--- a/crates/rimz/src/config/notifications.rs
+++ b/crates/rimz/src/config/notifications.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::agents::AgentStatus;
 
-pub const KNOWN_TEMPLATE_VARS: &[&str] = &[
+const KNOWN_TEMPLATE_VARS: &[&str] = &[
     "kind", "agent", "handle", "status", "worktree", "task", "count", "unread", "pane", "root",
     "title", "body",
 ];
@@ -206,7 +206,7 @@ pub fn render_template(
     Ok(out)
 }
 
-pub fn referenced_vars(template: &str) -> Vec<String> {
+fn referenced_vars(template: &str) -> Vec<String> {
     let mut vars = Vec::new();
     let mut rest = template;
     while let Some(start) = rest.find("{{") {

--- a/crates/rimz/src/config/resume.rs
+++ b/crates/rimz/src/config/resume.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 /// The default nudge an enabled auto-continue sends a parked agent — the text a
 /// human would type to pick the turn back up.
-pub const DEFAULT_AUTO_CONTINUE_TEXT: &str = "continue";
+const DEFAULT_AUTO_CONTINUE_TEXT: &str = "continue";
 
 /// The default backoff ramp, in seconds, between non-clocked auto-continue
 /// nudges. The first retry lands 3 minutes after the marker, then the 5-minute
@@ -14,7 +14,7 @@ pub const DEFAULT_AUTO_CONTINUE_BACKOFF_SECS: &[u64] = &[180, 300];
 /// The default ceiling on backoff auto-continue attempts. At the [default ramp][`DEFAULT_AUTO_CONTINUE_BACKOFF_SECS`]
 /// this spans ~58min (180 + 300x11) before the producer stops attempting
 /// and leaves the row parked.
-pub const DEFAULT_AUTO_CONTINUE_MAX_RETRIES: u32 = 12;
+const DEFAULT_AUTO_CONTINUE_MAX_RETRIES: u32 = 12;
 
 /// Minimum blocked time an automatic reset-credit redemption buys by default.
 pub const DEFAULT_AUTO_REDEEM_MIN_GAIN: &str = "12h";

--- a/crates/rimz/src/config/sidebar.rs
+++ b/crates/rimz/src/config/sidebar.rs
@@ -71,7 +71,7 @@ impl SidebarConfig {
 /// The shipped default focus-sidebar chord: `Alt+p`, a toggle that reaches the
 /// sidebar and returns to the last pane. `Alt` survives the terminal and
 /// Zellij's locked mode; the user can rebind or disable it.
-pub fn default_focus_key() -> String {
+fn default_focus_key() -> String {
     "Alt+p".to_owned()
 }
 

--- a/crates/rimz/src/config/template_tests.rs
+++ b/crates/rimz/src/config/template_tests.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 
 use super::*;
+use MachineConfigFileKind as Kind;
 
 const ACTIVE_ZELLIJ_DEFAULTS: &[&str] = &[
     "mouse_click_through",
@@ -27,17 +28,17 @@ fn template_defaults_deserialize_to_machine_defaults() {
     let dir = tempfile::tempdir().expect("tempdir");
     std::fs::write(
         dir.path().join("config.toml"),
-        uncomment_default_lines(MachineConfig::template_core()),
+        uncomment_default_lines(Kind::Core.template()),
     )
     .expect("write config template");
     std::fs::write(
         dir.path().join("theme.toml"),
-        uncomment_default_lines(MachineConfig::template_theme()),
+        uncomment_default_lines(Kind::Theme.template()),
     )
     .expect("write theme template");
     std::fs::write(
         dir.path().join("agents.toml"),
-        uncomment_default_lines(MachineConfig::template_agents()),
+        uncomment_default_lines(Kind::Agents.template()),
     )
     .expect("write agents template");
     std::fs::write(
@@ -99,7 +100,7 @@ fn template_comparison_defaults(mut config: MachineConfig) -> MachineConfig {
 
 #[test]
 fn template_lists_optional_sidebar_theme_slots() {
-    let template = MachineConfig::template_theme();
+    let template = Kind::Theme.template();
     for setting in ["mode", "scheme"] {
         assert!(
             template.contains(&format!("## {setting} = ")),
@@ -133,9 +134,9 @@ fn template_lists_optional_sidebar_theme_slots() {
 }
 
 fn all_template_default_paths() -> BTreeSet<String> {
-    let mut out = template_default_paths(MachineConfig::template_core());
+    let mut out = template_default_paths(Kind::Core.template());
     out.extend(
-        template_default_paths(MachineConfig::template_theme())
+        template_default_paths(Kind::Theme.template())
             .into_iter()
             .map(|path| {
                 path.strip_prefix("colors.")
@@ -143,7 +144,7 @@ fn all_template_default_paths() -> BTreeSet<String> {
                     .unwrap_or(path)
             }),
     );
-    out.extend(template_default_paths(MachineConfig::template_agents()));
+    out.extend(template_default_paths(Kind::Agents.template()));
     out.extend(
         template_default_paths(MachineConfig::template_loop())
             .into_iter()

--- a/crates/rimz/src/config/worktree.rs
+++ b/crates/rimz/src/config/worktree.rs
@@ -53,7 +53,7 @@ impl WorktreeBase {
         }
     }
 
-    pub fn as_config_value(&self) -> &str {
+    fn as_config_value(&self) -> &str {
         match self {
             Self::Head => "head",
             Self::Fresh => "fresh",

--- a/crates/rimz/src/theme/glyphs.rs
+++ b/crates/rimz/src/theme/glyphs.rs
@@ -497,8 +497,8 @@ mod tests {
             theme: crate::config::ThemeConfig,
         }
 
-        let parsed: ThemeFile = toml::from_str(crate::config::MachineConfig::template_theme())
-            .expect("theme template parses");
+        let files = crate::config::MachineConfigFiles::machine().ordered();
+        let parsed: ThemeFile = toml::from_str(files[1].template()).expect("theme template parses");
         let mut unicode_theme = parsed.theme.clone();
         unicode_theme.glyphs.set = Some("unicode".to_owned());
         let from_template = GlyphSet::resolve(&unicode_theme);

--- a/crates/rimz/tests/integration/config.rs
+++ b/crates/rimz/tests/integration/config.rs
@@ -1267,7 +1267,7 @@ fn setup_yes_preserves_template_comments_for_untouched_config() {
     let env = Env::new();
     write_machine_file(
         &machine_config_path(&env),
-        rimz::config::MachineConfig::template_core(),
+        rimz::config::MachineConfigFiles::machine().ordered()[0].template(),
     );
 
     env.rimz().args(["setup", "--yes"]).assert().success();

--- a/refactor-target.toml
+++ b/refactor-target.toml
@@ -100,12 +100,32 @@ allowed-imports = [
 surface-budget = 12
 
 [[module]]
+path = "crates/rimz/src/config/notifications.rs"
+allowed-imports = ["agents"]
+surface-budget = 23
+
+[[module]]
+path = "crates/rimz/src/config/resume.rs"
+allowed-imports = []
+surface-budget = 5
+
+[[module]]
+path = "crates/rimz/src/config/sidebar.rs"
+allowed-imports = []
+surface-budget = 5
+
+[[module]]
+path = "crates/rimz/src/config/worktree.rs"
+allowed-imports = []
+surface-budget = 4
+
+[[module]]
 path = "crates/rimz/src/config.rs"
 allowed-imports = [
     "store::parse_cache",
     "store::paths",
 ]
-surface-budget = 176
+surface-budget = 168
 
 [[module]]
 path = "crates/rimz/src/daemon_content.rs"


### PR DESCRIPTION
## Context

`config.rs` carried two ways to reach the same per-machine config templates: the `MachineConfigFiles` registry, which owns the ordered path/template pairs, and a parallel family on `MachineConfig` left behind when editing was centralized on the registry. Four raw `include_str!` template constants were public alongside both. Four helpers in child config modules were published beyond their defining file with no caller outside it.

This is a behavior-preserving pass: structure and visibility change; CLI output, config keys, template bytes, defaults, parsing, validation, load and fallback order, fragment precedence, diagnostics, and persisted bytes do not.

## Target shape

`MachineConfigFiles` alone owns ordered file paths and templates. `MachineConfig` keeps only the accessors production calls, and the embedded template constants never escape the module. Child config modules publish only behavior a sibling module consumes; parser tables, default constructors, and serialization spellings stay private.

What a caller stops needing to know: which of two template interfaces to reach for, that raw embedded template constants exist at all, and six child implementation helpers.

## Implementation

- Demoted `MACHINE_CONFIG_TEMPLATE`, `MACHINE_THEME_TEMPLATE`, `MACHINE_AGENTS_TEMPLATE`, and `MACHINE_LOOP_TEMPLATE` to private consts. Names, values, includes, and the `MachineConfigFileKind::template` mapping are unchanged.
- Deleted `MachineConfigFiles::ordered_paths` and `MachineConfig::{template_core,template_theme,template_agents}`, none of which had a caller outside tests. `MachineConfig::template_loop` stays public: machine loop task editing calls it, and the file-kind enum it forwards to is private.
- Made `notifications::{KNOWN_TEMPLATE_VARS,referenced_vars}`, `resume::{DEFAULT_AUTO_CONTINUE_TEXT,DEFAULT_AUTO_CONTINUE_MAX_RETRIES}`, `sidebar::default_focus_key`, and `WorktreeBase::as_config_value` private. Values and algorithms stay where they are.
- Moved the affected test call sites onto the canonical mappings: config descendants use the private `MachineConfigFileKind::template`, and the `theme::glyphs` unit test plus the external integration test read the retained public `MachineConfigFiles` registry — the latter deliberately proving an external Cargo target still has what it needs. Assertions and template bytes are unchanged.
- Ratcheted `refactor-target.toml`: `config.rs` from 176 to the measured 168, plus new per-file rules for `config/{notifications,resume,sidebar,worktree}.rs` at 23/5/5/4. Every touched rule sits at `current == budget`, so none carries slack. The broad `crates/rimz/src/config` rule stays at 12; it measures parent-folder escape, not child-row interfaces.

Deviation from plan: the plan budgeted neutral test SLOC, and the change ships +11 test lines. `Kind::Core.template()` is a two-element method chain where `MachineConfig::template_core()` was one, so rustfmt breaks it across an extra line at eleven call sites. The alternatives — a test helper, or keeping a public convenience method — both put back interface this pass exists to remove. Production source is unaffected.

## Surface removed

Production source is −12 lines by Atlas measure (`config.rs` 1,500 → 1,488); child-module production lines are neutral. Test lines are +11, stated apart and discounted. Physical production Rust is −19 lines.

Fourteen escaping entries are gone — eight at the root facade, six across child rows:

- root, escaping 176 → 168: four template constants, `ordered_paths`, and three `MachineConfig::template_*` methods
- `config/notifications.rs` 25 → 23, `config/resume.rs` 7 → 5, `config/sidebar.rs` 6 → 5, `config/worktree.rs` 5 → 4

No flags, options, or files were removed; this pass is interface subtraction.

## Advisories

- Two cross-module tests now index the ordered registry positionally (`ordered()[0]` for core, `[1]` for theme) and call `MachineConfigFiles::machine()`, which resolves real machine config roots, only to reach a static string. Neither is a defect — the registry order is asserted in `config/edit/tests.rs`, the glyphs test fails loudly on the wrong template, and nothing reads or writes those paths — but `from_paths` is the documented test-and-tooling constructor and would say what it means. Left as is to avoid adding a test helper or a re-export.
- Between them, the four sibling templates are now fetched three ways across the test suite: the private kind mapping, `MachineConfig::template_loop`, and positional registry indexing. The public API is smaller for it; the test-side idiom count went up by one.

Next passes, recorded but not taken here:

- **Worth exploring — rehome edit value typing.** The string-valued edit exception table in `config/edit.rs` has grown a predicate plus a validation branch per feature. A from-scratch editor would trial typed rendered config instead of enumerating semantic string paths. Blocked until a design preserves exact `ConfigEditErr` selection, the existing invalid-value wording, and existing-invalid precedence while showing net subtraction.
- **Speculative — collapse strict/lenient load preparation.** The shared file reads and notices look duplicated, but the fragment and torn-read fixes underneath encode different recovery contracts. Reopen only with a single result model that deletes branches and keeps every characterization test.
- **Out of scope — project config and trust read.** `config/effective.rs` and `trust.rs` parse overlapping project data. Same-read trust correctness is an invariant and security pass, not behavior-preserving cleanup.

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>mill</code> team · 3 agents · 45m active · $15.47 · 3 messages (1 from you)</summary>

- **architect** — Codex `gpt-5.6-sol@high`
  - effort: 18m active · $9.31
  - calls: 75 tool calls
  - messages: 1 from you · 1 to teammates
  - tokens: 278.1k input, 33.7k output, 13.8m cache read
- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 14m active · $3.53
  - calls: 38 tool calls
  - messages: 1 from teammates · 1 to teammates
  - tokens: 119.7k input, 19.8k output, 4.7m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 12m active · $2.63
  - calls: 38 tool calls
  - messages: 1 from teammates
  - tokens: 72 input, 28.1k output, 75k cache write, 2.4m cache read

</details>