### PR TITLE
refactor(room): collapse birth request shells and narrow session reach

### DIFF
--- a/crates/rimz/src/cli/room/mod.rs
+++ b/crates/rimz/src/cli/room/mod.rs
@@ -16,10 +16,7 @@ use rimz::room::session::{
     MissingSessionReport, ensure_single_backend_room, pick_mux_for_session, retire_renamed_session,
     session_probe_retry_timeout, session_probe_timeout, workspace_record_for_session,
 };
-use rimz::room::{
-    AttendedRecovery, BackgroundViewBirth, NormalBirth, NormalRebirth, RoomBirth, RoomContext,
-    RoomSizing,
-};
+use rimz::room::{AttendedRecovery, NormalRebirth, RoomBirth, RoomContext, RoomSizing};
 use rimz::{RuntimePaths, store::workspace_record::WorkspaceRecord};
 
 use crate::cli::hooks::ensure_detected_agent_hooks;
@@ -422,9 +419,9 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
         let readiness =
             rimz::remote_control::ReadinessSnapshot::probe(&machine_config.remote_control);
         readiness.start_gate()?;
-        BackgroundViewBirth::Launch(readiness)
+        Some(readiness)
     } else {
-        BackgroundViewBirth::Skip
+        None
     };
 
     let mux = match &entry {
@@ -550,7 +547,7 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
                 entry.no_resume(),
                 entry.resume_prompt_mode(),
                 entry.refresh_ms(),
-                BackgroundViewBirth::Skip,
+                None,
                 workspace.worktree_root.clone(),
             )?;
             ReadyRoom::Managed(Box::new(context))
@@ -564,7 +561,7 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
                 entry.no_resume(),
                 entry.resume_prompt_mode(),
                 entry.refresh_ms(),
-                BackgroundViewBirth::Skip,
+                None,
                 record.project_root.clone(),
             )?;
             ReadyRoom::Managed(Box::new(context))
@@ -587,7 +584,7 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
                     entry.no_resume(),
                     entry.resume_prompt_mode(),
                     entry.refresh_ms(),
-                    BackgroundViewBirth::Skip,
+                    None,
                     record.project_root.clone(),
                 )?;
                 ReadyRoom::Managed(Box::new(context))
@@ -639,7 +636,7 @@ fn birth_managed_room(
     no_resume: bool,
     resume_prompt: ResumePromptMode,
     refresh_ms: Option<u16>,
-    background_view: BackgroundViewBirth,
+    background_view: Option<rimz::remote_control::ReadinessSnapshot>,
     cwd: std::path::PathBuf,
 ) -> Result<()> {
     let rebirth = if was_live {
@@ -666,7 +663,7 @@ fn birth_managed_room(
         }
     };
     let outcome = render::room::present_birth_outcome(
-        context.birth(RoomBirth::Normal(NormalBirth {
+        context.birth(RoomBirth::Normal {
             cwd,
             rebirth,
             background_view,
@@ -676,7 +673,7 @@ fn birth_managed_room(
             } else {
                 AttendedRecovery::RequireExplicitReset
             },
-        })),
+        }),
         context.session_name(),
     )?;
     report_resume(&outcome.resume);

--- a/crates/rimz/src/cli/sessions/picker.rs
+++ b/crates/rimz/src/cli/sessions/picker.rs
@@ -18,7 +18,7 @@ use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, Paragraph};
 use ratatui::{Frame, Terminal};
 use rimz::config::{GlyphRole, MachineConfig, ThemeConfig, ThemeProviderStyle};
 use rimz::ids::{AgentKind, MuxName};
-use rimz::room::session::{LiveRoom, LiveSessions};
+use rimz::room::session::LiveRoom;
 use rimz::sidebar::consumer::PublishedSnapshotReader;
 use rimz::theme::{Identity, Palette, Tone, resolve_provider_brand, theme_glyphs};
 use rimz::tui::{MouseCapture, Screen, TerminalModeGuard};
