### PR TITLE
refactor(worktree): close vestigial lifecycle seams

### DIFF
--- a/crates/rimz/src/sidebar/produce/git/tests.rs
+++ b/crates/rimz/src/sidebar/produce/git/tests.rs
@@ -105,8 +105,24 @@ fn project_group_roots_publishes_exact_marker_names() {
         worktree_path: external.clone(),
         created_at: jiff::Timestamp::now(),
     };
-    atomic::write_temp_then_rename(&crate::worktree::marker_path(&external).unwrap(), &marker)
-        .unwrap();
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(&external)
+        .args(["rev-parse", "--git-dir"])
+        .output()
+        .expect("git dir");
+    assert!(output.status.success(), "resolve git dir");
+    let git_dir = PathBuf::from(
+        String::from_utf8(output.stdout)
+            .expect("utf8 git dir")
+            .trim(),
+    );
+    let git_dir = if git_dir.is_absolute() {
+        git_dir
+    } else {
+        external.join(git_dir)
+    };
+    atomic::write_temp_then_rename(&git_dir.join("rimz-worktree.json"), &marker).unwrap();
     let runtime_dir = tempfile::tempdir().unwrap();
     let runtime =
         RuntimePaths::under(WorkspaceId::from_project_root(&main), runtime_dir.path()).unwrap();

--- a/crates/rimz/src/sidebar/refresh/git_stats/tests.rs
+++ b/crates/rimz/src/sidebar/refresh/git_stats/tests.rs
@@ -83,11 +83,11 @@ fn write_rimz_worktree_marker_with_pr(
         worktree_path: repo.path().to_path_buf(),
         created_at: jiff::Timestamp::now(),
     };
-    crate::store::atomic::write_temp_then_rename(
-        &crate::worktree::marker_path(repo.path()).unwrap(),
-        &marker,
-    )
-    .unwrap();
+    let git_dir = crate::worktree::git_admin_dir_from_checkout_metadata(repo.path())
+        .unwrap()
+        .expect("git admin dir");
+    crate::store::atomic::write_temp_then_rename(&git_dir.join("rimz-worktree.json"), &marker)
+        .unwrap();
 }
 
 #[test]

--- a/crates/rimz/src/worktree.rs
+++ b/crates/rimz/src/worktree.rs
@@ -321,12 +321,6 @@ pub enum LandedVerdict {
     Unknown,
 }
 
