### PR TITLE
Deepen remote attach and shrink its escaping interface

### DIFF
--- a/crates/rimz/src/cli/remote/supervisor.rs
+++ b/crates/rimz/src/cli/remote/supervisor.rs
@@ -35,7 +35,7 @@ const PROBE_RESPAWN_BACKOFF_MAX: Duration = Duration::from_secs(30);
 const SSH_CONFIG_QUERY_TIMEOUT: Duration = Duration::from_secs(5);
 const AUTO_FORWARD_CONTROL_TIMEOUT: Duration = Duration::from_secs(2);
 
-pub(super) struct OutageState {
+struct OutageState {
     connect_stage: ConnectStage,
     started: Instant,
     internet_probe: Option<InternetProbe>,
@@ -44,7 +44,7 @@ pub(super) struct OutageState {
 }
 
 impl OutageState {
-    pub(super) fn new(
+    fn new(
         connect_stage: ConnectStage,
         handoff_stage: HandoffStage,
         host: &str,
@@ -79,6 +79,135 @@ impl OutageState {
 
     fn note_next_attempt(&mut self) {
         self.panel.note_attempt(self.attempts.saturating_add(1));
+    }
+}
+
+pub(super) struct LinkSupervisor {
+    plan: SshAttachPlan,
+    control_path: PathBuf,
+    policy: rimz::remote::ReconnectPolicy,
+    dial_plan: Option<DialPlan>,
+    stop: AtomicBool,
+    outage: Option<OutageState>,
+    master: Option<MasterGuard>,
+    held_alt: bool,
+    host: String,
+}
+
+impl LinkSupervisor {
+    /// Establish the initial batch-mode master. `None` means the user
+    /// interrupted the recovery panel; a supervisor without a control path
+    /// requests the initial interactive fallback.
+    pub(super) fn connect(plan: SshAttachPlan, control_path: PathBuf) -> Result<Option<Self>> {
+        let dial_plan = resolve_dial_plan(plan.target().ssh_destination().as_str());
+        let host = plan.target().host_display().to_owned();
+        let mut supervisor = Self {
+            plan,
+            control_path,
+            policy: rimz::remote::ReconnectPolicy::from_env(),
+            dial_plan,
+            stop: AtomicBool::new(false),
+            outage: None,
+            master: None,
+            held_alt: false,
+            host,
+        };
+        let mut ui = OutageUi::auto(ConnectStage::Initial, &supervisor.host);
+        ui.report_connecting();
+        let mut outage = OutageState::new(
+            ConnectStage::Initial,
+            HandoffStage::WebTunnel,
+            &supervisor.host,
+            internet_probe_for_wait(&ui),
+            supervisor.dial_plan.as_ref(),
+        );
+        match wait_for_master(
+            &supervisor.plan,
+            &supervisor.control_path,
+            supervisor.dial_plan.as_ref(),
+            &supervisor.policy,
+            &mut outage,
+            &mut ui,
+            Some(&supervisor.stop),
+        )? {
+            WaitOutcome::Connected { master, held_alt } => {
+                supervisor.master = Some(master);
+                supervisor.held_alt = held_alt;
+                Ok(Some(supervisor))
+            }
+            WaitOutcome::NeedsInteractive => Ok(Some(supervisor)),
+            WaitOutcome::Interrupted => Ok(None),
+        }
+    }
+
+    pub(super) fn recover(&mut self) -> Result<bool> {
+        self.release_screen();
+        drop(self.master.take());
+        let mut ui = OutageUi::auto(ConnectStage::Recovery, &self.host);
+        let outage = self.outage.get_or_insert_with(|| {
+            if ui.is_plain() {
+                let _ = writeln!(
+                    std::io::stderr().lock(),
+                    "rimz: web tunnel to {} lost — reconnecting in the background; Ctrl-C stops",
+                    self.host,
+                );
+            }
+            OutageState::new(
+                ConnectStage::Recovery,
+                HandoffStage::WebTunnel,
+                &self.host,
+                internet_probe_for_wait(&ui),
+                self.dial_plan.as_ref(),
+            )
+        });
+        match wait_for_master(
+            &self.plan,
+            &self.control_path,
+            self.dial_plan.as_ref(),
+            &self.policy,
+            outage,
+            &mut ui,
+            Some(&self.stop),
+        )? {
+            WaitOutcome::Connected { master, held_alt } => {
+                self.master = Some(master);
+                self.held_alt = held_alt;
+                Ok(true)
+            }
+            WaitOutcome::Interrupted => {
+                let _ = writeln!(std::io::stderr().lock(), "rimz: reconnect stopped");
+                Ok(false)
+            }
+            WaitOutcome::NeedsInteractive => unreachable!("web recovery stays in batch mode"),
+        }
+    }
+
+    pub(super) fn control(&self) -> Option<&Path> {
+        self.master.as_ref().map(|_| self.control_path.as_path())
+    }
+
+    pub(super) fn round_ready(&mut self) {
+        self.release_screen();
+        self.outage = None;
+    }
+
+    pub(super) fn wait_for_exit(&mut self) -> Result<Option<i32>> {
+        self.master
+            .as_mut()
+            .context("remote web ControlMaster is not running")?
+            .wait_for_exit()
+    }
+
+    fn release_screen(&mut self) {
+        if std::mem::take(&mut self.held_alt) {
+            release_handoff_screen();
+        }
+    }
+}
+
+impl Drop for LinkSupervisor {
+    fn drop(&mut self) {
+        self.release_screen();
     }
 }
 
@@ -416,7 +545,7 @@ struct SessionOutcome {
     stderr: Option<String>,
 }
 
-pub(super) fn resolve_dial_plan(destination: &str) -> Option<DialPlan> {
+fn resolve_dial_plan(destination: &str) -> Option<DialPlan> {
     dial_interval_from_env()?;
     let output = match ssh_config_query_spec(destination).run_with_timeout(SSH_CONFIG_QUERY_TIMEOUT)
     {
@@ -458,13 +587,13 @@ fn dial_with_timeout(plan: &DialPlan, timeout: Duration) -> bool {
     false
 }
 
-pub(super) enum WaitOutcome {
+enum WaitOutcome {
     Connected { master: MasterGuard, held_alt: bool },
     NeedsInteractive,
     Interrupted,
 }
 
-pub(super) fn internet_probe_for_wait(ui: &OutageUi) -> Option<InternetProbe> {
+fn internet_probe_for_wait(ui: &OutageUi) -> Option<InternetProbe> {
     if ui.is_plain() {
         None
     } else {
@@ -472,7 +601,7 @@ pub(super) fn internet_probe_for_wait(ui: &OutageUi) -> Option<InternetProbe> {
     }
 }
 
-pub(super) fn wait_for_master(
+fn wait_for_master(
     plan: &SshAttachPlan,
     control_path: &Path,
     dial_plan: Option<&DialPlan>,
@@ -1077,7 +1206,7 @@ impl Drop for MasterAttempt {
     }
 }
 
-pub(super) struct MasterGuard {
+struct MasterGuard {
     child: Option<Child>,
     stderr: Option<std::thread::JoinHandle<String>>,
     control_path: PathBuf,
@@ -1086,7 +1215,7 @@ pub(super) struct MasterGuard {
 impl MasterGuard {
     /// Wait for the owning ControlMaster. Master-owned forwards remain live
     /// until this child exits, so remote web uses this as its foreground wait.
-    pub(super) fn wait_for_exit(&mut self) -> Result<Option<i32>> {
+    fn wait_for_exit(&mut self) -> Result<Option<i32>> {
         let mut child = self
             .child
             .take()

--- a/crates/rimz/src/cli/remote/web.rs
+++ b/crates/rimz/src/cli/remote/web.rs
@@ -5,19 +5,15 @@
 
 use std::io::{IsTerminal, Read as _, Write as _};
 use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
-use std::path::Path;
 use std::process::Stdio;
-use std::sync::atomic::AtomicBool;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
-use rimz::remote::recovery::{ConnectStage, HandoffStage};
 
 use super::RemoteConnect;
-use super::outage_ui::{OutageUi, release_handoff_screen};
-use super::supervisor::{OutageState, WaitOutcome};
+use super::supervisor::LinkSupervisor;
 
 #[derive(Clone, Copy, Debug, Default)]
 pub(super) struct RemoteWebOptions {
@@ -114,26 +110,6 @@ impl RemoteTunnel {
     }
 }
 
-struct HeldAlternateScreen(bool);
-
-impl HeldAlternateScreen {
-    fn new(held: bool) -> Self {
-        Self(held)
-    }
-
-    fn release(&mut self) {
-        if std::mem::take(&mut self.0) {
-            release_handoff_screen();
-        }
-    }
-}
-
-impl Drop for HeldAlternateScreen {
-    fn drop(&mut self) {
-        self.release();
-    }
-}
-
 pub(super) fn run_remote_web(
     remote: &RemoteConnect,
     client_size: Option<(u16, u16)>,
@@ -159,16 +135,18 @@ fn run_direct_web(remote: &RemoteConnect, client_size: Option<(u16, u16)>) -> Re
     let WebPrepOutcome::Ready(prep) = prep else {
         bail!("preparing remote web access failed with status 255");
     };
-    let (payload, credential) = parse_web_payload(&prep)?;
+    let (payload, tunnel_port, credential) = parse_web_payload(&prep)?;
     let relay_listener = rimz::remote::web::bind_local_relay(&payload.session, remote.web.port)
         .context("binding local web tunnel relay")?;
     let local_port = relay_listener.local_addr()?.port();
     let forward_port = rimz::remote::web::reserve_forward_port()
         .context("reserving local SSH web forward port")?;
-    let relay_target = Arc::new(Mutex::new(make_relay_target(forward_port, &credential)));
+    let relay_target = Arc::new(Mutex::new(rimz::web::RelayTarget {
+        upstream: SocketAddr::from(([127, 0, 0, 1], forward_port)),
+        authorization: credential.authorization(),
+    }));
     spawn_tunnel_relay(relay_listener, relay_target)?;
-    let spec =
-        rimz::remote::web::web_tunnel_spec(&remote.target, forward_port, tunnel_port(&payload));
+    let spec = rimz::remote::web::web_tunnel_spec(&remote.target, forward_port, tunnel_port);
     let mut tunnel = RemoteTunnel::start(&spec, remote.target.host_display())?;
     match tunnel.wait_until_ready(forward_port)? {
         PortWait::Ready => {}
@@ -176,7 +154,7 @@ fn run_direct_web(remote: &RemoteConnect, client_size: Option<(u16, u16)>) -> Re
             bail!("web tunnel exited before local port accepted connections");
         }
     }
-    let url = rimz::remote::web::local_url(&payload, local_port);
+    let url = payload.local_url(local_port);
     writeln!(std::io::stdout().lock(), "{url}")?;
     super::super::open_browser_best_effort(&url);
     report_web_tunnel_up(remote.target.host_display(), false);
@@ -194,48 +172,24 @@ fn run_supervised_web(remote: &RemoteConnect, client_size: Option<(u16, u16)>) -
     let control = rimz::remote::link::validated_control_path()
         .context("checking SSH ControlMaster socket path")?;
     let plan = remote.attach_plan(client_size)?;
-    let policy = rimz::remote::ReconnectPolicy::from_env();
     let mut reconnect = rimz::remote::ReconnectState::new();
-    let dial_plan = super::supervisor::resolve_dial_plan(remote.target.ssh_destination().as_str());
-    let stop = AtomicBool::new(false);
     let host = remote.target.host_display();
-    let mut initial_ui = OutageUi::auto(ConnectStage::Initial, host);
-    initial_ui.report_connecting();
-    let mut initial_outage = OutageState::new(
-        ConnectStage::Initial,
-        HandoffStage::WebTunnel,
-        host,
-        super::supervisor::internet_probe_for_wait(&initial_ui),
-        dial_plan.as_ref(),
-    );
-    let (mut master, initial_held_alt) = match super::supervisor::wait_for_master(
-        &plan,
-        &control,
-        dial_plan.as_ref(),
-        &policy,
-        &mut initial_outage,
-        &mut initial_ui,
-        Some(&stop),
-    )? {
-        WaitOutcome::Connected { master, held_alt } => (Some(master), held_alt),
-        WaitOutcome::NeedsInteractive => (None, false),
-        WaitOutcome::Interrupted => return Ok(()),
+    let Some(mut supervisor) = LinkSupervisor::connect(plan, control)? else {
+        return Ok(());
     };
-    let mut held_alt = HeldAlternateScreen::new(initial_held_alt);
     let mut first_prep = true;
     let mut first_round = true;
     let mut local_port = None;
     let mut relay_state = None;
-    let mut outage = None;
 
     loop {
-        let master_confirmed = master.is_some();
-        let round_control = master_confirmed.then_some(control.as_path());
+        let round_control = supervisor.control().map(ToOwned::to_owned);
+        let master_confirmed = round_control.is_some();
         let prep = run_web_prep(
             &rimz::remote::web::web_prep_spec(
                 &remote.target,
                 web_prep_options(remote, client_size, first_prep),
-                round_control,
+                round_control.as_deref(),
             ),
             "preparing remote web access",
             host,
@@ -258,31 +212,21 @@ fn run_supervised_web(remote: &RemoteConnect, client_size: Option<(u16, u16)>) -
                 )? {
                     WebExitAction::Done => return Ok(()),
                     WebExitAction::Retry => {
-                        held_alt.release();
-                        drop(master.take());
-                        let Some((next_master, next_held_alt)) = wait_for_web_recovery(
-                            &plan,
-                            &control,
-                            dial_plan.as_ref(),
-                            &policy,
-                            &stop,
-                            host,
-                            &mut outage,
-                        )?
-                        else {
+                        if !supervisor.recover()? {
                             return Ok(());
-                        };
-                        master = Some(next_master);
-                        held_alt = HeldAlternateScreen::new(next_held_alt);
+                        }
                         continue;
                     }
                 }
             }
         };
-        let (payload, credential) = parse_web_payload(&prep)?;
+        let (payload, tunnel_port, credential) = parse_web_payload(&prep)?;
         let forward_port = rimz::remote::web::reserve_forward_port()
             .context("reserving local SSH web forward port")?;
-        let round_target = make_relay_target(forward_port, &credential);
+        let round_target = rimz::web::RelayTarget {
+            upstream: SocketAddr::from(([127, 0, 0, 1], forward_port)),
+            authorization: credential.authorization(),
+        };
         let local_port = match local_port {
             Some(port) => port,
             None => {
@@ -300,19 +244,16 @@ fn run_supervised_web(remote: &RemoteConnect, client_size: Option<(u16, u16)>) -
         let mut tunnel = if round_control.is_some() {
             None
         } else {
-            let spec = rimz::remote::web::web_tunnel_spec(
-                &remote.target,
-                forward_port,
-                tunnel_port(&payload),
-            );
+            let spec =
+                rimz::remote::web::web_tunnel_spec(&remote.target, forward_port, tunnel_port);
             Some(RemoteTunnel::start(&spec, host)?)
         };
-        let readiness = match (round_control, tunnel.as_mut()) {
+        let readiness = match (round_control.as_deref(), tunnel.as_mut()) {
             (Some(control), None) => establish_control_forward(
                 &rimz::remote::web::web_control_forward_spec(
                     &remote.target,
                     forward_port,
-                    tunnel_port(&payload),
+                    tunnel_port,
                     control,
                 ),
                 host,
@@ -332,37 +273,23 @@ fn run_supervised_web(remote: &RemoteConnect, client_size: Option<(u16, u16)>) -
                 )? {
                     WebExitAction::Done => return Ok(()),
                     WebExitAction::Retry => {
-                        held_alt.release();
-                        drop(master.take());
-                        let Some((next_master, next_held_alt)) = wait_for_web_recovery(
-                            &plan,
-                            &control,
-                            dial_plan.as_ref(),
-                            &policy,
-                            &stop,
-                            host,
-                            &mut outage,
-                        )?
-                        else {
+                        if !supervisor.recover()? {
                             return Ok(());
-                        };
-                        master = Some(next_master);
-                        held_alt = HeldAlternateScreen::new(next_held_alt);
+                        }
                         continue;
                     }
                 }
             }
         };
 
-        held_alt.release();
-        replace_relay_target(
-            relay_state
-                .as_ref()
-                .context("local web tunnel relay is not running")?,
-            round_target,
-        );
+        supervisor.round_ready();
+        *relay_state
+            .as_ref()
+            .context("local web tunnel relay is not running")?
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = round_target;
         if first_round {
-            let url = rimz::remote::web::local_url(&payload, local_port);
+            let url = payload.local_url(local_port);
             writeln!(std::io::stdout().lock(), "{url}")?;
             super::super::open_browser_best_effort(&url);
             report_web_tunnel_up(host, true);
@@ -370,14 +297,9 @@ fn run_supervised_web(remote: &RemoteConnect, client_size: Option<(u16, u16)>) -
         } else {
             let _ = writeln!(std::io::stderr().lock(), "rimz: tunnel to {host} restored");
         }
-        outage = None;
-
         let exit_code = match tunnel.as_mut() {
             Some(tunnel) => tunnel.wait_for_exit()?,
-            None => master
-                .as_mut()
-                .context("remote web ControlMaster is not running")?
-                .wait_for_exit()?,
+            None => supervisor.wait_for_exit()?,
         };
         match web_exit_action(
             settle_web_exit(&mut reconnect, exit_code, master_confirmed, port_ready),
@@ -385,67 +307,10 @@ fn run_supervised_web(remote: &RemoteConnect, client_size: Option<(u16, u16)>) -
         )? {
             WebExitAction::Done => return Ok(()),
             WebExitAction::Retry => {
-                drop(master.take());
-                let Some((next_master, next_held_alt)) = wait_for_web_recovery(
-                    &plan,
-                    &control,
-                    dial_plan.as_ref(),
-                    &policy,
-                    &stop,
-                    host,
-                    &mut outage,
-                )?
-                else {
+                if !supervisor.recover()? {
                     return Ok(());
-                };
-                master = Some(next_master);
-                held_alt = HeldAlternateScreen::new(next_held_alt);
+                }
             }
-        }
-    }
-}
-
-fn wait_for_web_recovery(
-    plan: &rimz::remote::SshAttachPlan,
-    control: &Path,
-    dial_plan: Option<&rimz::remote::reachability::DialPlan>,
-    policy: &rimz::remote::ReconnectPolicy,
-    stop: &AtomicBool,
-    host: &str,
-    outage: &mut Option<OutageState>,
-) -> Result<Option<(super::supervisor::MasterGuard, bool)>> {
-    let mut ui = OutageUi::auto(ConnectStage::Recovery, host);
-    let outage = outage.get_or_insert_with(|| {
-        if ui.is_plain() {
-            let _ = writeln!(
-                std::io::stderr().lock(),
-                "rimz: web tunnel to {host} lost — reconnecting in the background; Ctrl-C stops",
-            );
-        }
-        OutageState::new(
-            ConnectStage::Recovery,
-            HandoffStage::WebTunnel,
-            host,
-            super::supervisor::internet_probe_for_wait(&ui),
-            dial_plan,
-        )
-    });
-    match super::supervisor::wait_for_master(
-        plan,
-        control,
-        dial_plan,
-        policy,
-        outage,
-        &mut ui,
-        Some(stop),
-    )? {
-        WaitOutcome::Connected { master, held_alt } => Ok(Some((master, held_alt))),
-        WaitOutcome::Interrupted => {
-            let _ = writeln!(std::io::stderr().lock(), "rimz: reconnect stopped");
-            Ok(None)
-        }
-        WaitOutcome::NeedsInteractive => {
-            unreachable!("web recovery stays in batch mode")
         }
     }
 }
@@ -465,7 +330,7 @@ fn web_prep_options(
 
 fn parse_web_payload(
     bytes: &[u8],
-) -> Result<(rimz::web::WebOpenPayload, rimz::web::WebCredential)> {
+) -> Result<(rimz::web::WebOpenPayload, u16, rimz::web::WebCredential)> {
     let payload: rimz::web::WebOpenPayload = serde_json::from_slice(bytes)
         .with_context(|| remote_output_context("parsing remote `rimz web open --json`", bytes))?;
     if !payload.version_ok() {
@@ -474,33 +339,9 @@ fn parse_web_payload(
             payload.version
         );
     }
-    if matches!(&payload.auth, rimz::web::WebAuth::TrustedHeader { .. })
-        && payload.credential.is_none()
-    {
-        bail!(
-            "the remote serves browser access behind a reverse proxy (trusted-header auth) — open `{}` directly; no SSH tunnel applies",
-            payload.url
-        );
-    }
-    let credential = payload
-        .credential
-        .clone()
-        .context("remote `rimz web open --json` omitted the ttyd credential")?;
-    Ok((payload, credential))
-}
-
-fn tunnel_port(payload: &rimz::web::WebOpenPayload) -> u16 {
-    payload.tunnel_port.unwrap_or(payload.port)
-}
-
-fn make_relay_target(
-    forward_port: u16,
-    credential: &rimz::web::WebCredential,
-) -> rimz::web::RelayTarget {
-    rimz::web::RelayTarget {
-        upstream: SocketAddr::from(([127, 0, 0, 1], forward_port)),
-        authorization: credential.authorization(),
-    }
+    let (tunnel_port, credential) = payload.tunnel()?;
+    let credential = credential.clone();
+    Ok((payload, tunnel_port, credential))
 }
 
 fn spawn_tunnel_relay(
@@ -516,13 +357,6 @@ fn spawn_tunnel_relay(
         })
         .context("starting local web tunnel relay")?;
     Ok(())
-}
-
-fn replace_relay_target(
-    target: &Mutex<rimz::web::RelayTarget>,
-    replacement: rimz::web::RelayTarget,
-) {
-    *target.lock().unwrap_or_else(PoisonError::into_inner) = replacement;
 }
 
 enum WebPrepOutcome {
@@ -643,50 +477,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn legacy_trusted_header_payload_refuses_an_ssh_tunnel() {
+    fn wrong_web_payload_schema_keeps_upgrade_diagnosis() {
         let bytes = br#"{
-            "version":"rimz.web.v2",
-            "url":"https://devbox.example/rimz/?arg=room",
-            "session":"room",
-            "port":8200,
-            "auth":{"mode":"trusted_header","header":"X-Forwarded-User"}
-        }"#;
-        let err = parse_web_payload(bytes).expect_err("trusted-header tunnel refusal");
-        let message = err.to_string();
-        assert!(message.contains("behind a reverse proxy"), "{message}");
-        assert!(
-            message.contains("open `https://devbox.example/rimz/?arg=room` directly"),
-            "{message}"
-        );
-    }
-
-    #[test]
-    fn trusted_header_payload_with_a_credential_tunnels_to_its_upstream_port() {
-        let bytes = br#"{
-            "version":"rimz.web.v2",
-            "url":"https://devbox.example/rimz/?arg=room",
-            "session":"room",
-            "port":8200,
-            "tunnel_port":41820,
-            "auth":{"mode":"trusted_header","header":"X-Forwarded-User"},
-            "credential":{"username":"rimz","secret":"secret"}
-        }"#;
-        let (payload, credential) = parse_web_payload(bytes).expect("trusted-header tunnel");
-        assert_eq!(credential.username, "rimz");
-        assert_eq!(tunnel_port(&payload), 41820);
-    }
-
-    #[test]
-    fn legacy_basic_payload_tunnels_to_its_public_port() {
-        let bytes = br#"{
-            "version":"rimz.web.v2",
+            "version":"rimz.web.v1",
             "url":"http://127.0.0.1:8200/?arg=room",
             "session":"room",
             "port":8200,
             "credential":{"username":"rimz","secret":"secret"}
         }"#;
-        let (payload, _) = parse_web_payload(bytes).expect("legacy Basic tunnel");
-        assert_eq!(tunnel_port(&payload), 8200);
+        assert_eq!(
+            parse_web_payload(bytes)
+                .expect_err("schema refusal")
+                .to_string(),
+            "remote `rimz web open --json` returned schema `rimz.web.v1`; upgrade the remote rimz binary"
+        );
     }
 
     #[test]

--- a/crates/rimz/src/cli/web/mod.rs
+++ b/crates/rimz/src/cli/web/mod.rs
@@ -197,11 +197,7 @@ pub fn run(args: WebArgs, globals: &GlobalFlags) -> Result<()> {
 
 fn open(args: WebOpenArgs, globals: &GlobalFlags) -> Result<()> {
     let config = machine_config();
-    if !config.web.enabled {
-        bail!(
-            "Browser access is disabled: set `[web] enabled = true` in the RimZ config on the machine serving this room (`rimz config path`) to allow browser sharing."
-        );
-    }
+    ensure_web_enabled(&config)?;
     let context = if let Some(session) = args.session {
         room::ensure_session_room_for_web(&session, globals, args.no_resume, args.confirm_resume)?
     } else {

--- a/crates/rimz/src/remote/aliases.rs
+++ b/crates/rimz/src/remote/aliases.rs
@@ -22,8 +22,8 @@ use crate::remote::{RemoteTarget, RemoteTargetError};
 use crate::store::atomic;
 use crate::store::paths::config_home;
 
-pub const REMOTE_FILE: &str = "remote.toml";
-pub const REMOTE_TEMPLATE: &str = include_str!("../config/templates/remote.template.toml");
+const REMOTE_FILE: &str = "remote.toml";
+const REMOTE_TEMPLATE: &str = include_str!("../config/templates/remote.template.toml");
 const RIMZ_CONFIG_SUBDIR: &str = "rimz";
 const ALIAS_NAME_MAX_LEN: usize = 64;
 
@@ -116,7 +116,7 @@ impl RemoteAliases {
     }
 
     /// Test-only loader. Production callers go through [`Self::load`].
-    pub fn load_from(path: &Path) -> Result<Self> {
+    fn load_from(path: &Path) -> Result<Self> {
         match std::fs::read_to_string(path) {
             Ok(text) => {
                 let parsed: Self = toml::from_str(&text).map_err(|source| AliasErr::Parse {
@@ -134,7 +134,7 @@ impl RemoteAliases {
     }
 
     /// Test-only writer. Production callers go through [`Self::save`].
-    pub fn save_to(&self, path: &Path) -> Result<()> {
+    fn save_to(&self, path: &Path) -> Result<()> {
         let sorted = self.clone().validated()?.sorted();
         let text = toml::to_string_pretty(&sorted)?;
         atomic::write_bytes_atomically(path, text.as_bytes())?;

--- a/crates/rimz/src/remote/link.rs
+++ b/crates/rimz/src/remote/link.rs
@@ -15,12 +15,12 @@ use crate::sock;
 
 use super::{RemoteSpec, RemoteTarget, env_ms, quote_remote_path, remote_path_prefix, sh_quote};
 
-pub const LINK_SCHEMA_VERSION: &str = "rimz.link.v1";
-pub const LINK_STATS_FILE: &str = "link-stats.json";
-pub const LINK_PROBE_INTERVAL: Duration = Duration::from_secs(2);
-pub const LINK_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
-pub const LINK_BLACKOUT_AFTER: Duration = Duration::from_secs(8);
-pub const LINK_WINDOW: usize = 30;
+const LINK_SCHEMA_VERSION: &str = "rimz.link.v1";
+const LINK_STATS_FILE: &str = "link-stats.json";
+const LINK_PROBE_INTERVAL: Duration = Duration::from_secs(2);
+const LINK_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+const LINK_BLACKOUT_AFTER: Duration = Duration::from_secs(8);
+const LINK_WINDOW: usize = 30;
 
 const PROBE_INTERVAL_ENV: &str = "RIMZ_REMOTE_PROBE_MS";
 const PROBE_TIMEOUT_ENV: &str = "RIMZ_REMOTE_PROBE_TIMEOUT_MS";
@@ -57,7 +57,7 @@ pub struct LinkProbe {
 }
 
 impl LinkProbe {
-    pub fn new(seq: u64, sent_at_ms: u64, stats: LinkStats) -> Self {
+    fn new(seq: u64, sent_at_ms: u64, stats: LinkStats) -> Self {
         Self {
             v: LINK_SCHEMA_VERSION.to_owned(),
             seq,
@@ -243,7 +243,7 @@ impl SessionLinkState {
         }
     }
 
-    pub fn established(&self, elapsed: Duration) -> bool {
+    fn established(&self, elapsed: Duration) -> bool {
         self.established || elapsed >= self.gatetime
     }
 
@@ -384,14 +384,6 @@ pub fn stats_path(runtime: &crate::RuntimePaths) -> PathBuf {
     runtime.root.join(LINK_STATS_FILE)
 }
 
-/// PID-scoped SSH ControlMaster socket path. Concurrent `rimz remote connect`
-/// invocations never share a master. This socket is independent of the workspace
-/// runtime budget, so callers that hand it to OpenSSH use
-/// [`validated_control_path`] to fail with RimZ's AF_UNIX remedy first.
-pub fn control_path() -> PathBuf {
-    control_path_under(&crate::store::paths::runtime_home(), std::process::id())
-}
-
 pub fn validated_control_path() -> std::result::Result<PathBuf, sock::SocketPathTooLong> {
     validated_control_path_under(&crate::store::paths::runtime_home(), std::process::id())
 }
@@ -410,20 +402,6 @@ fn control_path_under(runtime_root: &Path, pid: u32) -> PathBuf {
         .join("rimz")
         .join("link")
         .join(format!("link-{pid}.sock"))
-}
-
-/// Compile the interactive attach's control options. The attach can create the
-/// master, so its lifetime stays tied to the supervised child rather than an
-/// inherited `ControlPersist` background process holding RimZ's socket.
-pub fn control_options(path: &Path) -> Vec<String> {
-    vec![
-        "-o".to_owned(),
-        "ControlMaster=auto".to_owned(),
-        "-o".to_owned(),
-        format!("ControlPath={}", path.display()),
-        "-o".to_owned(),
-        "ControlPersist=no".to_owned(),
-    ]
 }
 
 /// Check that the interactive attach's ControlMaster socket is already live.
@@ -496,7 +474,7 @@ enum ProbeOutcome {
 /// Rolling probe accounting: late acks are ignored, pending probes expire into
 /// misses, and settled outcomes are capped to the latest [`LINK_WINDOW`].
 #[derive(Clone, Debug)]
-pub struct ProbeWindow {
+struct ProbeWindow {
     outcomes: VecDeque<ProbeOutcome>,
     ewma_ms: Option<f64>,
     reported_ms: Option<u32>,
@@ -512,7 +490,7 @@ impl Default for ProbeWindow {
 }
 
 impl ProbeWindow {
-    pub fn with_timeout(timeout: Duration) -> Self {
+    fn with_timeout(timeout: Duration) -> Self {
         Self {
             outcomes: VecDeque::new(),
             ewma_ms: None,
@@ -529,11 +507,11 @@ impl ProbeWindow {
     /// cold spawn cost. Re-arm the single-sample discard without clearing the
     /// EWMA or displayed RTT; a reconnect keeps showing the last steady value
     /// until real samples arrive.
-    pub fn begin_stream(&mut self) {
+    fn begin_stream(&mut self) {
         self.discard_next_ack_sample = true;
     }
 
-    pub fn record_sent(&mut self, seq: u64, at_ms: u64) {
+    fn record_sent(&mut self, seq: u64, at_ms: u64) {
         self.outcomes.push_back(ProbeOutcome::Pending {
             seq,
             sent_at_ms: at_ms,
@@ -541,7 +519,7 @@ impl ProbeWindow {
         self.trim();
     }
 
-    pub fn record_ack(&mut self, seq: u64, at_ms: u64) -> bool {
+    fn record_ack(&mut self, seq: u64, at_ms: u64) -> bool {
         let Some(index) = self
             .outcomes
             .iter()
@@ -560,7 +538,7 @@ impl ProbeWindow {
         true
     }
 
-    pub fn expire(&mut self, now_ms: u64) {
+    fn expire(&mut self, now_ms: u64) {
         let timeout_ms = self.timeout.as_millis() as u64;
         for outcome in &mut self.outcomes {
             if let ProbeOutcome::Pending { sent_at_ms, .. } = *outcome
@@ -571,7 +549,7 @@ impl ProbeWindow {
         }
     }
 
-    pub fn stats(&self) -> LinkStats {
+    fn stats(&self) -> LinkStats {
         let mut settled: u16 = 0;
         let mut misses: u16 = 0;
         for outcome in &self.outcomes {
@@ -596,11 +574,11 @@ impl ProbeWindow {
         }
     }
 
-    pub fn reported_rtt_ms(&self) -> Option<u32> {
+    fn reported_rtt_ms(&self) -> Option<u32> {
         self.reported_ms
     }
 
-    pub fn blackout_ms(&self, now_ms: u64) -> u64 {
+    fn blackout_ms(&self, now_ms: u64) -> u64 {
         if let Some(last_ack) = self.last_ack_at_ms {
             return now_ms.saturating_sub(last_ack);
         }
@@ -734,10 +712,6 @@ impl LinkMonitor {
             return Some(LinkEvent::Blackout(Duration::from_millis(blackout_ms)));
         }
         None
-    }
-
-    pub fn stats(&self) -> LinkStats {
-        self.window.stats()
     }
 
     fn next_seq(&mut self) -> u64 {
@@ -1028,7 +1002,7 @@ mod tests {
             "the first ack is accounted but keeps the badge warming"
         );
         assert_eq!(first.events, vec![LinkEvent::FirstAck]);
-        assert_eq!(monitor.stats().rtt_ms, None);
+        assert_eq!(monitor.window.stats().rtt_ms, None);
 
         let second = monitor.record_ack(second_probe.seq, 1_040);
         assert!(second.accepted);
@@ -1037,8 +1011,8 @@ mod tests {
             "the second ack seeds the displayed RTT and should publish immediately"
         );
         assert!(second.events.is_empty());
-        assert!(monitor.stats().rtt_ms.is_some());
-        let stats = monitor.stats();
+        assert!(monitor.window.stats().rtt_ms.is_some());
+        let stats = monitor.window.stats();
         assert_eq!(stats.window, 2);
         assert_eq!(stats.miss_pct, 0);
 
@@ -1109,7 +1083,7 @@ mod tests {
 
         let control = PathBuf::from("/tmp/rimz.sock");
         assert_eq!(
-            control_options(&control),
+            super::super::control_options(&control),
             vec![
                 "-o",
                 "ControlMaster=auto",

--- a/crates/rimz/src/remote/mod.rs
+++ b/crates/rimz/src/remote/mod.rs
@@ -30,7 +30,7 @@ use crate::mux::{CLIENT_SIZE_ENV, CommandSpec};
 /// Binary override for tests (`tests/fixtures/ssh-trace`), mirroring
 /// `RIMZ_ZELLIJ_BIN` — the single chokepoint every ssh invocation resolves
 /// through.
-pub const SSH_BIN_ENV: &str = "RIMZ_SSH_BIN";
+const SSH_BIN_ENV: &str = "RIMZ_SSH_BIN";
 
 /// Marks an SSH attach started by the local reconnect supervisor's retry
 /// loop, so the remote room start uses its unattended posture.
@@ -55,7 +55,7 @@ pub const REMOTE_CLIENT_VERSION_ENV: &str = "RIMZ_REMOTE_CLIENT_VERSION";
 pub const REMOTE_FORCE_VERSION_ENV: &str = "RIMZ_REMOTE_FORCE_VERSION";
 
 /// Binary override for tests, mirroring `RIMZ_SSH_BIN`.
-pub const INFOCMP_BIN_ENV: &str = "RIMZ_INFOCMP_BIN";
+const INFOCMP_BIN_ENV: &str = "RIMZ_INFOCMP_BIN";
 
 /// The exit code OpenSSH reserves for its own transport and usage errors —
 /// the "link died" signal the reconnect loop watches for.
@@ -455,7 +455,7 @@ impl SshAttachAttempt<'_> {
                 "-o",
                 "Compression=yes",
             ])
-            .args(control_path.into_iter().flat_map(link::control_options))
+            .args(control_path.into_iter().flat_map(control_options))
             .args(["-t", "--"])
             .arg(options.target.ssh_destination().as_str())
             .arg(guarded_snippet(
@@ -465,6 +465,20 @@ impl SshAttachAttempt<'_> {
                 self.outer_scroll_bracket,
             ))
     }
+}
+
+/// Compile the interactive attach's control options. The attach can create the
+/// master, so its lifetime stays tied to the supervised child rather than an
+/// inherited `ControlPersist` background process holding RimZ's socket.
+fn control_options(path: &Path) -> Vec<String> {
+    vec![
+        "-o".to_owned(),
+        "ControlMaster=auto".to_owned(),
+        "-o".to_owned(),
+        format!("ControlPath={}", path.display()),
+        "-o".to_owned(),
+        "ControlPersist=no".to_owned(),
+    ]
 }
 
 /// How the remote session resolves the local terminal. `-t` carries the local
@@ -499,7 +513,7 @@ impl TermPlan {
 
 /// Names the remote host can be trusted to resolve; everything else needs
 /// provisioning.
-pub fn term_needs_terminfo_copy(name: &str) -> bool {
+fn term_needs_terminfo_copy(name: &str) -> bool {
     const UNIVERSAL: &[&str] = &[
         "xterm",
         "xterm-color",
@@ -593,17 +607,13 @@ fn guarded_snippet(
     )
 }
 
-pub(crate) fn client_size_env_setup(client_size: Option<(u16, u16)>) -> String {
+fn client_size_env_setup(client_size: Option<(u16, u16)>) -> String {
     client_size.map_or_else(String::new, |(cols, rows)| {
         format!("export {CLIENT_SIZE_ENV}={cols}x{rows}; ")
     })
 }
 
-pub(crate) fn remote_exec_snippet(
-    host_display: &str,
-    env_setup: &str,
-    rimz_command: &str,
-) -> String {
+fn remote_exec_snippet(host_display: &str, env_setup: &str, rimz_command: &str) -> String {
     let not_found = sh_quote(&format!(
         "rimz not found on {host_display} — run `rimz remote setup <alias-or-host>` locally, or install rimz manually",
     ));
@@ -616,13 +626,13 @@ pub(crate) fn remote_exec_snippet(
     )
 }
 
-pub(crate) fn remote_path_prefix() -> &'static str {
+fn remote_path_prefix() -> &'static str {
     "PATH=\"$HOME/.cargo/bin:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH\""
 }
 
 /// POSIX single-quote: wrap in `'…'`, escaping each embedded `'` with the
 /// classic `'\''` close-reopen. Safe for any string a shell word can hold.
-pub(crate) fn sh_quote(s: &str) -> String {
+fn sh_quote(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 2);
     out.push('\'');
     for ch in s.chars() {
@@ -652,7 +662,7 @@ fn normalize_tilde(target: &str) -> String {
 /// Quote a normalized remote path, keeping a leading `$HOME` outside the
 /// single quotes (double-quoted) so the remote shell expands it while the
 /// tail stays literal.
-pub(crate) fn quote_remote_path(path: &str) -> String {
+fn quote_remote_path(path: &str) -> String {
     match path.strip_prefix("$HOME") {
         Some("") => "\"$HOME\"".to_owned(),
         Some(rest) => format!("\"$HOME\"{}", sh_quote(rest)),
@@ -752,7 +762,7 @@ impl ReconnectPolicy {
 
     /// Pace SSH retries from outage age when direct TCP dials prove the
     /// endpoint remains reachable.
-    pub fn reachable_delay(&self, outage_age: Duration) -> Duration {
+    fn reachable_delay(&self, outage_age: Duration) -> Duration {
         if outage_age < self.flat_window {
             return self.reachable_retry.min(self.backoff_cap);
         }
@@ -765,7 +775,7 @@ impl ReconnectPolicy {
 
     /// Pace hidden safety attempts while every configured network checkpoint
     /// is down: 1s through 10s, then 20s, then the 30s ceiling.
-    pub fn unreachable_delay(&self, failures: u32) -> Duration {
+    fn unreachable_delay(&self, failures: u32) -> Duration {
         let seconds = match failures {
             0..=9 => u64::from(failures) + 1,
             10 => 20,
@@ -860,7 +870,7 @@ fn summarize_ssh_line(line: &str) -> String {
     summary
 }
 
-pub(crate) fn env_ms(key: &str) -> Option<Duration> {
+fn env_ms(key: &str) -> Option<Duration> {
     std::env::var(key)
         .ok()?
         .parse::<u64>()
@@ -883,18 +893,6 @@ pub enum Verdict {
     Retry,
 }
 
-/// Classify a finished ssh session. Pure: the caller measures `established`
-/// from a confirmed transport or the gatetime fallback.
-pub fn verdict(exit_code: Option<i32>, established: bool) -> Verdict {
-    match exit_code {
-        Some(0) => Verdict::CleanExit,
-        Some(SSH_TRANSPORT_EXIT) if established => Verdict::Retry,
-        Some(code) => Verdict::Fatal { code },
-        // Signal-death: something killed ssh deliberately; don't fight it.
-        None => Verdict::Fatal { code: 1 },
-    }
-}
-
 #[derive(Default)]
 pub struct ReconnectState {
     established: bool,
@@ -914,15 +912,17 @@ impl ReconnectState {
             self.established = true;
             self.consecutive_failures = 0;
         }
-        let verdict = verdict(exit_code, self.established);
+        let verdict = match exit_code {
+            Some(0) => Verdict::CleanExit,
+            Some(SSH_TRANSPORT_EXIT) if self.established => Verdict::Retry,
+            Some(code) => Verdict::Fatal { code },
+            // Signal-death: something killed ssh deliberately; don't fight it.
+            None => Verdict::Fatal { code: 1 },
+        };
         if matches!(verdict, Verdict::Retry) {
             self.consecutive_failures = self.consecutive_failures.saturating_add(1);
         }
         verdict
-    }
-
-    pub fn consecutive_failures(&self) -> u32 {
-        self.consecutive_failures
     }
 
     /// Settle an intentional zombie-transport kill without classifying its

--- a/crates/rimz/src/remote/reachability.rs
+++ b/crates/rimz/src/remote/reachability.rs
@@ -7,7 +7,7 @@ use crate::mux::CommandSpec;
 
 use super::{ReconnectPolicy, env_ms};
 
-pub const DIAL_INTERVAL: Duration = Duration::from_secs(1);
+const DIAL_INTERVAL: Duration = Duration::from_secs(1);
 pub const DIAL_TIMEOUT: Duration = Duration::from_secs(2);
 
 const DIAL_INTERVAL_ENV: &str = "RIMZ_REMOTE_DIAL_MS";

--- a/crates/rimz/src/remote/recovery.rs
+++ b/crates/rimz/src/remote/recovery.rs
@@ -7,8 +7,8 @@ use super::{
     reachability::{DialPlan, FooterPhase},
 };
 
-pub const RECOVERY_GRACE: Duration = Duration::from_millis(500);
-pub const RECOVERY_MIN_DISPLAY: Duration = Duration::from_millis(1_500);
+const RECOVERY_GRACE: Duration = Duration::from_millis(500);
+const RECOVERY_MIN_DISPLAY: Duration = Duration::from_millis(1_500);
 pub const INTERNET_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 
 const INTERNET_PROBE: &str = "http://cp.cloudflare.com/generate_204";
@@ -25,7 +25,7 @@ impl InternetProbe {
         &self.url
     }
 
-    pub fn host(&self) -> &str {
+    fn host(&self) -> &str {
         &self.host
     }
 }
@@ -136,8 +136,8 @@ impl RecoveryPanel {
             host,
             internet,
             server,
-            recovery_grace_from_env(),
-            recovery_min_display_from_env(),
+            env_ms("RIMZ_REMOTE_GRACE_MS").unwrap_or(RECOVERY_GRACE),
+            env_ms("RIMZ_REMOTE_MIN_DISPLAY_MS").unwrap_or(RECOVERY_MIN_DISPLAY),
         )
     }
 
@@ -319,14 +319,6 @@ impl RecoveryPanel {
             rows,
         }
     }
-}
-
-pub fn recovery_grace_from_env() -> Duration {
-    env_ms("RIMZ_REMOTE_GRACE_MS").unwrap_or(RECOVERY_GRACE)
-}
-
-pub fn recovery_min_display_from_env() -> Duration {
-    env_ms("RIMZ_REMOTE_MIN_DISPLAY_MS").unwrap_or(RECOVERY_MIN_DISPLAY)
 }
 
 /// Internet checkpoint URL. Empty, `0`, or an invalid HTTP URL disables the

--- a/crates/rimz/src/remote/tests.rs
+++ b/crates/rimz/src/remote/tests.rs
@@ -760,21 +760,22 @@ fn verdict_and_backoff_classify_reconnects() {
         ]
     );
 
-    assert_eq!(verdict(Some(0), true), Verdict::CleanExit);
-    assert_eq!(verdict(Some(SSH_TRANSPORT_EXIT), true), Verdict::Retry);
+    let settle = |exit_code, established| ReconnectState::new().settle(exit_code, established);
+    assert_eq!(settle(Some(0), true), Verdict::CleanExit);
+    assert_eq!(settle(Some(SSH_TRANSPORT_EXIT), true), Verdict::Retry);
     assert_eq!(
-        verdict(Some(SSH_TRANSPORT_EXIT), false),
+        settle(Some(SSH_TRANSPORT_EXIT), false),
         Verdict::Fatal {
             code: SSH_TRANSPORT_EXIT
         }
     );
     assert_eq!(
-        verdict(Some(REMOTE_RIMZ_MISSING_EXIT), true),
+        settle(Some(REMOTE_RIMZ_MISSING_EXIT), true),
         Verdict::Fatal {
             code: REMOTE_RIMZ_MISSING_EXIT
         }
     );
-    assert_eq!(verdict(None, true), Verdict::Fatal { code: 1 });
+    assert_eq!(settle(None, true), Verdict::Fatal { code: 1 });
 }
 
 #[test]
@@ -845,19 +846,19 @@ fn reconnect_state_settles_established_sessions_and_failures() {
             code: SSH_TRANSPORT_EXIT
         }
     );
-    assert_eq!(state.consecutive_failures(), 0);
+    assert_eq!(state.consecutive_failures, 0);
 
     assert_eq!(state.settle(Some(SSH_TRANSPORT_EXIT), true), Verdict::Retry);
-    assert_eq!(state.consecutive_failures(), 1);
+    assert_eq!(state.consecutive_failures, 1);
 
     assert_eq!(
         state.settle(Some(SSH_TRANSPORT_EXIT), false),
         Verdict::Retry
     );
-    assert_eq!(state.consecutive_failures(), 2);
+    assert_eq!(state.consecutive_failures, 2);
 
     state.settle_zombie_kill();
-    assert_eq!(state.consecutive_failures(), 0);
+    assert_eq!(state.consecutive_failures, 0);
 
     assert_eq!(
         state.settle(Some(REMOTE_RIMZ_MISSING_EXIT), true),
@@ -865,5 +866,5 @@ fn reconnect_state_settles_established_sessions_and_failures() {
             code: REMOTE_RIMZ_MISSING_EXIT
         }
     );
-    assert_eq!(state.consecutive_failures(), 0);
+    assert_eq!(state.consecutive_failures, 0);
 }

--- a/crates/rimz/src/remote/version.rs
+++ b/crates/rimz/src/remote/version.rs
@@ -2,7 +2,7 @@
 
 /// The numeric components RimZ uses to judge remote compatibility.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Version {
+struct Version {
     major: u64,
     minor: u64,
     patch: u64,

--- a/crates/rimz/src/remote/web.rs
+++ b/crates/rimz/src/remote/web.rs
@@ -8,13 +8,11 @@ use std::net::TcpListener;
 use std::ops::RangeInclusive;
 use std::path::Path;
 
-use crate::mux::CommandSpec;
-use crate::web::WebOpenPayload;
-
 use super::{
     REMOTE_CLIENT_VERSION_ENV, REMOTE_FORCE_VERSION_ENV, RemoteSpec, RemoteTarget,
     client_size_env_setup, quote_remote_path, remote_exec_snippet, sh_quote, ssh_program,
 };
+use crate::mux::CommandSpec;
 
 const LOCAL_PORT_RANGE: RangeInclusive<u16> = 8300..=8399;
 
@@ -41,13 +39,6 @@ fn bind_first_local_port(ports: impl IntoIterator<Item = u16>) -> Option<TcpList
 pub fn reserve_forward_port() -> io::Result<u16> {
     let listener = TcpListener::bind(("127.0.0.1", 0))?;
     Ok(listener.local_addr()?.port())
-}
-
-pub fn local_url(remote: &WebOpenPayload, local_port: u16) -> String {
-    format!(
-        "http://127.0.0.1:{local_port}/?room={}",
-        crate::web::encode_query_value(&remote.session)
-    )
 }
 
 fn derive_port(session: &str, range: &RangeInclusive<u16>) -> u16 {
@@ -158,7 +149,7 @@ fn one_shot_spec(
 ) -> CommandSpec {
     CommandSpec::new(ssh_program())
         .args(["-o", "ConnectTimeout=10"])
-        .args(control.into_iter().flat_map(super::link::control_options))
+        .args(control.into_iter().flat_map(super::control_options))
         .args(["--"])
         .arg(target.ssh_destination().as_str())
         .arg(web_snippet(target, rimz, client_size, force_version))
@@ -247,22 +238,6 @@ mod tests {
     fn forward_port_reservation_returns_a_reusable_loopback_port() {
         let port = reserve_forward_port().expect("reserve forward port");
         TcpListener::bind(("127.0.0.1", port)).expect("reserved port is released");
-    }
-
-    #[test]
-    fn local_url_percent_encodes_the_browser_room() {
-        let payload = WebOpenPayload::for_session(
-            "rimz/a b",
-            "https://remote",
-            8200,
-            Some(8200),
-            crate::web::WebAuth::Basic,
-            None,
-        );
-        assert_eq!(
-            local_url(&payload, 8301),
-            "http://127.0.0.1:8301/?room=rimz%2Fa%20b"
-        );
     }
 
     #[test]

--- a/crates/rimz/src/web/mod.rs
+++ b/crates/rimz/src/web/mod.rs
@@ -60,7 +60,7 @@ fn without_ttyd_launch_context(spec: CommandSpec) -> CommandSpec {
         .fold(spec, |spec, key| spec.env_remove(key))
 }
 
-pub const WEB_SCHEMA_VERSION: &str = "rimz.web.v2";
+const WEB_SCHEMA_VERSION: &str = "rimz.web.v2";
 pub const TTYD_SESSION_OSC: u16 = 7717;
 pub(crate) const TTYD_PIXEL_PROTOCOL: u32 = 3;
 
@@ -178,6 +178,12 @@ pub enum WebErr {
     },
     #[error("{0}")]
     InvalidSession(String),
+    #[error(
+        "the remote serves browser access behind a reverse proxy (trusted-header auth) — open `{url}` directly; no SSH tunnel applies"
+    )]
+    TrustedHeaderTunnel { url: String },
+    #[error("remote `rimz web open --json` omitted the ttyd credential")]
+    TunnelCredentialMissing,
     #[error(transparent)]
     LiveRoom(#[from] crate::room::LiveRoomErr),
 }
@@ -224,7 +230,7 @@ pub struct WebOpenPayload {
 }
 
 impl WebOpenPayload {
-    pub fn for_session(
+    fn for_session(
         session: impl Into<String>,
         base_url: impl Into<String>,
         port: u16,
@@ -248,6 +254,23 @@ impl WebOpenPayload {
 
     pub fn version_ok(&self) -> bool {
         self.version == WEB_SCHEMA_VERSION
+    }
+
+    pub fn tunnel(&self) -> Result<(u16, &WebCredential)> {
+        if matches!(self.auth, WebAuth::TrustedHeader { .. }) && self.credential.is_none() {
+            return Err(WebErr::TrustedHeaderTunnel {
+                url: self.url.clone(),
+            });
+        }
+        let credential = self
+            .credential
+            .as_ref()
+            .ok_or(WebErr::TunnelCredentialMissing)?;
+        Ok((self.tunnel_port.unwrap_or(self.port), credential))
+    }
+
+    pub fn local_url(&self, port: u16) -> String {
+        join_session_url(&format!("http://127.0.0.1:{port}"), &self.session)
     }
 }
 
@@ -779,6 +802,54 @@ mod tests {
         .expect("old v2 payload");
         assert_eq!(basic.auth, WebAuth::Basic);
         assert_eq!(basic.tunnel_port, None);
+    }
+
+    #[test]
+    fn trusted_header_payload_without_credential_refuses_tunnel() {
+        let payload: WebOpenPayload = serde_json::from_str(
+            r#"{"version":"rimz.web.v2","url":"https://devbox.example/rimz/?arg=room","session":"room","port":8200,"auth":{"mode":"trusted_header","header":"X-Forwarded-User"}}"#,
+        )
+        .expect("trusted-header payload");
+
+        assert_eq!(
+            payload.tunnel().expect_err("tunnel refusal").to_string(),
+            "the remote serves browser access behind a reverse proxy (trusted-header auth) — open `https://devbox.example/rimz/?arg=room` directly; no SSH tunnel applies"
+        );
+    }
+
+    #[test]
+    fn trusted_header_payload_with_credential_uses_tunnel_port() {
+        let payload: WebOpenPayload = serde_json::from_str(
+            r#"{"version":"rimz.web.v2","url":"https://devbox.example/rimz/?arg=room","session":"room","port":8200,"tunnel_port":41820,"auth":{"mode":"trusted_header","header":"X-Forwarded-User"},"credential":{"username":"rimz","secret":"secret"}}"#,
+        )
+        .expect("trusted-header payload");
+
+        let (port, credential) = payload.tunnel().expect("tunnel");
+        assert_eq!(port, 41820);
+        assert_eq!(credential.username, "rimz");
+    }
+
+    #[test]
+    fn legacy_basic_payload_uses_public_port() {
+        let payload: WebOpenPayload = serde_json::from_str(
+            r#"{"version":"rimz.web.v2","url":"http://127.0.0.1:8200/?arg=room","session":"room","port":8200,"credential":{"username":"rimz","secret":"secret"}}"#,
+        )
+        .expect("legacy Basic payload");
+
+        assert_eq!(payload.tunnel().expect("tunnel").0, 8200);
+    }
+
+    #[test]
+    fn payload_local_url_percent_encodes_session() {
+        let payload: WebOpenPayload = serde_json::from_str(
+            r#"{"version":"rimz.web.v2","url":"https://remote","session":"rimz/a b","port":8200}"#,
+        )
+        .expect("payload");
+
+        assert_eq!(
+            payload.local_url(8301),
+            "http://127.0.0.1:8301/?room=rimz%2Fa%20b"
+        );
     }
 
     #[test]

--- a/refactor-target.toml
+++ b/refactor-target.toml
@@ -84,6 +84,19 @@ allowed-imports = [
 surface-budget = 26
 
 [[module]]
+path = "crates/rimz/src/cli/remote/supervisor.rs"
+allowed-imports = [
+    "cli::remote::outage_ui",
+    "remote",
+]
+surface-budget = 9
+
+[[module]]
+path = "crates/rimz/src/cli/remote/web.rs"
+allowed-imports = ["cli::remote"]
+surface-budget = 2
+
+[[module]]
 path = "crates/rimz/src/config"
 allowed-imports = [
     "agents",
@@ -367,9 +380,8 @@ allowed-imports = [
     "sock",
     "store",
     "update",
-    "web",
 ]
-surface-budget = 217
+surface-budget = 172
 
 [[module]]
 path = "crates/rimz/src/remote_control.rs"
@@ -705,4 +717,9 @@ baseline = 0
 [[strangler]]
 symbol = "run::PermissionMode"
 path = "crates/rimz/src"
+baseline = 0
+
+[[strangler]]
+symbol = "wait_for_web_recovery"
+path = "crates/rimz/src/cli/remote/web.rs"
 baseline = 0


### PR DESCRIPTION
## Context

A behavior-preserving pass over the local remote-attach path: domain `remote/`, `cli/remote/`, and the browser-payload symbols they reach into. The slice had accreted in three ways. 217 items escaped a 2,472-SLOC domain module, most of them implementation detail the binary CLI cannot act on — probe-window accounting, tuning constants, one-use env helpers, test-path loaders. `cli/remote/web.rs` imported seven supervisor internals and rebuilt the same recovery choreography at three retry sites. And one payload rule — is this tunnelable, which remote port, which credential, what local URL — was spread across CLI remote, domain remote web, and domain web.

Observable behavior is unchanged: CLI grammar, stdout/stderr, exit codes, SSH argv, JSON wire records, alias files, terminal bytes, reconnect timing, browser URL and credential behavior, and notification ordering all hold. No CLI snapshot moved.

## Target shape

**`WebOpenPayload` owns tunnel interpretation.** The payload already carried schema, auth mode, credential, port, and optional tunnel port; it now also answers whether a tunnel applies (`tunnel()`) and what the local session URL is (`local_url()`), with the two refusal messages as typed `WebErr` variants. CLI remote keeps JSON parsing and presentation and stops holding the rules. Domain `remote::web` compiles SSH commands and picks local ports, nothing else, and no longer imports domain `web` in production.

**`LinkSupervisor` owns browser master lifecycle.** One private facade in `cli/remote/supervisor.rs` holds the attach plan, control path, reconnect policy, dial plan, stop flag, outage state, master guard, and held alternate screen. The browser caller asks it to connect, asks for the current control path, marks a round ready, waits, and asks it to recover — five operations against the nine internals it used to import. Its `Drop` releases the held screen before the master falls. The direct foreground tunnel and the supervised ControlMaster loop stay separate paths.

**Domain `remote` keeps its category modules, loses its implementation detail.** Each category stays public because the binary CLI is a distinct Cargo target that consumes those paths. What stopped escaping is the knowledge a caller cannot act on.

## Implementation

Two commits: the payload and supervisor deepening, then the visibility ratchet. Both are independently green.

Every visibility cut was arbitrated by `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --all-features` rather than by name evidence, because Atlas over-matches common names and under-matches returned types across the library/binary/integration target split. All 44 planned cuts held with **zero** restorations. With `-D warnings` that same run also proves no privatized item was left dead.

Deviations from the plan, and why:

- **Facade construction merged into `LinkSupervisor::connect`.** The plan sketched separate construct and connect operations; folding them, plus folding master disposal and screen release into `recover`/`Drop`, reached the supervisor budget of 9 while exposing fewer lifecycle states than the seven operations planned.
- **`control_options` moved to `remote/mod.rs` rather than staying `pub(super)` in `remote::link`.** Two sibling modules call it, so parent-private is the tighter seam than a `pub(super)` re-export.
- **Production subtraction overshot the planned -35..-10 to -61.** No filler was added to compensate: the facade collapsed three recovery branches and the payload rehome removed more caller code than estimated.

Five domain payload tests were added or relocated to pin the trusted-header refusal, the trusted-header-with-credential tunnel port, the legacy Basic port fallback, the percent-encoded local URL, and the schema-upgrade diagnosis. The CLI test narrowed to schema presentation.

## Surface removed

Production Rust **-61 lines**, tests **+3**, `refactor-target.toml` **+17**. 13 files, 356 insertions, 397 deletions. Two files grow and both are argued: `cli/remote/supervisor.rs` +129 against `cli/remote/web.rs` -166, and `web/mod.rs` +23 against the CLI and domain-remote duplication it deletes.

- **Domain remote escaping surface 217 -> 172.** Root: `SSH_BIN_ENV`, `INFOCMP_BIN_ENV`, `term_needs_terminfo_copy`, six quoting/snippet helpers, two policy-delay methods, the standalone `verdict` classifier (folded into `ReconnectState::settle`), and `ReconnectState::consecutive_failures`. Link: six tuning and schema constants, `LinkProbe::new`, `SessionLinkState::established`, `control_options`, the whole `ProbeWindow` plus its eight methods, and `LinkMonitor::stats`. Recovery, aliases, reachability, and version: five, four, one, and one respectively, including both timing wrappers and both test-path alias loaders.
- **CLI remote supervisor 11 -> 9.** Nine items — `OutageState` and its constructor, `WaitOutcome`, `resolve_dial_plan`, `internet_probe_for_wait`, `wait_for_master`, `MasterGuard` and its wait — became private behind seven facade items.
- **Deleted outright, not merely hidden:** `link::control_path`, `remote::web::local_url`, `wait_for_web_recovery`, `HeldAlternateScreen`, `tunnel_port`, `make_relay_target`, `replace_relay_target`, and the two recovery env wrappers.
- **Ratchets:** domain remote budget 217 -> 172 with `web` dropped from its allowed imports, new leaf rules for `cli/remote/supervisor.rs` (9) and `cli/remote/web.rs` (2), and a zero-baseline strangler on `wait_for_web_recovery`.
- No files, flags, or options added or removed.

## Verification

`cargo xtask gate` (fmt, invariants, conform, docs-links, lint, 5,760 tests), `cargo xtask test -P journey` (25), `cargo xtask test -P live` (95), `cargo xtask test 'remote'` (199), `cargo xtask atlas conform` (63 rules, 0 regressions), and the all-target `-D warnings` check. CLI snapshot diff empty.

Review independently re-measured the line split, re-ran conform, the all-target check, and the remote suite, and traced each removed invariant to where the new code re-establishes it — alternate-screen release across all three sites plus `Drop`, outage continuity across failed and successful rounds, `master_confirmed`, the `NeedsInteractive` branch, the `verdict` fold, `local_url` byte-equality, and the two error strings.

## Advisories

Not blocking; carried forward rather than fixed here.

- **Duplicated `RelayTarget` construction** at `cli/remote/web.rs:144` and `:226`. `make_relay_target` was module-private and never counted against a surface budget, so deleting it bought about one line and left two copies of the same three-field literal. Restoring the two-caller helper is a reasonable follow-up.
- **Orphaned test.** The `control_options` assertion stayed in `remote::link::tests` after the function moved to `remote/mod.rs`, reaching it via `super::super::`. It belongs in `remote/tests.rs`.
- **Facade doc gaps** in `cli/remote/supervisor.rs`. `connect`'s doc says "a supervisor without a control path" where the absent thing is the master; `recover() -> Result<bool>` does not say that `false` means the user stopped the reconnect; `round_ready()` names neither of its two effects.
- **Weak spot.** The highest-risk path is real SSH failure timing and the alternate-screen handoff. The shipped suites exercise it through shims and backends; no external SSH host was available for a manual network run.
- **Next passes.** `cli/remote/supervisor.rs` remains a large deep implementation — its probe threads and reachability workers stay private inside it, and extracting them without deleting source or interface would be sideways work. Moving the CLI under the library root would erase the Cargo-target visibility pressure entirely but affects the whole CLI architecture; the remote slice alone does not justify it. A generic `WebRound` shared by the direct and supervised paths was rejected: their lifetimes differ, so it would be shallow.

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>mill</code> team · 3 agents · 1h02m active · $20.93 · 3 messages (1 from you)</summary>

- **architect** — Codex `gpt-5.6-sol@high`
  - effort: 16m active · $5.47
  - calls: 115 tool calls
  - messages: 1 from you · 1 to teammates
  - tokens: 225.8k input, 30k output, 6.9m cache read
- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 27m active · $11.18
  - calls: 81 tool calls
  - messages: 1 from teammates · 1 to teammates
  - tokens: 244.3k input, 36.6k output, 17.7m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 17m active · $4.27
  - calls: 48 tool calls
  - messages: 1 from teammates
  - tokens: 72 input, 46.1k output, 124.5k cache write, 3.8m cache read

</details>