@@ -221,8 +221,7 @@ fn exit_status_label(status: std::process::ExitStatus) -> String {
 fn probe_inventory(
     readers: &mut BTreeMap<String, PublishedSnapshotReader>,
 ) -> rimz::room::LiveRoomResult<(Vec<RoomRow>, Vec<KnownWorkspace>)> {
-    let live = LiveSessions::probe();
-    let inventory = rimz::room::session::room_inventory_with(&live)?;
+    let inventory = rimz::room::session::room_inventory()?;
     let rooms = inventory.live;
     let live_names = rooms
         .iter()

--- a/crates/rimz/src/cli/supervised/run.rs
+++ b/crates/rimz/src/cli/supervised/run.rs
@@ -793,16 +793,14 @@ pub(in crate::cli) fn run_supervised(
         rimz::room::RoomSizing::Birth,
     )?;
     render::room::present_birth_outcome(
-        room.birth(rimz::room::RoomBirth::Supervised(
-            rimz::room::SupervisedBirth {
-                cwd: prepared.launch.cwd.clone(),
-                recovery: if std::io::stdin().is_terminal() {
-                    rimz::room::AttendedRecovery::Reset
-                } else {
-                    rimz::room::AttendedRecovery::RequireExplicitReset
-                },
+        room.birth(rimz::room::RoomBirth::Supervised {
+            cwd: prepared.launch.cwd.clone(),
+            recovery: if std::io::stdin().is_terminal() {
+                rimz::room::AttendedRecovery::Reset
+            } else {
+                rimz::room::AttendedRecovery::RequireExplicitReset
             },
-        )),
+        }),
         room.session_name(),
     )?;
     let retries = request.retries;

--- a/crates/rimz/src/room/birth.rs
+++ b/crates/rimz/src/room/birth.rs
@@ -39,6 +39,7 @@ pub enum RoomBirth {
     Normal {
         cwd: PathBuf,
         rebirth: NormalRebirth,
+        /// `None` requests no configured background-view launch.
         background_view: Option<ReadinessSnapshot>,
         refresh_ms: Option<u16>,
         recovery: AttendedRecovery,

--- a/crates/rimz/src/room/birth.rs
+++ b/crates/rimz/src/room/birth.rs
@@ -34,32 +34,19 @@ pub enum AttendedRecovery {
     RequireExplicitReset,
 }
 
-/// Whether normal room birth carries the configured daemon view.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum BackgroundViewBirth {
-    Launch(ReadinessSnapshot),
-    Skip,
-}
-
-/// Normal start/attach birth inputs.
-pub struct NormalBirth {
-    pub cwd: PathBuf,
-    pub rebirth: NormalRebirth,
-    pub background_view: BackgroundViewBirth,
-    pub refresh_ms: Option<u16>,
-    pub recovery: AttendedRecovery,
-}
-
-/// Supervised-run birth inputs.
-pub struct SupervisedBirth {
-    pub cwd: PathBuf,
-    pub recovery: AttendedRecovery,
-}
-
 /// Two real room birth policies.
 pub enum RoomBirth {
-    Normal(NormalBirth),
-    Supervised(SupervisedBirth),
+    Normal {
+        cwd: PathBuf,
+        rebirth: NormalRebirth,
+        background_view: Option<ReadinessSnapshot>,
+        refresh_ms: Option<u16>,
+        recovery: AttendedRecovery,
+    },
+    Supervised {
+        cwd: PathBuf,
+        recovery: AttendedRecovery,
+    },
 }
 
 /// Reset details returned for CLI presentation.
@@ -70,19 +57,12 @@ pub struct RoomResetReport {
 }
 
 /// Health retry failed after an attended reset already changed room state.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
 pub struct ResetRecoveryError {
     pub report: RoomResetReport,
     message: String,
 }
-
-impl std::fmt::Display for ResetRecoveryError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.message)
-    }
-}
-
-impl std::error::Error for ResetRecoveryError {}
 
 /// Birth results rendered by the command boundary.
 #[derive(Default)]
@@ -126,34 +106,30 @@ impl RoomContext {
         }
 
         let (cwd, refresh_ms, rebirth, background_view, recovery, supervised) = match birth {
-            RoomBirth::Normal(normal) => (
-                normal.cwd,
-                normal.refresh_ms,
-                Some(normal.rebirth),
-                normal.background_view,
-                normal.recovery,
+            RoomBirth::Normal {
+                cwd,
+                rebirth,
+                background_view,
+                refresh_ms,
+                recovery,
+            } => (
+                cwd,
+                refresh_ms,
+                Some(rebirth),
+                background_view,
+                recovery,
                 false,
             ),
-            RoomBirth::Supervised(supervised) => (
-                supervised.cwd,
-                None,
-                None,
-                BackgroundViewBirth::Skip,
-                supervised.recovery,
-                true,
-            ),
+            RoomBirth::Supervised { cwd, recovery } => (cwd, None, None, None, recovery, true),
         };
         self.backend.ensure_session(&self.session_options(&cwd))?;
         if supervised && pre_existed {
             self.detected_size = None;
         }
 
-        let background_view = match background_view {
-            BackgroundViewBirth::Launch(readiness) => {
-                Some(self.background_view(&readiness, refresh_ms))
-            }
-            BackgroundViewBirth::Skip => None,
-        };
+        let background_view = background_view
+            .as_ref()
+            .map(|readiness| self.background_view(readiness, refresh_ms));
 
         let resume = match rebirth {
             Some(rebirth) => match rebirth {
@@ -188,7 +164,14 @@ impl RoomContext {
 
         let background_view = background_view.as_ref();
         let daemon = background_view.map(|options| &options.view);
-        self.launch_sidebar(&sidebar, !pre_existed, daemon);
+        let mut birth_sidebar = sidebar.clone();
+        birth_sidebar.pristine_birth = !pre_existed;
+        let _ = crate::sidebar::launch_sidebar_if_needed(
+            self.backend.as_ref(),
+            &self.runtime,
+            &birth_sidebar,
+            daemon,
+        );
 
         if let Some(options) = background_view {
             self.launch_background_view(options);
@@ -197,22 +180,6 @@ impl RoomContext {
         let reset = self.ensure_healthy(&sidebar, daemon, recovery)?;
         self.load_presence();
         Ok(BirthOutcome { resume, reset })
-    }
-
-    fn launch_sidebar(
-        &self,
-        options: &SidebarPaneOptions,
-        pristine_birth: bool,
-        daemon: Option<&DaemonView>,
-    ) {
-        let mut opts = options.clone();
-        opts.pristine_birth = pristine_birth;
-        let _ = crate::sidebar::launch_sidebar_if_needed(
-            self.backend.as_ref(),
-            &self.runtime,
-            &opts,
-            daemon,
-        );
     }
 
     fn launch_background_view(&self, options: &BackgroundViewOptions) {
@@ -260,10 +227,12 @@ impl RoomContext {
             return Ok(None);
         }
         if recovery == AttendedRecovery::RequireExplicitReset {
-            return Err(ResetRequired {
-                session: self.workspace.session_name.clone(),
-            }
-            .into());
+            anyhow::bail!(
+                "The '{}' Zellij room is stuck or cannot be inspected safely enough to self-heal \
+                 without a destructive reset.\n\
+                 No terminal is available to confirm one. Run `rimz reset` to rebuild it cleanly.",
+                self.workspace.session_name,
+            );
         }
         let reset = self.reset(false)?;
         match self.clean_session(sidebar, daemon) {
@@ -320,23 +289,3 @@ impl RoomContext {
         Ok(RoomResetReport { teardown, records })
     }
 }
-
-/// No terminal is available to confirm destructive reset of a stuck room.
-#[derive(Debug)]
-struct ResetRequired {
-    session: String,
-}
-
-impl std::fmt::Display for ResetRequired {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "The '{}' Zellij room is stuck or cannot be inspected safely enough to self-heal \
-             without a destructive reset.\n\
-             No terminal is available to confirm one. Run `rimz reset` to rebuild it cleanly.",
-            self.session,
-        )
-    }
-}
-
-impl std::error::Error for ResetRequired {}

--- a/crates/rimz/src/room/mod.rs
+++ b/crates/rimz/src/room/mod.rs
@@ -13,7 +13,7 @@ use crate::config::{MachineConfig, MultiplexerConfig};
 use crate::harness::rebirth::RebirthPlan;
 use crate::ids::{MuxName, WorkspaceId};
 use crate::mux::{
-    BackgroundViewOptions, CommandSpec, MuxBackend, MuxErr, PresencePluginOptions, SessionLiveness,
+    BackgroundViewOptions, CommandSpec, MuxBackend, MuxErr, PresencePluginOptions, SessionHealth,
     SessionOptions, SidebarPaneOptions, SidebarWidth,
 };
 use crate::remote_control::ReadinessSnapshot;
@@ -57,11 +57,13 @@ pub fn require_live_mux(
 
 /// Require one managed room session on an already-selected backend.
 pub fn require_live_session(backend: &dyn MuxBackend, session_name: &str) -> LiveRoomResult<()> {
-    match backend.session_liveness(session_name)? {
-        SessionLiveness::Live => Ok(()),
-        SessionLiveness::Exited | SessionLiveness::Absent => Err(LiveRoomErr::Unavailable {
+    let sessions = backend.list_sessions()?;
+    if sessions.iter().any(|session| session == session_name) {
+        Ok(())
+    } else {
+        Err(LiveRoomErr::Unavailable {
             session_name: session_name.to_owned(),
-        }),
+        })
     }
 }
 
@@ -239,10 +241,19 @@ impl RoomContext {
     /// Probe a selected backend before first-run config can construct final context.
     pub fn session_is_healthy_live(mux: MuxName, session_name: &str) -> bool {
         let backend = crate::mux::backend_for(mux);
-        matches!(
-            backend.session_liveness(session_name),
-            Ok(SessionLiveness::Live)
-        )
+        Self::probe_healthy_live(backend.as_ref(), session_name)
+    }
+
+    fn probe_healthy_live(backend: &dyn MuxBackend, session_name: &str) -> bool {
+        let exists = backend
+            .list_sessions()
+            .map(|sessions| sessions.iter().any(|name| name == session_name))
+            .unwrap_or(false);
+        exists
+            && matches!(
+                backend.probe_session_health(session_name),
+                Ok(SessionHealth::Healthy)
+            )
     }
 
     /// Inspect previous incarnation state without mutating it.

--- a/crates/rimz/src/room/mod.rs
+++ b/crates/rimz/src/room/mod.rs
@@ -22,8 +22,7 @@ use crate::workspace::ResolvedWorkspace;
 use crate::{RuntimePaths, StatePaths, Store, store::workspace_record::WorkspaceRecord};
 
 pub use birth::{
-    AttendedRecovery, BackgroundViewBirth, BirthOutcome, NormalBirth, NormalRebirth,
-    ResetRecoveryError, RoomBirth, RoomResetReport, SupervisedBirth,
+    AttendedRecovery, BirthOutcome, NormalRebirth, ResetRecoveryError, RoomBirth, RoomResetReport,
 };
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/rimz/src/room/mod.rs
+++ b/crates/rimz/src/room/mod.rs
@@ -13,7 +13,7 @@ use crate::config::{MachineConfig, MultiplexerConfig};
 use crate::harness::rebirth::RebirthPlan;
 use crate::ids::{MuxName, WorkspaceId};
 use crate::mux::{
-    BackgroundViewOptions, CommandSpec, MuxBackend, MuxErr, PresencePluginOptions, SessionHealth,
+    BackgroundViewOptions, CommandSpec, MuxBackend, MuxErr, PresencePluginOptions, SessionLiveness,
     SessionOptions, SidebarPaneOptions, SidebarWidth,
 };
 use crate::remote_control::ReadinessSnapshot;
@@ -58,13 +58,11 @@ pub fn require_live_mux(
 
 /// Require one managed room session on an already-selected backend.
 pub fn require_live_session(backend: &dyn MuxBackend, session_name: &str) -> LiveRoomResult<()> {
-    let sessions = backend.list_sessions()?;
-    if sessions.iter().any(|session| session == session_name) {
-        Ok(())
-    } else {
-        Err(LiveRoomErr::Unavailable {
+    match backend.session_liveness(session_name)? {
+        SessionLiveness::Live => Ok(()),
+        SessionLiveness::Exited | SessionLiveness::Absent => Err(LiveRoomErr::Unavailable {
             session_name: session_name.to_owned(),
-        })
+        }),
     }
 }
 
@@ -242,19 +240,10 @@ impl RoomContext {
     /// Probe a selected backend before first-run config can construct final context.
     pub fn session_is_healthy_live(mux: MuxName, session_name: &str) -> bool {
         let backend = crate::mux::backend_for(mux);
-        Self::probe_healthy_live(backend.as_ref(), session_name)
-    }
-
-    fn probe_healthy_live(backend: &dyn MuxBackend, session_name: &str) -> bool {
-        let exists = backend
-            .list_sessions()
-            .map(|sessions| sessions.iter().any(|name| name == session_name))
-            .unwrap_or(false);
-        exists
-            && matches!(
-                backend.probe_session_health(session_name),
-                Ok(SessionHealth::Healthy)
-            )
+        matches!(
+            backend.session_liveness(session_name),
+            Ok(SessionLiveness::Live)
+        )
     }
 
     /// Inspect previous incarnation state without mutating it.

--- a/crates/rimz/src/room/session.rs
+++ b/crates/rimz/src/room/session.rs
@@ -41,7 +41,7 @@ pub fn room_inventory() -> LiveRoomResult<RoomInventory> {
 }
 
 /// Inventory every known workspace against an existing mux-session probe.
-pub fn room_inventory_with(live: &LiveSessions) -> LiveRoomResult<RoomInventory> {
+pub(crate) fn room_inventory_with(live: &LiveSessions) -> LiveRoomResult<RoomInventory> {
     let known = crate::workspace::known_workspaces()
         .map_err(|source| LiveRoomErr::WorkspaceRecords { source })?;
     Ok(room_inventory_from(known, |session| live.mux_of(session)))
@@ -92,7 +92,7 @@ pub struct MuxPickErr {
 
 /// Both backends' live session names, probed once for batch operations.
 /// Missing backends and transient list failures contribute an empty set.
-pub struct LiveSessions {
+pub(crate) struct LiveSessions {
     zellij: HashSet<String>,
     tmux: HashSet<String>,
 }
@@ -107,7 +107,7 @@ pub enum BackendRoomState {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RoomOwnership {
-    pub selected: MuxName,
+    selected: MuxName,
     pub zellij: BackendRoomState,
     pub tmux: BackendRoomState,
 }
@@ -165,7 +165,7 @@ pub fn probe_room_ownership(selected: MuxName, session_name: &str) -> RoomOwners
 }
 
 impl LiveSessions {
-    pub fn probe() -> Self {
+    pub(crate) fn probe() -> Self {
         let names = |mux| -> HashSet<String> {
             crate::mux::backend_for(mux)
                 .list_sessions()
@@ -181,7 +181,7 @@ impl LiveSessions {
 
     /// Resolve a live session with Zellij-first precedence. An absent session
     /// maps to `None`, preserving best-effort empty-set fallback.
-    pub fn mux_of(&self, session: &str) -> Option<MuxName> {
+    pub(crate) fn mux_of(&self, session: &str) -> Option<MuxName> {
         if self.zellij.contains(session) {
             Some(MuxName::Zellij)
         } else if self.tmux.contains(session) {

--- a/docs/internals/rimzd.md
+++ b/docs/internals/rimzd.md
@@ -40,7 +40,7 @@ Two similarly named predicates answer different questions, and the difference ma
 
 Conditionality lives entirely in the inputs. `codex_present` decides the broker. `claude_host_argv` arrives already resolved from `ReadinessSnapshot::probe`, which is `Some` only when remote control is enabled for Claude and the probe reports ready, so the spec never re-derives the policy. Host order is broker first, then Claude.
 
-`rimz start` is the only entry point that births the view. `rimz attach` and web-session entry pass `BackgroundViewBirth::Skip` and inherit whatever is already there. Repair holds the same line: it restores missing panes into a view that exists, and creates nothing when the view is gone.
+`rimz start` is the only entry point that births the view: start carries remote-control readiness into room birth, while attach and web-session entry carry no background-view request and inherit whatever is already there. Repair holds the same line: it restores missing panes into a view that exists, and creates nothing when the view is gone.
 
 ## The content column and its supervisor
 

--- a/refactor-target.toml
+++ b/refactor-target.toml
@@ -374,7 +374,22 @@ allowed-imports = [
     "store",
     "workspace",
 ]
-surface-budget = 51
+surface-budget = 48
+
+[[strangler]]
+symbol = "NormalBirth"
+path = "crates/rimz/src"
+baseline = 0
+
+[[strangler]]
+symbol = "SupervisedBirth"
+path = "crates/rimz/src"
+baseline = 0
+
+[[strangler]]
+symbol = "BackgroundViewBirth"
+path = "crates/rimz/src"
+baseline = 0
 
 [[module]]
 path = "crates/rimz/src/sidebar"


### PR DESCRIPTION
## Context

`crates/rimz/src/room/` is 1,070 production SLOC across three modules, and its crate-external interface had accreted names that carry no knowledge. `cli/**` is a separate Cargo target from the library, so every room name a command touches is `pub`, and three of them existed only to wrap what `RoomBirth` already expresses. This is a behavior-preserving pass: structure changes, observable behavior does not.

## Target shape

One deep `RoomContext` remains the room lifecycle seam — canonical workspace identity, selected mux adapter, derived config and geometry, birth/reset ordering, sidebar and presence options. Callers choose intent; they do not reconstruct lifecycle order. `RoomContext::birth` takes one typed `RoomBirth` sum whose variants carry their fields directly, so a caller stops learning three shallow request names to say the two things birth actually distinguishes.

`session` stays a separate seam because its three interfaces carry genuinely different semantics: best-effort inventory, diagnostic ownership with unavailable evidence, and bounded operational mux selection. What changed is reach, not shape: the batch liveness snapshot is an implementation detail of the library's own callers (web, reload, remote control), and the binary no longer needs to know it exists.

## Implementation

Two passes shipped:

- **Birth request shells collapse.** `NormalBirth`, `SupervisedBirth`, and `BackgroundViewBirth` are deleted; `RoomBirth::{Normal,Supervised}` carry their fields inline, with `background_view: Option<ReadinessSnapshot>` documented so `None` still reads as "no configured background-view launch". One-use `launch_sidebar` is inlined, `ResetRecoveryError`'s handwritten `Display`/`Error` impls become a `thiserror` derive with the same message, and the private `ResetRequired` type plus its two trait impls become a direct `bail!` with byte-identical text. Birth ordering — existence probe, fresh-only cleanup, session ensure, rebirth materialization, sidebar launch, health/reset, presence — is untouched.
- **Session snapshot reach narrows.** The sessions picker probed `LiveSessions` only to hand it straight back to `room_inventory_with`; it now calls `room_inventory()`, which does exactly that. `LiveSessions`, `LiveSessions::{probe,mux_of}`, and `room_inventory_with` drop to crate reach, and `RoomOwnership.selected` becomes private.

A third pass — routing both room liveness paths onto the typed `MuxBackend::session_liveness` seam — landed and was then reverted in review. The typed seam is the right one, but Zellij's override runs its `list-sessions` query under the 30s `COMMAND_TIMEOUT`, while `list_sessions()` runs under the 3s `LIST_SESSIONS_TIMEOUT` that `fix(start): bound session probes` paid for. Reuse would have let a wedged Zellij server stall `rimz start` and `rimz agents launch|fork|list|resume|top` for 30s instead of 3s, and changed the timeout error text with it. `require_live_session`, `session_is_healthy_live`, and `probe_healthy_live` are restored byte-identical to their baseline, and no mux timeout was adjusted to make the reuse fit — that would move behavior outside this target.

Verified with the crate's own gates: `cargo xtask gate` (5,759 tests), `RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --all-features` (the arbiter for the visibility cuts, since `cli/**` is a separate target), and a focused eight-test birth/reset/liveness batch, all green on the final tree.

## Surface removed

Net **−57 raw source lines** (`git diff --shortstat` reports 8 files, +85 −127; the remainder is `refactor-target.toml`, which grew by 15 lines of budget and strangler config). Test lines are unchanged at 349 SLOC — no hunk lands in a test module. Atlas measures room production SLOC 1,070 → **1,031** and raw public/escaping items 62 → **56**; the whole-room conformance budget ratchets 51 → **48**.

- Deleted from the crate-external interface: `NormalBirth`, `SupervisedBirth`, `BackgroundViewBirth`.
- Narrowed to crate reach: `LiveSessions`, `LiveSessions::probe`, `LiveSessions::mux_of`, `room_inventory_with`.
- Hidden: `RoomOwnership.selected`.
- Deleted implementation surface: `RoomContext::launch_sidebar`, the private `ResetRequired` type, and four handwritten error-trait impls.
- Added: no files, no flags, no options, no compatibility shims. No source file grew.

## Advisories

- **Pre-existing timeout inconsistency, not introduced here.** `MuxBackend::session_liveness`'s trait default runs under `LIST_SESSIONS_TIMEOUT` (3s) while the Zellij override runs the same read-only `list-sessions` query under `COMMAND_TIMEOUT` (30s). Anything that reaches for the typed liveness seam on a hot path inherits the 30s bound silently — that is what made the reverted pass unsafe, and it is worth resolving deliberately before the seam is reused.
- **Next passes**, carried from planning and still open: collapsing `LiveSessions` into `RoomInventory` stays rejected while web validates raw recorded ownership before liveness and reload/remote control need different enumeration and probe order; rehoming renamed-session retirement into owner claim needs an exact side-effect ledger first, since the trust prompt sits between retirement and the owner-record write; deleting `MissingSessionReport` requires new mux-pick result state and caller rendering, which did not pay for itself here.
- One `xtask` bug surfaced during the work and is left unfixed: `atlas rank --since <rev>` deadlocks in `revision_sources`, with `xtask` and its `git cat-file --batch` child both blocked writing to a full pipe. The historical comparison in this PR is assembled from separately measured baseline and current counts instead.

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>mill</code> team · 3 agents · 1h00m active · $25.97 · 7 messages (1 from you)</summary>

- **architect** — Codex `gpt-5.6-sol@high`
  - effort: 19m active · $7.40 incl. subagents
  - calls: 110 tool calls
  - messages: 1 from you · 1 from teammates · 2 to teammates
  - tokens: 252.9k input, 31.7k output, 10.4m cache read
  - subagents: 1 × room\_birth · 1 × room\_root · 1 × room\_session
- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 29m active · $13.59
  - calls: 83 tool calls
  - messages: 3 from teammates · 3 to teammates
  - tokens: 397.1k input, 29.6k output, 21.4m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 11m active · $4.98
  - calls: 62 tool calls
  - messages: 2 from teammates · 1 to teammates
  - tokens: 111 input, 42.3k output, 121.1k cache write, 5.4m cache read

</details>