-impl LandedVerdict {
-    pub const fn is_landed(self) -> bool {
-        matches!(self, Self::Landed)
-    }
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BranchDeletion {
     Deleted,
@@ -335,19 +329,19 @@ pub enum BranchDeletion {
 
 /// One live mux pane fact gathered before worktree removal assessment.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PaneProtectionFact {
-    pub pane_id: PaneId,
-    pub cwd: Option<PathBuf>,
-    pub sidebar: bool,
+struct PaneProtectionFact {
+    pane_id: PaneId,
+    cwd: Option<PathBuf>,
+    sidebar: bool,
 }
 
 /// One durable agent fact with process state already probed by CLI.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct AgentProtectionFact {
-    pub pane_id: Option<PaneId>,
-    pub liveness: AgentLiveness,
-    pub stored_path: Option<PathBuf>,
-    pub process_cwd: Option<PathBuf>,
+struct AgentProtectionFact {
+    pane_id: Option<PaneId>,
+    liveness: AgentLiveness,
+    stored_path: Option<PathBuf>,
+    process_cwd: Option<PathBuf>,
 }
 
 /// Normalized paths whose live panes or agents prevent checkout removal.
@@ -412,7 +406,7 @@ pub enum RemovalAssessment {
 
 impl ProtectionSet {
     /// Fold already-probed pane and agent facts into one normalized set.
-    pub fn from_facts(
+    fn from_facts(
         panes: &[PaneProtectionFact],
         agents: &[AgentProtectionFact],
         own_pane: Option<&PaneId>,
@@ -448,7 +442,9 @@ impl ProtectionSet {
     /// Whether a candidate checkout contains any protected path.
     pub fn protects(&self, candidate: &Path) -> bool {
         let candidate = normalize_path_lexical(candidate);
-        self.paths.iter().any(|path| path_inside(path, &candidate))
+        self.paths
+            .iter()
+            .any(|path| path == &candidate || path.starts_with(&candidate))
     }
 
     /// Classify one checkout with in-use taking precedence over work state.
@@ -457,7 +453,7 @@ impl ProtectionSet {
             RemovalAssessment::InUse
         } else if status.dirty {
             RemovalAssessment::Dirty
-        } else if !status.landed.is_landed() {
+        } else if status.landed != LandedVerdict::Landed {
             RemovalAssessment::NotLanded
         } else {
             RemovalAssessment::Removable
@@ -479,7 +475,6 @@ impl ProtectionSet {
 pub struct RemovalOutcome {
     worktree_name: String,
     branch: String,
-    repo_root: PathBuf,
     removed_path: PathBuf,
     branch_deletion: BranchDeletion,
 }
@@ -492,20 +487,8 @@ pub struct RemovalRetirement {
 }
 
 impl RemovalOutcome {
-    pub fn worktree_name(&self) -> &str {
-        &self.worktree_name
-    }
-
     pub fn branch(&self) -> &str {
         &self.branch
-    }
-
-    pub fn repo_root(&self) -> &Path {
-        &self.repo_root
-    }
-
-    pub fn removed_path(&self) -> &Path {
-        &self.removed_path
     }
 
     pub const fn branch_deletion(&self) -> BranchDeletion {
@@ -524,9 +507,9 @@ pub fn retire_removal(
     session_name: &str,
 ) -> RemovalRetirement {
     let session_retirement =
-        store.retire_worktree_sessions(removed.removed_path(), Some(removed.branch()));
+        store.retire_worktree_sessions(&removed.removed_path, Some(removed.branch()));
     let message_archival =
-        store.archive_channel_messages(removed.worktree_name(), archive_reason, session_name);
+        store.archive_channel_messages(&removed.worktree_name, archive_reason, session_name);
     RemovalRetirement {
         session_retirement,
         message_archival,
@@ -823,18 +806,18 @@ pub fn sweep_owned(
                 );
                 if let Err(err) = retirement.session_retirement {
                     tracing::warn!(
-                        worktree = %removed.worktree_name(),
+                        worktree = %removed.worktree_name,
                         error = %err,
                         "could not retire sessions for removed worktree",
                     );
                 }
                 let archive_error = retirement.message_archival.err().map(|err| err.to_string());
                 sweep.removed.push(SweptWorktree {
-                    name: removed.worktree_name().to_owned(),
-                    branch: removed.branch().to_owned(),
-                    path: removed.removed_path().to_owned(),
+                    name: removed.worktree_name,
+                    branch: removed.branch,
+                    path: removed.removed_path,
                     bytes,
-                    branch_deletion: Some(removed.branch_deletion()),
+                    branch_deletion: Some(removed.branch_deletion),
                     archive_error,
                 });
             }
@@ -846,7 +829,7 @@ pub fn sweep_owned(
     }
     if !sweep.removed.is_empty()
         && !dry_run
-        && let Err(err) = prune(repo_root)
+        && let Err(err) = git_run(repo_root, ["worktree", "prune"])
     {
         tracing::debug!(error = %err, "could not prune worktree metadata after sweep");
     }
@@ -898,7 +881,6 @@ pub fn remove_marked_worktree(
     Ok(RemovalOutcome {
         worktree_name: marker.name.clone(),
         branch: marker.branch.clone(),
-        repo_root: repo_root.to_owned(),
         removed_path: path.to_owned(),
         branch_deletion,
     })
@@ -952,11 +934,6 @@ pub fn discover_owned(repo_root: &Path) -> Result<Vec<ManagedWorktree>> {
     Ok(entries)
 }
 
-pub fn prune(repo_root: &Path) -> Result<()> {
-    ensure_repo(repo_root)?;
-    git_run(repo_root, ["worktree", "prune"])
-}
-
 pub fn status(worktree: &Path, marker: &WorktreeMarker) -> Result<WorktreeStatus> {
     let porcelain = git_stdout(worktree, ["status", "--porcelain"])?;
     let landed = comparison_ref(worktree, marker)
@@ -970,7 +947,9 @@ pub fn status(worktree: &Path, marker: &WorktreeMarker) -> Result<WorktreeStatus
 
 fn leave_worktree_before_removal(repo_root: &Path, path: &Path) -> Result<()> {
     let cwd = std::env::current_dir()?;
-    if path_inside(&normalize_path_lexical(&cwd), &normalize_path_lexical(path)) {
+    let cwd = normalize_path_lexical(&cwd);
+    let path = normalize_path_lexical(path);
+    if cwd == path || cwd.starts_with(path) {
         std::env::set_current_dir(repo_root)?;
     }
     Ok(())
@@ -1091,7 +1070,7 @@ pub(crate) fn git_admin_dir_from_checkout_metadata(worktree: &Path) -> Result<Op
     Ok(Some(git_dir))
 }
 
-pub fn marker_path(worktree: &Path) -> Result<PathBuf> {
+fn marker_path(worktree: &Path) -> Result<PathBuf> {
     let git_dir = git_stdout(worktree, ["rev-parse", "--git-dir"])?;
     let path = PathBuf::from(git_dir.trim());
     Ok(if path.is_absolute() {
@@ -1100,10 +1079,6 @@ pub fn marker_path(worktree: &Path) -> Result<PathBuf> {
         worktree.join(path)
     }
     .join(MARKER_FILE))
-}
-
-pub fn path_inside(path: &Path, parent: &Path) -> bool {
-    path == parent || path.starts_with(parent)
 }
 
 /// Fold `.` and `..` components without touching the filesystem.

--- a/crates/rimz/src/worktree/exclude.rs
+++ b/crates/rimz/src/worktree/exclude.rs
@@ -51,7 +51,7 @@ fn ensure_excluded_patterns<'a>(checkout: &Path, patterns: impl IntoIterator<Ite
     }
 }
 
-pub(super) fn exclude_path(checkout: &Path) -> Option<PathBuf> {
+fn exclude_path(checkout: &Path) -> Option<PathBuf> {
     let raw = match git_stdout(checkout, ["rev-parse", "--git-path", "info/exclude"]) {
         Ok(raw) => raw,
         Err(err) => {

--- a/crates/rimz/src/worktree/link.rs
+++ b/crates/rimz/src/worktree/link.rs
@@ -195,7 +195,15 @@ mod tests {
                 .expect("src canonical")
         );
 
-        let exclude = super::super::exclude::exclude_path(&worktree).expect("exclude path");
+        let exclude =
+            super::super::git_stdout(&worktree, ["rev-parse", "--git-path", "info/exclude"])
+                .map(std::path::PathBuf::from)
+                .expect("exclude path");
+        let exclude = if exclude.is_absolute() {
+            exclude
+        } else {
+            worktree.join(exclude)
+        };
         let text = std::fs::read_to_string(&exclude).expect("exclude text");
         assert_eq!(
             text.lines().filter(|line| *line == "/node_modules").count(),

--- a/crates/rimz/src/worktree/tests.rs
+++ b/crates/rimz/src/worktree/tests.rs
@@ -37,7 +37,6 @@ fn removal_retirement_returns_both_independent_results() {
     let removed = RemovalOutcome {
         worktree_name: "demo".to_owned(),
         branch: "demo".to_owned(),
-        repo_root: PathBuf::from("/repo"),
         removed_path: PathBuf::from("/repo-worktrees/demo"),
         branch_deletion: BranchDeletion::Deleted,
     };
@@ -225,10 +224,6 @@ fn explicit_branch_wins_over_branch_style_spelling() {
 
 #[test]
 fn landed_verdict_and_status_constructors() {
-    assert!(LandedVerdict::Landed.is_landed());
-    assert!(!LandedVerdict::Pending.is_landed());
-    assert!(!LandedVerdict::Unknown.is_landed());
-
     assert_eq!(
         WorktreeStatus::default(),
         WorktreeStatus {

--- a/crates/rimz/tests/integration/worktree.rs
+++ b/crates/rimz/tests/integration/worktree.rs
@@ -67,12 +67,6 @@ fn worktree_new_list_and_remove_round_trip() {
         git_stdout(&path, &["rev-parse", "--abbrev-ref", "HEAD"]),
         "demo"
     );
-    assert!(
-        rimz::worktree::marker_path(&path)
-            .expect("marker path")
-            .is_file(),
-        "marker lives in git admin dir"
-    );
     let marker = rimz::worktree::read_marker_for_worktree(&path)
         .expect("read marker")
         .expect("marker");

--- a/docs/internals/harness/worktrees.md
+++ b/docs/internals/harness/worktrees.md
@@ -153,7 +153,7 @@ The sidebar also resolves its own trunk, trying the per-machine `[sidebar] trunk
 
 Git safety is not enough on its own: a tree can be clean and landed while a human still has a shell open in it. `ProtectionSet` folds the room's live state into the answer.
 
-The CLI gathers the facts once (pane cwds from the mux, agent rows and liveness from the store) and `ProtectionSet::from_facts` normalizes them:
+The CLI gathers the facts once (pane cwds from the mux, agent rows and liveness from the store) and `protection_set_from_runtime` normalizes them:
 
 - Panes contribute their cwd, except the sidebar's own chrome and the caller's own pane.
 - A **live** agent contributes both its recorded launch path and its real process cwd.

--- a/refactor-target.toml
+++ b/refactor-target.toml
@@ -711,7 +711,7 @@ allowed-imports = [
     "store::runtime",
     "workspace",
 ]
-surface-budget = 65
+surface-budget = 55
 
 [[strangler]]
 symbol = "purge_zellij_session_cache_in"


### PR DESCRIPTION
## Context

`crates/rimz/src/worktree.rs` is the repository's widest single module by escaping interface: Atlas ranks it `pin,hub` at 1,488 production SLOC spread over 65 escaping items, 22.9 lines per escape. A deep read found ten of those items had no caller outside the module's own implementation or its sibling tests — helpers left public because a test reached for them, and getters on a result type nobody read.

This pass closes those seams. It is behavior-preserving: CLI output, JSON, Git command order, marker schema v4, error modes, removal precedence, store retirement, and persisted data are all unchanged.

## Target shape

One deep `worktree` module whose interface is user and domain operations plus their result types — create/reuse/launch, discover/status, removal/sweep/retirement, merge, the marker reads projections need, and the landed verdict. Private implementations own Git commands, marker paths, normalized containment, runtime-fact folding, branch pruning, and seed-manifest mechanics.

Callers stop needing to know that protection is assembled through intermediate fact DTOs, that a marker path is derived by a Git helper, that pruning has a standalone entry point, or that removal outcomes wrap private fields in getters.

An alternative sketch splitting creation, marker, landing, removal, and protection into five public modules was rejected: the same callers would learn five interfaces instead of one, no implementation has a second adapter, and files and import paths grow while behavior stays distributed. The root facade is already the better seam, so this pass deepens it by deleting accidental reach rather than moving code sideways.

## Implementation

- Deleted `LandedVerdict::is_landed`, standalone `path_inside`, and standalone `prune`. The owning call sites now express the exact predicate and the Git invocation in place, preserving each guard condition, log level, and error text.
- Reduced `RemovalOutcome` to the data still needed after removal, keeping only the two getters the CLI calls. Sweep consumes the remaining fields by move at its owning boundary.
- Made the protection fact DTOs and their fold, marker path resolution, and `exclude::exclude_path` private. Tests reach production behaviour or ask Git directly instead of reaching through module internals.
- Tightened the Atlas ratchet for the root module from 65 to 55.

Deviations from the plan:

- The plan named deleting `RemovalOutcome::repo_root`'s getter. The field went with it: caller verification found no read anywhere, and keeping private dead state would have weakened a subtractive pass.
- The plan replaced the sidebar marker test's setup with the production metadata resolver. Review caught that this makes the test self-referential — writing and reading through the same helper under test, so a resolver that moved the admin directory could no longer fail it. The test now runs `git rev-parse --git-dir` itself, keeping Git as the independent answer, which is what the sidebar's subprocess-free marker read depends on.

Verified with `cargo check --workspace --all-targets --all-features` under `-D warnings`, the 216-test focused worktree suite, `cargo xtask atlas conform` (85 rules, no regressions), and a full `cargo xtask gate` at 5,766 tests.

## Surface removed

- **Source:** production −25 lines. Tests are +13, spent restoring the marker cross-check described above.
- **Root escaping interface, 65 → 55:** `PaneProtectionFact`, `AgentProtectionFact`, `ProtectionSet::from_facts`, `LandedVerdict::is_landed`, `RemovalOutcome::{worktree_name, repo_root, removed_path}`, `prune`, `marker_path`, `path_inside`.
- **Child interface:** `exclude::exclude_path` leaves parent-visible reach — `exclude` 3 → 2, aggregate child surface 6 → 5.
- **Internal data:** the unused `RemovalOutcome::repo_root` field.
- No flag, option, wrapper, file, or public replacement was added.

## Advisories

- The marker filename `rimz-worktree.json` is now spelled literally in two sidebar test fixtures rather than reached through the module constant. A change to the constant makes both tests fail loudly rather than pass wrongly, so this is accepted; centralizing it would mean re-publishing the marker-path setup this pass removes.
- `normalize_path_lexical` still escapes `worktree` while serving workspace, agents, store, sidebar, harness, and CLI. Rehoming it touches 19 production modules and removes no total interface, so it fails the refactor test as a standalone move. Revisit only under a broader path-identity target that deletes duplicated normalization decisions.
- Splitting the root file into private creation/removal/landing files would help navigation, but adds files and moves 1,000+ lines without shrinking the caller interface. Not worth a standalone pass.
- Collapsing the three PR checkout strategies (review-only, same-repo, fork) was rejected: they encode different push and branch-safety behaviour, and a request enum or helper layer would add surface rather than remove knowledge.
- Atlas still flags `RequestedName` as test-only and `RemovalRetirement` as unreferenced. Both are name-match false positives — each is consumed through type inference at its call sites.

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>mill</code> team · 3 agents · 56m active · $16.43 · 5 messages (1 from you)</summary>

- **architect** — Codex `gpt-5.6-sol@high`
  - effort: 15m active · $5.16
  - calls: 55 tool calls
  - messages: 1 from you · 1 to teammates
  - tokens: 222.6k input, 23.7k output, 6.7m cache read
- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 29m active · $7.59
  - calls: 91 tool calls
  - messages: 2 from teammates · 2 to teammates
  - tokens: 210k input, 28.8k output, 11.4m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 10m active · $3.68
  - calls: 59 tool calls
  - messages: 2 from teammates · 1 to teammates
  - tokens: 79 input, 38.9k output, 102.3k cache write, 3.4m cache read

</details>