### PR TITLE
Narrow the sidebar interface: refresh surface, rate-limit modes, election vestiges, consumer memo, visibility ratchet

### DIFF
--- a/crates/rimz/benches/hotpath.rs
+++ b/crates/rimz/benches/hotpath.rs
@@ -244,13 +244,9 @@ fn consumer_adopt_fixture(warm_parse: bool) -> ConsumerAdoptFixture {
         None,
     );
     if warm_parse {
-        let read = reader
+        reader
             .read_adopting(&workspace.paths)
             .expect("warm adoption");
-        assert_eq!(
-            read.source,
-            rimz::sidebar::consumer::ConsumerSnapshotSource::Adoption
-        );
     }
     ConsumerAdoptFixture {
         paths: workspace.paths.clone(),

--- a/crates/rimz/src/cli/agents_cmd/reconcile.rs
+++ b/crates/rimz/src/cli/agents_cmd/reconcile.rs
@@ -40,6 +40,7 @@ pub(super) fn reconcile_cohort_launch(
                     pane_id,
                     rimz::sidebar::focus_anchor::FocusOrigin::User,
                     None,
+                    Default::default(),
                 )?;
                 writeln!(
                     std::io::stderr().lock(),

--- a/crates/rimz/src/cli/agents_cmd/restart.rs
+++ b/crates/rimz/src/cli/agents_cmd/restart.rs
@@ -155,6 +155,7 @@ pub(in crate::cli) fn restart_resolved(
         old_pane.clone(),
         rimz::sidebar::focus_anchor::FocusOrigin::User,
         None,
+        Default::default(),
     )
     .context("focusing the agent pane for restart")
     {

--- a/crates/rimz/src/cli/agents_cmd/resume.rs
+++ b/crates/rimz/src/cli/agents_cmd/resume.rs
@@ -103,6 +103,7 @@ pub(super) fn resume_lane(
                 pane_id,
                 rimz::sidebar::focus_anchor::FocusOrigin::User,
                 None,
+                Default::default(),
             )?;
             writeln!(
                 std::io::stdout().lock(),

--- a/crates/rimz/src/cli/agents_cmd/show.rs
+++ b/crates/rimz/src/cli/agents_cmd/show.rs
@@ -737,6 +737,7 @@ pub(in crate::cli) fn focus_resolved(ctx: &Ctx, agent: &AgentState) -> Result<()
         pane.pane_id.clone(),
         rimz::sidebar::focus_anchor::FocusOrigin::User,
         None,
+        Default::default(),
     )?;
     Ok(())
 }

--- a/crates/rimz/src/cli/pane.rs
+++ b/crates/rimz/src/cli/pane.rs
@@ -567,6 +567,7 @@ fn focus(
         pane.clone(),
         rimz::sidebar::focus_anchor::FocusOrigin::User,
         None,
+        Default::default(),
     )?;
     Ok(())
 }

--- a/crates/rimz/src/cli/sidebar.rs
+++ b/crates/rimz/src/cli/sidebar.rs
@@ -1252,6 +1252,7 @@ fn focus(globals: &GlobalFlags, session_name: Option<String>, toggle: bool) -> R
             target,
             rimz::sidebar::focus_anchor::FocusOrigin::User,
             None,
+            Default::default(),
         )
         .context("focusing pane")?;
     }

--- a/crates/rimz/src/mux/zellij/backend.rs
+++ b/crates/rimz/src/mux/zellij/backend.rs
@@ -175,6 +175,7 @@ impl ZellijBackend {
                 target_pane.clone(),
                 crate::sidebar::focus_anchor::FocusOrigin::User,
                 None,
+                Default::default(),
             );
         } else {
             let _ = self.focus_pane(target_pane, Some(session_name));
@@ -1351,14 +1352,16 @@ fn execute_focus_restoration(
         },
     )?;
     let _ = backend.go_to_tab_position(session_name, tab_position);
-    if crate::sidebar::focus_anchor::dispatch_action_retried(
+    if crate::sidebar::focus_anchor::dispatch_action(
         backend,
         runtime,
         session_name,
         pane,
         nonce,
-        super::FOCUS_RESTORE_ATTEMPTS,
-        super::FOCUS_RESTORE_RETRY_DELAY,
+        crate::sidebar::focus_anchor::FocusDispatchRetries {
+            attempts: super::FOCUS_RESTORE_ATTEMPTS,
+            delay: super::FOCUS_RESTORE_RETRY_DELAY,
+        },
     )? {
         Ok(())
     } else {

--- a/crates/rimz/src/mux/zellij/sidebar.rs
+++ b/crates/rimz/src/mux/zellij/sidebar.rs
@@ -463,7 +463,7 @@ impl ZellijBackend {
         let Ok(runtime) = self.runtime_paths_for_workspace(workspace_id.clone()) else {
             return;
         };
-        let _ = crate::sidebar::focus_anchor::execute_action_retried(
+        let _ = crate::sidebar::focus_anchor::execute_action(
             self,
             &runtime,
             session,

--- a/crates/rimz/src/sidebar/cache.rs
+++ b/crates/rimz/src/sidebar/cache.rs
@@ -120,7 +120,7 @@ pub struct PresenceStamp {
 /// throttles external `list-clients` calls; pane presence remains sourced from
 /// the published frame.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PresenceProbeStamp {
+struct PresenceProbeStamp {
     pub written_at_ms: u64,
 }
 
@@ -129,7 +129,7 @@ pub fn presence_stamp_path(runtime: &RuntimePaths) -> PathBuf {
     runtime.root.join("presence.stamp")
 }
 
-pub fn presence_probe_stamp_path(runtime: &RuntimePaths) -> PathBuf {
+fn presence_probe_stamp_path(runtime: &RuntimePaths) -> PathBuf {
     runtime.root.join("client-presence-probe.stamp")
 }
 

--- a/crates/rimz/src/sidebar/consumer.rs
+++ b/crates/rimz/src/sidebar/consumer.rs
@@ -30,7 +30,12 @@ pub struct PublishedSnapshotReader {
     session: String,
     exclude: Option<PaneId>,
     cursor: RollupCursor,
+    source: ConsumerSnapshotSource,
+    last_fold: Option<(ConsumerFoldInputsStamp, u64, ConsumerSnapshotSource)>,
+    prepared_stamp: Option<(ConsumerSnapshotSource, ConsumerFoldInputsStamp)>,
 }
+
+const CONSUMER_UNCHANGED_BACKSTOP_MS: u64 = 30_000;
 
 impl PublishedSnapshotReader {
     pub fn new(runtime: RuntimePaths, session: impl Into<String>, exclude: Option<PaneId>) -> Self {
@@ -39,6 +44,9 @@ impl PublishedSnapshotReader {
             session: session.into(),
             exclude,
             cursor: RollupCursor::new(),
+            source: ConsumerSnapshotSource::Fallback,
+            last_fold: None,
+            prepared_stamp: None,
         }
     }
 
@@ -62,18 +70,10 @@ impl PublishedSnapshotReader {
         read_published_workspace_snapshot(&mut self.cursor, state, &self.runtime, &self.session)
     }
 
-    pub fn inputs_stamp(&self, state: &StatePaths) -> ConsumerFoldInputsStamp {
-        consumer_fold_inputs_stamp(state, &self.runtime)
-    }
-
-    pub fn projection_inputs_stamp(&self, state: &StatePaths) -> ConsumerFoldInputsStamp {
-        consumer_projection_inputs_stamp(state, &self.runtime)
-    }
-
     pub fn read_adopting(
         &mut self,
         state: &StatePaths,
-    ) -> crate::store::snapshot::Result<ConsumerSnapshotRead> {
+    ) -> crate::store::snapshot::Result<SidebarSnapshot> {
         let frame = read_snapshot_cache(&self.runtime.pane_frame_path(), &self.session);
         let adopted = frame.as_deref().and_then(|frame| {
             let published = read_workspace_projection(&self.runtime)?;
@@ -92,15 +92,45 @@ impl PublishedSnapshotReader {
             })
         });
         match adopted {
-            Some(snapshot) => Ok(ConsumerSnapshotRead {
-                snapshot,
-                source: ConsumerSnapshotSource::Adoption,
-            }),
-            None => self.read(state).map(|snapshot| ConsumerSnapshotRead {
-                snapshot,
-                source: ConsumerSnapshotSource::Fallback,
-            }),
+            Some(snapshot) => {
+                self.source = ConsumerSnapshotSource::Adoption;
+                Ok(snapshot)
+            }
+            None => {
+                self.source = ConsumerSnapshotSource::Fallback;
+                self.read(state)
+            }
         }
+    }
+
+    pub(crate) fn fold_unchanged(&mut self, state: &StatePaths, now_ms: u64) -> bool {
+        let source = self.source;
+        let stamp = source.inputs_stamp(state, &self.runtime);
+        let unchanged =
+            self.last_fold
+                .as_ref()
+                .is_some_and(|(last_stamp, folded_at_ms, last_source)| {
+                    *last_source == source
+                        && last_stamp == &stamp
+                        && now_ms.saturating_sub(*folded_at_ms) < CONSUMER_UNCHANGED_BACKSTOP_MS
+                });
+        self.prepared_stamp = Some((source, stamp));
+        unchanged
+    }
+
+    pub(crate) fn record_fold(&mut self, state: &StatePaths, now_ms: u64) {
+        let source = self.source;
+        let stamp = match self.prepared_stamp.take() {
+            Some((prepared_source, stamp)) if prepared_source == source => stamp,
+            _ => source.inputs_stamp(state, &self.runtime),
+        };
+        self.last_fold = Some((stamp, now_ms, source));
+    }
+
+    pub(crate) fn clear_fold(&mut self) {
+        self.source = ConsumerSnapshotSource::Fallback;
+        self.last_fold = None;
+        self.prepared_stamp = None;
     }
 
     /// Producer lane escape hatch for sharing the warm rollup with pane production.
@@ -115,18 +145,22 @@ impl PublishedSnapshotReader {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ConsumerSnapshotSource {
+enum ConsumerSnapshotSource {
     Adoption,
     Fallback,
 }
 
-pub struct ConsumerSnapshotRead {
-    pub snapshot: SidebarSnapshot,
-    pub source: ConsumerSnapshotSource,
+impl ConsumerSnapshotSource {
+    fn inputs_stamp(self, state: &StatePaths, runtime: &RuntimePaths) -> ConsumerFoldInputsStamp {
+        match self {
+            Self::Adoption => consumer_projection_inputs_stamp(state, runtime),
+            Self::Fallback => consumer_fold_inputs_stamp(state, runtime),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ConsumerFoldInputsStamp {
+struct ConsumerFoldInputsStamp {
     state: Vec<StampedPath>,
     runtime: Vec<StampedPath>,
     dirs: Vec<StampedPath>,
@@ -344,7 +378,7 @@ fn consumer_fold_inputs_stamp(
 /// Slim unchanged identity after a successful projection adoption. Every
 /// source-identity input and the projection publication itself remains in the
 /// set; broad enrichment sidecars return only after a fallback.
-pub(crate) fn consumer_projection_inputs_stamp(
+fn consumer_projection_inputs_stamp(
     state: &StatePaths,
     runtime: &RuntimePaths,
 ) -> ConsumerFoldInputsStamp {

--- a/crates/rimz/src/sidebar/consumer.rs
+++ b/crates/rimz/src/sidebar/consumer.rs
@@ -35,6 +35,11 @@ pub struct PublishedSnapshotReader {
     prepared_stamp: Option<(ConsumerSnapshotSource, ConsumerFoldInputsStamp)>,
 }
 
+/// Maximum time unchanged input metadata may suppress a real fold.
+///
+/// Stamps are a latency hint, not truth: bounded re-reads cover filesystem
+/// metadata aliasing and future drift in the fold's input set. Skips never
+/// advance this window; it measures from the last successful fold.
 const CONSUMER_UNCHANGED_BACKSTOP_MS: u64 = 30_000;
 
 impl PublishedSnapshotReader {
@@ -70,6 +75,7 @@ impl PublishedSnapshotReader {
         read_published_workspace_snapshot(&mut self.cursor, state, &self.runtime, &self.session)
     }
 
+    /// Adopt a matching producer projection, or run the full consumer fold.
     pub fn read_adopting(
         &mut self,
         state: &StatePaths,
@@ -103,6 +109,11 @@ impl PublishedSnapshotReader {
         }
     }
 
+    /// Prepare the stamp for a possible fold and test it against the last success.
+    ///
+    /// This query does not advance the successful-fold timestamp. Its prepared
+    /// stamp lets [`Self::record_fold`] avoid a second filesystem walk when the
+    /// read keeps the same adoption/fallback source.
     pub(crate) fn fold_unchanged(&mut self, state: &StatePaths, now_ms: u64) -> bool {
         let source = self.source;
         let stamp = source.inputs_stamp(state, &self.runtime);
@@ -118,6 +129,10 @@ impl PublishedSnapshotReader {
         unchanged
     }
 
+    /// Record a successful fold, reusing a prepared stamp when its source matches.
+    ///
+    /// Missing preparation or an adoption/fallback transition pays a fresh
+    /// filesystem walk for the correct input set.
     pub(crate) fn record_fold(&mut self, state: &StatePaths, now_ms: u64) {
         let source = self.source;
         let stamp = match self.prepared_stamp.take() {
@@ -127,6 +142,7 @@ impl PublishedSnapshotReader {
         self.last_fold = Some((stamp, now_ms, source));
     }
 
+    /// Clear skip state and restore full inputs after a producer, mandatory, or failed fold.
     pub(crate) fn clear_fold(&mut self) {
         self.source = ConsumerSnapshotSource::Fallback;
         self.last_fold = None;

--- a/crates/rimz/src/sidebar/consumer.rs
+++ b/crates/rimz/src/sidebar/consumer.rs
@@ -306,18 +306,10 @@ fn consumer_fold_inputs_stamp(
     ];
     let runtime_files = [
         runtime.pane_frame_path(),
-        runtime.diff_stats_path(),
-        runtime.cohort_spend_path(),
-        runtime.pr_state_path(),
         runtime.unread_path(),
         crate::remote::link::stats_path(runtime),
-        runtime.shared_accounts_path(),
-        runtime.shared_rate_limits_path(),
-        runtime.shared_credits_path(),
-        runtime.shared_provider_spending_path(),
         runtime.agent_projection_path(),
         runtime.root.join("metrics-sample.json"),
-        super::refresh::daemon_reap::codex_daemon_reap_path(runtime),
     ];
     let dirs = [
         state.messages_dir.as_path(),
@@ -331,6 +323,11 @@ fn consumer_fold_inputs_stamp(
         .iter()
         .map(|path| StampedPath::of(path.as_path()))
         .collect::<Vec<_>>();
+    runtime_stamps.extend(
+        super::refresh::inputs::published_lane_inputs(runtime)
+            .iter()
+            .map(|path| StampedPath::of(path)),
+    );
     runtime_stamps.extend(filtered_runtime_inputs(runtime));
 
     ConsumerFoldInputsStamp {
@@ -370,7 +367,7 @@ pub(crate) fn consumer_projection_inputs_stamp(
 
 fn filtered_runtime_inputs(runtime: &RuntimePaths) -> Vec<StampedPath> {
     let mut paths = filtered_paths(&runtime.root, |name| {
-        (name.starts_with("workspace-spending.")
+        (super::refresh::inputs::is_workspace_spending_file(name)
             || name.starts_with("budget.")
             || name.starts_with("auto-continue."))
             && name.ends_with(".json")

--- a/crates/rimz/src/sidebar/consumer.rs
+++ b/crates/rimz/src/sidebar/consumer.rs
@@ -292,7 +292,7 @@ fn read_published_agent_projection(
 /// Cheap identity of the files a consumer fold reads. A matching stamp lets a
 /// long-lived renderer skip the fold and keep its last committed frame; the
 /// poll backstop still forces a real fold periodically.
-pub fn consumer_fold_inputs_stamp(
+fn consumer_fold_inputs_stamp(
     state: &StatePaths,
     runtime: &RuntimePaths,
 ) -> ConsumerFoldInputsStamp {
@@ -347,7 +347,7 @@ pub fn consumer_fold_inputs_stamp(
 /// Slim unchanged identity after a successful projection adoption. Every
 /// source-identity input and the projection publication itself remains in the
 /// set; broad enrichment sidecars return only after a fallback.
-pub fn consumer_projection_inputs_stamp(
+pub(crate) fn consumer_projection_inputs_stamp(
     state: &StatePaths,
     runtime: &RuntimePaths,
 ) -> ConsumerFoldInputsStamp {

--- a/crates/rimz/src/sidebar/consumer/tests.rs
+++ b/crates/rimz/src/sidebar/consumer/tests.rs
@@ -52,10 +52,6 @@ impl StampFixture {
             runtime,
         }
     }
-
-    fn reader(&self) -> PublishedSnapshotReader {
-        PublishedSnapshotReader::new(self.runtime.clone(), "rimz-test", None)
-    }
 }
 
 fn file_stamp_inputs(state: &StatePaths, runtime: &RuntimePaths) -> Vec<(&'static str, PathBuf)> {
@@ -275,12 +271,23 @@ fn cached_daemon_reap_forwards_published_live_panes() {
 #[test]
 fn consumer_fold_inputs_stamp_is_stable_for_unchanged_inputs() {
     let fixture = StampFixture::new();
-    let reader = fixture.reader();
 
     assert_eq!(
-        reader.inputs_stamp(&fixture.state),
-        reader.inputs_stamp(&fixture.state)
+        consumer_fold_inputs_stamp(&fixture.state, &fixture.runtime),
+        consumer_fold_inputs_stamp(&fixture.state, &fixture.runtime)
     );
+}
+
+#[test]
+fn unchanged_backstop_uses_last_successful_fold_time() {
+    let fixture = StampFixture::new();
+    let mut reader = PublishedSnapshotReader::new(fixture.runtime.clone(), "rimz-test", None);
+    let folded_at_ms = 10;
+
+    assert!(!reader.fold_unchanged(&fixture.state, folded_at_ms));
+    reader.record_fold(&fixture.state, folded_at_ms);
+    assert!(reader.fold_unchanged(&fixture.state, folded_at_ms + 29_999));
+    assert!(!reader.fold_unchanged(&fixture.state, folded_at_ms + 30_000));
 }
 
 #[test]
@@ -323,8 +330,7 @@ fn consumer_fold_inputs_stamp_changes_for_each_file_input() {
         "codex_daemon_reap",
     ] {
         let fixture = StampFixture::new();
-        let reader = fixture.reader();
-        let before = reader.inputs_stamp(&fixture.state);
+        let before = consumer_fold_inputs_stamp(&fixture.state, &fixture.runtime);
         let path = file_stamp_inputs(&fixture.state, &fixture.runtime)
             .into_iter()
             .find(|(candidate, _)| *candidate == name)
@@ -334,7 +340,7 @@ fn consumer_fold_inputs_stamp_changes_for_each_file_input() {
         std::fs::write(&path, format!("{name}-changed-with-a-longer-body")).unwrap();
 
         assert_ne!(
-            reader.inputs_stamp(&fixture.state),
+            consumer_fold_inputs_stamp(&fixture.state, &fixture.runtime),
             before,
             "{name} must participate in the consumer fold input stamp",
         );
@@ -352,8 +358,7 @@ fn consumer_fold_inputs_stamp_changes_for_each_dir_input() {
         "read_marks_dir",
     ] {
         let fixture = StampFixture::new();
-        let reader = fixture.reader();
-        let before = reader.inputs_stamp(&fixture.state);
+        let before = consumer_fold_inputs_stamp(&fixture.state, &fixture.runtime);
         let path = dir_stamp_inputs(&fixture.state, &fixture.runtime)
             .into_iter()
             .find(|(candidate, _)| *candidate == name)
@@ -363,7 +368,7 @@ fn consumer_fold_inputs_stamp_changes_for_each_dir_input() {
         std::fs::remove_dir_all(&path).unwrap();
 
         assert_ne!(
-            reader.inputs_stamp(&fixture.state),
+            consumer_fold_inputs_stamp(&fixture.state, &fixture.runtime),
             before,
             "{name} must participate in the consumer fold input stamp",
         );
@@ -373,8 +378,7 @@ fn consumer_fold_inputs_stamp_changes_for_each_dir_input() {
 #[test]
 fn consumer_fold_inputs_stamp_ignores_unrelated_runtime_churn() {
     let fixture = StampFixture::new();
-    let reader = fixture.reader();
-    let baseline = reader.inputs_stamp(&fixture.state);
+    let baseline = consumer_fold_inputs_stamp(&fixture.state, &fixture.runtime);
     let unrelated = [
         fixture.runtime.root.join("snapshot.lock"),
         fixture.runtime.root.join("presence.stamp"),
@@ -384,7 +388,7 @@ fn consumer_fold_inputs_stamp_ignores_unrelated_runtime_churn() {
     for path in unrelated {
         std::fs::write(&path, b"churn").unwrap();
         assert_eq!(
-            reader.inputs_stamp(&fixture.state),
+            consumer_fold_inputs_stamp(&fixture.state, &fixture.runtime),
             baseline,
             "{} is not a consumer fold input",
             path.display(),
@@ -399,13 +403,15 @@ fn consumer_fold_inputs_stamp_ignores_unrelated_runtime_churn() {
     std::fs::remove_file(renamed).unwrap();
     let heartbeat = fixture.runtime.heartbeat_dir.join("sidebar.unrelated.json");
     std::fs::write(heartbeat, b"{}").unwrap();
-    assert_eq!(reader.inputs_stamp(&fixture.state), baseline,);
+    assert_eq!(
+        consumer_fold_inputs_stamp(&fixture.state, &fixture.runtime),
+        baseline,
+    );
 }
 
 #[test]
 fn consumer_fold_inputs_stamp_tracks_filtered_dynamic_files() {
     let fixture = StampFixture::new();
-    let reader = fixture.reader();
     for path in [
         fixture
             .runtime
@@ -423,18 +429,18 @@ fn consumer_fold_inputs_stamp_tracks_filtered_dynamic_files() {
             .persistent_shared_root
             .join("budget.account.codex.json"),
     ] {
-        let before_create = reader.inputs_stamp(&fixture.state);
+        let before_create = consumer_fold_inputs_stamp(&fixture.state, &fixture.runtime);
         write_stamp_file(&path, "created");
-        let after_create = reader.inputs_stamp(&fixture.state);
+        let after_create = consumer_fold_inputs_stamp(&fixture.state, &fixture.runtime);
         assert_ne!(after_create, before_create, "create {}", path.display());
 
         std::fs::write(&path, b"replaced-with-a-longer-payload").unwrap();
-        let after_replace = reader.inputs_stamp(&fixture.state);
+        let after_replace = consumer_fold_inputs_stamp(&fixture.state, &fixture.runtime);
         assert_ne!(after_replace, after_create, "replace {}", path.display());
 
         std::fs::remove_file(&path).unwrap();
         assert_ne!(
-            reader.inputs_stamp(&fixture.state),
+            consumer_fold_inputs_stamp(&fixture.state, &fixture.runtime),
             after_replace,
             "remove {}",
             path.display(),
@@ -1096,19 +1102,19 @@ impl AdoptionFixture {
         }
     }
 
-    fn read(&self) -> ConsumerSnapshotRead {
-        PublishedSnapshotReader::new(self.runtime.clone(), "rimz-test", None)
-            .read_adopting(&self.state)
-            .unwrap()
+    fn read(&self) -> (SidebarSnapshot, ConsumerSnapshotSource) {
+        let mut reader = PublishedSnapshotReader::new(self.runtime.clone(), "rimz-test", None);
+        let snapshot = reader.read_adopting(&self.state).unwrap();
+        (snapshot, reader.source)
     }
 }
 
 #[test]
 fn consumer_adopts_only_an_exact_workspace_projection() {
     let fixture = AdoptionFixture::new();
-    let read = fixture.read();
-    assert_eq!(read.source, ConsumerSnapshotSource::Adoption);
-    assert_eq!(read.snapshot.display_name, "projected");
+    let (snapshot, read_source) = fixture.read();
+    assert_eq!(read_source, ConsumerSnapshotSource::Adoption);
+    assert_eq!(snapshot.display_name, "projected");
 
     for (field, value) in [
         ("schema_version", serde_json::json!(99)),
@@ -1122,7 +1128,7 @@ fn consumer_adopts_only_an_exact_workspace_projection() {
         projection[field] = value;
         atomic::write_temp_then_rename_cache(&path, &projection).unwrap();
         assert_eq!(
-            fixture.read().source,
+            fixture.read().1,
             ConsumerSnapshotSource::Fallback,
             "{field}"
         );
@@ -1134,14 +1140,14 @@ fn consumer_adopts_only_an_exact_workspace_projection() {
         b"{broken projection",
     )
     .unwrap();
-    assert_eq!(fixture.read().source, ConsumerSnapshotSource::Fallback);
+    assert_eq!(fixture.read().1, ConsumerSnapshotSource::Fallback);
 
     let fixture = AdoptionFixture::new();
     std::fs::remove_file(
         crate::sidebar::workspace_projection::workspace_projection_path(&fixture.runtime),
     )
     .unwrap();
-    assert_eq!(fixture.read().source, ConsumerSnapshotSource::Fallback);
+    assert_eq!(fixture.read().1, ConsumerSnapshotSource::Fallback);
 }
 
 #[test]
@@ -1155,20 +1161,20 @@ fn consumer_falls_back_for_stale_truth_or_legacy_frame() {
         ),
     )
     .unwrap();
-    assert_eq!(fixture.read().source, ConsumerSnapshotSource::Fallback);
+    assert_eq!(fixture.read().1, ConsumerSnapshotSource::Fallback);
 
     let mut fixture = AdoptionFixture::new();
     fixture.frame.metrics_stamp_ms = Some(99);
     atomic::write_temp_then_rename_cache(&fixture.runtime.pane_frame_path(), &fixture.frame)
         .unwrap();
-    assert_eq!(fixture.read().source, ConsumerSnapshotSource::Fallback);
+    assert_eq!(fixture.read().1, ConsumerSnapshotSource::Fallback);
 
     let mut fixture = AdoptionFixture::new();
     fixture.frame.topology_stamp_ms = None;
     fixture.frame.metrics_stamp_ms = None;
     atomic::write_temp_then_rename_cache(&fixture.runtime.pane_frame_path(), &fixture.frame)
         .unwrap();
-    assert_eq!(fixture.read().source, ConsumerSnapshotSource::Fallback);
+    assert_eq!(fixture.read().1, ConsumerSnapshotSource::Fallback);
 }
 
 #[test]
@@ -1198,9 +1204,9 @@ fn consumer_adopts_an_event_fresh_projection_while_latest_publish_trails() {
         )
         .unwrap();
 
-    let read = fixture.read();
-    assert_eq!(read.source, ConsumerSnapshotSource::Adoption);
-    assert_eq!(read.snapshot.display_name, "event-fresh projection");
+    let (snapshot, read_source) = fixture.read();
+    assert_eq!(read_source, ConsumerSnapshotSource::Adoption);
+    assert_eq!(snapshot.display_name, "event-fresh projection");
 }
 
 #[test]
@@ -1218,8 +1224,8 @@ fn presence_only_frame_publication_keeps_projection_match() {
     atomic::write_temp_then_rename_cache(&fixture.runtime.pane_frame_path(), &fixture.frame)
         .unwrap();
 
-    let read = fixture.read();
-    assert_eq!(read.source, ConsumerSnapshotSource::Adoption);
+    let (snapshot, read_source) = fixture.read();
+    assert_eq!(read_source, ConsumerSnapshotSource::Adoption);
     assert_eq!(
         (
             fixture.frame.topology_stamp_ms,
@@ -1228,7 +1234,7 @@ fn presence_only_frame_publication_keeps_projection_match() {
         source
     );
     assert_eq!(
-        read.snapshot.presence,
+        snapshot.presence,
         Some(crate::store::snapshot::SidebarPresence::Detached)
     );
 }

--- a/crates/rimz/src/sidebar/consumer/tests.rs
+++ b/crates/rimz/src/sidebar/consumer/tests.rs
@@ -209,7 +209,7 @@ fn cached_daemon_reap_drops_paneless_codex_ghost_before_worktree_pins() {
     let runtime = RuntimePaths::under(workspace.clone(), dir.path()).unwrap();
     runtime.ensure_dirs().unwrap();
     let owner_pid = std::process::id();
-    crate::sidebar::refresh::write_codex_daemon_reap(
+    crate::sidebar::refresh::daemon_reap::write_codex_daemon_reap(
         &runtime,
         &crate::sidebar::refresh::CodexDaemonReap {
             produced_at_ms: 1,
@@ -254,7 +254,7 @@ fn cached_daemon_reap_forwards_published_live_panes() {
     let pane_id = PaneId::from_parts(MuxName::Tmux, "%1");
     let pane = crate::pane::PaneRef::from_id(pane_id.clone());
     let codex = daemon_codex("live-pane", dir.path(), Some(pane.clone()), 77);
-    crate::sidebar::refresh::write_codex_daemon_reap(
+    crate::sidebar::refresh::daemon_reap::write_codex_daemon_reap(
         &runtime,
         &crate::sidebar::refresh::CodexDaemonReap {
             produced_at_ms: 1,

--- a/crates/rimz/src/sidebar/enrich.rs
+++ b/crates/rimz/src/sidebar/enrich.rs
@@ -34,7 +34,7 @@ use super::refresh::git_stats::{
 };
 use super::refresh::live_spend::{apply_live_day_spend, apply_live_today_spend};
 use super::refresh::pr::{PrLink, read_pr_state_cache};
-use super::refresh::rate_limits::apply_rate_limit_cache;
+use super::refresh::rate_limits::apply_cached_rate_limits;
 use super::timing::{LINK_STATS_EXPIRE, LINK_STATS_STALE};
 
 #[cfg(test)]
@@ -872,7 +872,7 @@ fn fold_machine_config(
     );
     // Every fold merges the producer-published account windows read-only. The
     // refresh lane owns writes.
-    apply_rate_limit_cache(&mut snapshot, runtime, false);
+    apply_cached_rate_limits(&mut snapshot, runtime);
     apply_credits_cache(&mut snapshot, runtime, &accounts_config);
     (snapshot, spending)
 }
@@ -900,7 +900,7 @@ pub fn provider_panels_from_caches(
         &provider_spending.spending.by_provider,
         RemoteControlServerHealth::default(),
     );
-    apply_rate_limit_cache(&mut snapshot, runtime, false);
+    apply_cached_rate_limits(&mut snapshot, runtime);
     apply_credits_cache(&mut snapshot, runtime, &config.accounts);
     crate::harness::budget::project_budget_views(
         &mut snapshot,

--- a/crates/rimz/src/sidebar/enrich.rs
+++ b/crates/rimz/src/sidebar/enrich.rs
@@ -40,17 +40,6 @@ use super::timing::{LINK_STATS_EXPIRE, LINK_STATS_STALE};
 #[cfg(test)]
 mod tests;
 
-/// The repo's worktree checkout roots the producer last published, read-only
-/// (no `git worktree list` fork). A consumer reuses whatever the elder cached,
-/// even stale; an empty set leaves the reducer's project-root prefix test to
-/// stand alone.
-pub fn cached_worktree_roots(runtime: &RuntimePaths) -> Vec<PathBuf> {
-    read_diff_stats_cache(&runtime.diff_stats_path())
-        .worktrees
-        .map(|cache| cache.roots)
-        .unwrap_or_default()
-}
-
 pub(crate) fn read_auto_continue_resume_messages(
     store: Option<&Store>,
     config: &crate::config::ResumeConfig,
@@ -65,7 +54,7 @@ pub(crate) fn read_auto_continue_resume_messages(
 
 /// Fold the remote-link stats sidecar onto the snapshot. Local rooms never have
 /// this file; corrupt, unknown-version, and expired files erase the badge.
-pub fn fold_link_stats(snapshot: &mut SidebarSnapshot, runtime: &RuntimePaths, now_ms: u64) {
+fn fold_link_stats(snapshot: &mut SidebarSnapshot, runtime: &RuntimePaths, now_ms: u64) {
     let path = crate::remote::link::stats_path(runtime);
     let Ok(bytes) = std::fs::read(path) else {
         snapshot.link = None;
@@ -106,7 +95,7 @@ pub fn fold_link_stats(snapshot: &mut SidebarSnapshot, runtime: &RuntimePaths, n
 /// validates checkout paths before refreshing their entries and publishes
 /// exact channel marker classifications; consumers project that cache without
 /// git subprocesses or checkout metadata reads.
-pub fn project_diff_stats(snapshot: &mut SidebarSnapshot, cache: &DiffStatsCache) {
+fn project_diff_stats(snapshot: &mut SidebarSnapshot, cache: &DiffStatsCache) {
     for group in &mut snapshot.worktree_groups {
         if group.kind == SidebarWorktreeKind::Channel {
             group.worktree_backed = false;
@@ -171,7 +160,7 @@ pub fn project_diff_stats(snapshot: &mut SidebarSnapshot, cache: &DiffStatsCache
 
 /// Qualify groups whose final display labels collide with the shortest
 /// distinguishing trailing checkout path.
-pub fn disambiguate_group_labels(snapshot: &mut SidebarSnapshot) {
+fn disambiguate_group_labels(snapshot: &mut SidebarSnapshot) {
     let mut by_label = BTreeMap::<String, Vec<(usize, Vec<String>, usize)>>::new();
 
     for (index, group) in snapshot.worktree_groups.iter_mut().enumerate() {
@@ -242,7 +231,7 @@ fn trailing_path_suffix(components: &[String], depth: usize) -> String {
     components[components.len().saturating_sub(depth)..].join("/")
 }
 
-pub fn project_cohort_effort(snapshot: &mut SidebarSnapshot, cache: &CohortSpendCache) {
+fn project_cohort_effort(snapshot: &mut SidebarSnapshot, cache: &CohortSpendCache) {
     for group in &mut snapshot.worktree_groups {
         group.cohort_effort = cache.groups.get(&group.key).cloned();
     }
@@ -270,7 +259,7 @@ fn cached_git_backed_worktree_path<'a>(
     }
 }
 
-pub fn project_pr_state_map(
+fn project_pr_state_map(
     snapshot: &mut SidebarSnapshot,
     states: &BTreeMap<String, PrLink>,
     branch_ci: &BTreeMap<String, WorktreePrCi>,
@@ -318,7 +307,7 @@ pub fn project_pr_state_map(
     }
 }
 
-pub(crate) fn project_cached_pr_states(
+fn project_cached_pr_states(
     snapshot: &mut SidebarSnapshot,
     runtime: &RuntimePaths,
     diff_cache: &DiffStatsCache,
@@ -327,7 +316,7 @@ pub(crate) fn project_cached_pr_states(
     project_pr_state_map(snapshot, &cache.states, &cache.branch_ci, diff_cache);
 }
 
-pub(crate) fn classify_trunk_sync(
+fn classify_trunk_sync(
     entry: &DiffStatsCacheEntry,
     label: &str,
     trunk_display: &str,
@@ -376,7 +365,7 @@ pub(crate) struct RemoteControlServerHealth {
 /// an enabled host must not have left a record saying its server died — a pane
 /// outlives the child that answers for it, so presence alone reads healthy long
 /// after the host stopped working. No record keeps the answer positive.
-pub(crate) fn claude_host_serving(
+fn claude_host_serving(
     pane_present: bool,
     enabled: bool,
     liveness: crate::agents::runtime_control::RuntimeControlLiveness,
@@ -986,7 +975,7 @@ fn remote_control_badge(
 /// `[theme.display.context_meter]` bands: [`crate::agents::ContextSeverity::classify`] over
 /// the row's gauge inputs, the one verdict the renderer's color ramp and any
 /// future signal emitter read. Process rows carry no context and stay `None`.
-pub(crate) fn stamp_context_severity(
+fn stamp_context_severity(
     groups: &mut [SidebarWorktreeGroup],
     bands: &crate::config::ContextMeterConfig,
 ) {

--- a/crates/rimz/src/sidebar/enrich/tests/mod.rs
+++ b/crates/rimz/src/sidebar/enrich/tests/mod.rs
@@ -5,11 +5,12 @@ use crate::pane::{RuntimeOwner, RuntimeOwnerKind};
 use crate::remote::link::{LinkStats, LinkStatsFile, LinkTier};
 use crate::sidebar::refresh::AccountsCache;
 use crate::sidebar::refresh::PrLink;
+use crate::sidebar::refresh::daemon_reap::write_codex_daemon_reap;
 use crate::sidebar::refresh::git_stats::{
     DiffStatsCache, DiffStatsCacheEntry, WorktreeRootsCache, focused_worktree_paths,
     hot_worktree_paths, needed_worktree_paths,
 };
-use crate::sidebar::refresh::{CodexDaemonReap, read_codex_daemon_reap, write_codex_daemon_reap};
+use crate::sidebar::refresh::{CodexDaemonReap, read_codex_daemon_reap};
 use crate::sidebar::test_support::{activity_row, pane, root_agent, worktree_group};
 use crate::sidebar::timing::GIT_ACTIVITY_WINDOW;
 use crate::sidebar::timing::unix_now_ms;

--- a/crates/rimz/src/sidebar/focus_anchor.rs
+++ b/crates/rimz/src/sidebar/focus_anchor.rs
@@ -17,7 +17,7 @@ use crate::mux::{ClientFocusOptions, ClientPaneView, MuxBackend};
 use crate::sidebar::timing::FOCUS_ANCHOR_FRESH;
 use crate::store::{RuntimePaths, atomic};
 
-pub const FOCUS_ANCHOR_VERSION: &str = "rimz.focus-anchor.v3";
+const FOCUS_ANCHOR_VERSION: &str = "rimz.focus-anchor.v3";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -399,14 +399,6 @@ pub fn execute_action_retried(
     }
 }
 
-pub fn observation_outcome(
-    anchor: &FocusAnchor,
-    snapshot: &crate::store::snapshot::SidebarSnapshot,
-    now_ms: u64,
-) -> FocusObservationOutcome {
-    observation_outcome_from(anchor, &FocusObservation::from_snapshot(snapshot), now_ms)
-}
-
 pub(crate) fn observation_outcome_from(
     anchor: &FocusAnchor,
     observation: &FocusObservation,
@@ -464,6 +456,15 @@ pub(crate) fn observation_outcome_from(
     } else {
         FocusObservationOutcome::Fence
     }
+}
+
+#[cfg(test)]
+fn observation_outcome(
+    anchor: &FocusAnchor,
+    snapshot: &crate::store::snapshot::SidebarSnapshot,
+    now_ms: u64,
+) -> FocusObservationOutcome {
+    observation_outcome_from(anchor, &FocusObservation::from_snapshot(snapshot), now_ms)
 }
 
 pub fn clear_matching(runtime: &RuntimePaths, nonce: FocusNonce) -> bool {

--- a/crates/rimz/src/sidebar/focus_anchor.rs
+++ b/crates/rimz/src/sidebar/focus_anchor.rs
@@ -124,6 +124,15 @@ pub struct FocusDispatchRetries {
     pub delay: Duration,
 }
 
+impl Default for FocusDispatchRetries {
+    fn default() -> Self {
+        Self {
+            attempts: 1,
+            delay: Duration::ZERO,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FocusObservationOutcome {
     Present,
@@ -286,26 +295,7 @@ pub fn dispatch_action(
     session_name: &str,
     pane_id: &PaneId,
     nonce: FocusNonce,
-) -> Result<bool, FocusActionError> {
-    dispatch_action_retried(
-        backend,
-        runtime,
-        session_name,
-        pane_id,
-        nonce,
-        1,
-        Duration::ZERO,
-    )
-}
-
-pub fn dispatch_action_retried(
-    backend: &dyn MuxBackend,
-    runtime: &RuntimePaths,
-    session_name: &str,
-    pane_id: &PaneId,
-    nonce: FocusNonce,
-    attempts: u32,
-    retry_delay: Duration,
+    retries: FocusDispatchRetries,
 ) -> Result<bool, FocusActionError> {
     let _guard = crate::store::lock::WorkspaceLock::acquire(&runtime.focus_anchor_lock())?;
     let Some(mut anchor) = load(runtime).filter(|anchor| anchor.nonce == nonce) else {
@@ -313,9 +303,9 @@ pub fn dispatch_action_retried(
     };
     let mut accepted = false;
     let mut last_error = None;
-    for attempt in 0..attempts.max(1) {
+    for attempt in 0..retries.attempts.max(1) {
         if attempt > 0 {
-            std::thread::sleep(retry_delay);
+            std::thread::sleep(retries.delay);
         }
         match backend.focus_pane(pane_id, Some(session_name)) {
             Ok(()) => accepted = true,
@@ -347,28 +337,6 @@ pub fn execute_action(
     pane_id: PaneId,
     origin: FocusOrigin,
     expected_pre_action: Option<&[ClientPaneView]>,
-) -> Result<FocusNonce, FocusActionError> {
-    execute_action_retried(
-        backend,
-        runtime,
-        session_name,
-        pane_id,
-        origin,
-        expected_pre_action,
-        FocusDispatchRetries {
-            attempts: 1,
-            delay: Duration::ZERO,
-        },
-    )
-}
-
-pub fn execute_action_retried(
-    backend: &dyn MuxBackend,
-    runtime: &RuntimePaths,
-    session_name: &str,
-    pane_id: PaneId,
-    origin: FocusOrigin,
-    expected_pre_action: Option<&[ClientPaneView]>,
     retries: FocusDispatchRetries,
 ) -> Result<FocusNonce, FocusActionError> {
     let nonce = request_action(
@@ -384,15 +352,7 @@ pub fn execute_action_retried(
             order: None,
         },
     )?;
-    if dispatch_action_retried(
-        backend,
-        runtime,
-        session_name,
-        &pane_id,
-        nonce,
-        retries.attempts,
-        retries.delay,
-    )? {
+    if dispatch_action(backend, runtime, session_name, &pane_id, nonce, retries)? {
         Ok(nonce)
     } else {
         Err(FocusActionError::Superseded)

--- a/crates/rimz/src/sidebar/frame.rs
+++ b/crates/rimz/src/sidebar/frame.rs
@@ -233,7 +233,7 @@ impl PaneState {
     /// metrics-layer derivation, and only that layer's `starttime` pid-reuse
     /// guard may restore it ([`super::produce`]'s metrics module) — a rotation
     /// carry would republish a stale binding without ever revalidating it.
-    pub fn rotate_on_process_change(&mut self, prior: &PaneState) {
+    pub(in crate::sidebar) fn rotate_on_process_change(&mut self, prior: &PaneState) {
         let spawn_changed = match (
             self.current.spawn_command.as_deref(),
             prior.current.spawn_command.as_deref(),
@@ -345,14 +345,6 @@ pub fn assemble_frame(
     produced_at_ms: u64,
     session_name: impl Into<String>,
 ) -> PaneFrame {
-    assemble_frame_with_diagnostics(panes, produced_at_ms, session_name).0
-}
-
-pub fn assemble_frame_with_diagnostics(
-    panes: Vec<PaneRef>,
-    produced_at_ms: u64,
-    session_name: impl Into<String>,
-) -> (PaneFrame, Vec<DiagEvent>) {
     assemble_frame_from_inputs(FrameInputs {
         panes,
         produced_at_ms,
@@ -364,6 +356,7 @@ pub fn assemble_frame_with_diagnostics(
         client_view_fresh: false,
         prior: None,
     })
+    .0
 }
 
 pub fn assemble_frame_from_inputs(inputs: FrameInputs<'_>) -> (PaneFrame, Vec<DiagEvent>) {
@@ -465,7 +458,7 @@ pub fn assemble_frame_from_inputs(inputs: FrameInputs<'_>) -> (PaneFrame, Vec<Di
     )
 }
 
-pub(crate) fn resolve_session_focus(
+fn resolve_session_focus(
     session_focus: Option<&PaneId>,
     prior: Option<&PaneId>,
     client_viewed: &[PaneId],

--- a/crates/rimz/src/sidebar/frame/tests.rs
+++ b/crates/rimz/src/sidebar/frame/tests.rs
@@ -437,14 +437,20 @@ fn sidebar_pane_can_be_the_session_focus_register() {
 
 #[test]
 fn duplicate_pane_ids_keep_first_and_report_diagnostic() {
-    let (frame, diagnostics) = assemble_frame_with_diagnostics(
-        vec![
+    let (frame, diagnostics) = assemble_frame_from_inputs(FrameInputs {
+        panes: vec![
             pane("terminal_1", "tab_0", Some("zsh"), false),
             pane("terminal_1", "tab_0", Some("cargo build"), true),
         ],
-        7,
-        "rimz-test",
-    );
+        produced_at_ms: 7,
+        observed_at_ms: 7,
+        session_name: "rimz-test".to_owned(),
+        session_focus: None,
+        client_viewed: &[],
+        client_views: &[],
+        client_view_fresh: false,
+        prior: None,
+    });
 
     assert_eq!(frame.pane_states().count(), 1);
     assert_eq!(

--- a/crates/rimz/src/sidebar/fuse.rs
+++ b/crates/rimz/src/sidebar/fuse.rs
@@ -108,20 +108,6 @@ fn apply_fusion(
     fused
 }
 
-pub fn focus_intent_confirmed(
-    pulled: &SidebarSnapshot,
-    events: &EventStore,
-    intent: &FocusAnchor,
-    now_ms: u64,
-) -> bool {
-    focus_intent_confirmed_from(
-        &FocusObservation::from_snapshot(pulled),
-        events,
-        intent,
-        now_ms,
-    )
-}
-
 pub(crate) fn focus_intent_confirmed_from(
     pulled: &FocusObservation,
     events: &EventStore,
@@ -149,6 +135,21 @@ pub(crate) fn focus_intent_confirmed_from(
     });
 
     pulled_confirms || event_confirms
+}
+
+#[cfg(test)]
+fn focus_intent_confirmed(
+    pulled: &SidebarSnapshot,
+    events: &EventStore,
+    intent: &FocusAnchor,
+    now_ms: u64,
+) -> bool {
+    focus_intent_confirmed_from(
+        &FocusObservation::from_snapshot(pulled),
+        events,
+        intent,
+        now_ms,
+    )
 }
 
 fn snapshot_has_pane(snapshot: &SidebarSnapshot, pane_id: &crate::ids::PaneId) -> bool {

--- a/crates/rimz/src/sidebar/meter.rs
+++ b/crates/rimz/src/sidebar/meter.rs
@@ -17,16 +17,16 @@ use crate::lane::WorkLane;
 
 /// Lifecycle frames are pinned under 1KiB; a 100-agent burst folds about 100KiB,
 /// and warm unchanged logs fold zero bytes. Cold catch-up trips one tick only.
-pub(crate) const TICK_FOLD_BYTES_BUDGET: u64 = 256 * 1024;
+const TICK_FOLD_BYTES_BUDGET: u64 = 256 * 1024;
 /// Warm produce with fresh inputs is pinned at zero spawns; hot git sweeps burst
 /// once per diff-stats TTL rather than on consecutive ticks.
-pub(crate) const TICK_SPAWN_BUDGET: u64 = 32;
+const TICK_SPAWN_BUDGET: u64 = 32;
 /// Mux subprocess wait budget. Mux waits are accounted separately from
 /// in-process work.
-pub(crate) const TICK_MUX_WAIT_BUDGET_MS: u64 = 5_000;
+const TICK_MUX_WAIT_BUDGET_MS: u64 = 5_000;
 /// Consecutive over-budget ticks required before a diagnostic. The streak window
 /// filters one-off IO stalls like the health-alert and observer windows do.
-pub(crate) const TICK_BUDGET_BREACH_TICKS: u32 = 5;
+const TICK_BUDGET_BREACH_TICKS: u32 = 5;
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 struct TickSample {
     wall_ms: u64,

--- a/crates/rimz/src/sidebar/mod.rs
+++ b/crates/rimz/src/sidebar/mod.rs
@@ -289,27 +289,6 @@ pub fn fresh_sidebar_present(rt: &RuntimePaths) -> bool {
     !fresh_sidebar_instances(rt).is_empty()
 }
 
-/// True when a live sidebar holds an older instance id than `own_id`. UUIDv7
-/// ids sort by birth time, so the lowest id is the eldest. The eldest is the
-/// sole producer (it finds no elder); every younger renderer reads its
-/// published cache rather than running its own mux/git reads (see
-/// [`crate::sidebar`] module docs). The election trusts the same heartbeat TTL
-/// as the launch gate, so a just-SIGKILLed elder is honoured for at most one
-/// TTL before the next-eldest renderer takes over production.
-pub fn elder_sidebar_instance(
-    rt: &RuntimePaths,
-    own_id: &SidebarInstanceId,
-) -> Option<SidebarInstanceId> {
-    fresh_sidebar_instances(rt)
-        .into_iter()
-        .filter(|id| id.as_str() < own_id.as_str())
-        .min_by(|left, right| left.as_str().cmp(right.as_str()))
-}
-
-pub fn elder_sidebar_present(rt: &RuntimePaths, own_id: &SidebarInstanceId) -> bool {
-    elder_sidebar_instance(rt, own_id).is_some()
-}
-
 /// Process-local memo of the renderer's producer election.
 ///
 /// Heartbeats remain the liveness source and the snapshot single-flight remains

--- a/crates/rimz/src/sidebar/mod.rs
+++ b/crates/rimz/src/sidebar/mod.rs
@@ -233,7 +233,7 @@ pub const FRESH_PANE_GRACE: Duration = SIDEBAR_HEARTBEAT_TTL.saturating_mul(2);
 /// matching heartbeat is unlocated (no pane id). Attach folds this into the
 /// reconcile planner so an older generation is replaced
 /// add-before-close instead of protected as healthy.
-pub fn sidebar_liveness(
+fn sidebar_liveness(
     rt: &RuntimePaths,
     build: &str,
     mux: MuxName,

--- a/crates/rimz/src/sidebar/notify.rs
+++ b/crates/rimz/src/sidebar/notify.rs
@@ -34,7 +34,7 @@ pub struct Notification {
 }
 
 impl Notification {
-    pub fn agent_env(&self) -> String {
+    fn agent_env(&self) -> String {
         self.agents
             .iter()
             .map(|agent| agent.label.as_str())

--- a/crates/rimz/src/sidebar/produce/mod.rs
+++ b/crates/rimz/src/sidebar/produce/mod.rs
@@ -207,7 +207,7 @@ pub fn produce_snapshot_with_refresh(
 /// pane targets; they do not read group roots, spending, accounts, provider
 /// dashboards, or git facts, so this path pays one pane enumeration and stops
 /// there.
-pub fn produce_resolution_snapshot(
+fn produce_resolution_snapshot(
     cursor: &mut RollupCursor,
     state: &StatePaths,
     runtime: &RuntimePaths,

--- a/crates/rimz/src/sidebar/refresh/accounts.rs
+++ b/crates/rimz/src/sidebar/refresh/accounts.rs
@@ -1,7 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
-use std::sync::Mutex;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use std::time::Instant;
 
@@ -352,42 +350,14 @@ fn execute_account_probes(
         };
     }
     let started = Instant::now();
-    let lane = crate::lane::current();
     let jobs: Vec<_> = due_kinds.iter().cloned().collect();
-    let next = AtomicUsize::new(0);
     let worker_count = MAX_PARALLEL_ACCOUNT_PROBES.min(jobs.len());
-    let results = Mutex::new((0..jobs.len()).map(|_| None).collect::<Vec<_>>());
-    std::thread::scope(|scope| {
-        let workers: Vec<_> = (0..worker_count)
-            .map(|_| {
-                scope.spawn(|| {
-                    crate::lane::set(lane);
-                    loop {
-                        let index = next.fetch_add(1, Ordering::Relaxed);
-                        let Some(kind) = jobs.get(index) else {
-                            break;
-                        };
-                        let active = active_version_kinds.contains(kind);
-                        let Some(result) = probe(kind, active) else {
-                            continue;
-                        };
-                        if let Ok(mut results) = results.lock() {
-                            results[index] = Some(result);
-                        }
-                    }
-                })
-            })
-            .collect();
-        for worker in workers {
-            let _ = worker.join();
-        }
-    });
-    let mut results: Vec<_> = results
-        .into_inner()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .into_iter()
-        .flatten()
-        .collect();
+    let mut results: Vec<_> = super::runner::bounded_map(worker_count, &jobs, |kind| {
+        probe(kind, active_version_kinds.contains(kind))
+    })
+    .into_iter()
+    .flatten()
+    .collect();
     results.sort_by(|left, right| left.kind.cmp(&right.kind));
     ProbeBatch {
         results,
@@ -562,10 +532,7 @@ fn active_version_probe_kinds(snapshot: &SidebarSnapshot) -> BTreeSet<String> {
 /// Read the producer's published account cache, or an empty cache on a cold,
 /// corrupt, or old-schema file. Read-only and fork-free.
 pub(crate) fn read_accounts_cache(path: &Path) -> AccountsCache {
-    std::fs::read(path)
-        .ok()
-        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
-        .unwrap_or_default()
+    super::runner::read_json_cache(path)
 }
 
 /// Publish the probed account cache atomically so readers never observe a
@@ -584,7 +551,7 @@ pub(super) fn write_accounts_cache(path: &Path, cache: &AccountsCache) {
 #[cfg(test)]
 mod tests {
     use std::path::Path;
-    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Barrier, Mutex};
 
     use jiff::Timestamp;

--- a/crates/rimz/src/sidebar/refresh/accounts.rs
+++ b/crates/rimz/src/sidebar/refresh/accounts.rs
@@ -94,7 +94,7 @@ impl ProviderStatus {
 /// Resolve provider accounts for the producer behind a process-wide
 /// single-flight. Fresh providers ride their own timestamps; only due kinds
 /// fork, and the winner merges those records into the shared cache.
-pub(crate) fn produce_accounts(
+pub(super) fn produce_accounts(
     snapshot: &SidebarSnapshot,
     runtime: &RuntimePaths,
 ) -> BTreeMap<String, AgentAccount> {
@@ -197,7 +197,7 @@ fn query_provider_accounts_with(
     }
 }
 
-pub(crate) fn cached_accounts_for_snapshot(
+pub(in crate::sidebar) fn cached_accounts_for_snapshot(
     cache: AccountsCache,
     snapshot: &SidebarSnapshot,
 ) -> BTreeMap<String, AgentAccount> {
@@ -205,7 +205,7 @@ pub(crate) fn cached_accounts_for_snapshot(
 }
 
 /// Cheap scheduling hint from the already-published account cache.
-pub(crate) fn cached_account_usage_hint(
+pub(super) fn cached_account_usage_hint(
     runtime: &RuntimePaths,
     kind: &str,
 ) -> Option<crate::agents::AccountUsageIdentity> {
@@ -532,7 +532,7 @@ fn active_version_probe_kinds(snapshot: &SidebarSnapshot) -> BTreeSet<String> {
 
 /// Read the producer's published account cache, or an empty cache on a cold,
 /// corrupt, or old-schema file. Read-only and fork-free.
-pub(crate) fn read_accounts_cache(path: &Path) -> AccountsCache {
+pub(in crate::sidebar) fn read_accounts_cache(path: &Path) -> AccountsCache {
     super::runner::read_json_cache(path)
 }
 

--- a/crates/rimz/src/sidebar/refresh/accounts.rs
+++ b/crates/rimz/src/sidebar/refresh/accounts.rs
@@ -352,12 +352,13 @@ fn execute_account_probes(
     let started = Instant::now();
     let jobs: Vec<_> = due_kinds.iter().cloned().collect();
     let worker_count = MAX_PARALLEL_ACCOUNT_PROBES.min(jobs.len());
-    let mut results: Vec<_> = super::runner::bounded_map(worker_count, &jobs, |kind| {
-        probe(kind, active_version_kinds.contains(kind))
-    })
-    .into_iter()
-    .flatten()
-    .collect();
+    let mut results: Vec<_> =
+        super::runner::bounded_map(crate::lane::current(), worker_count, &jobs, |kind| {
+            probe(kind, active_version_kinds.contains(kind))
+        })
+        .into_iter()
+        .flatten()
+        .collect();
     results.sort_by(|left, right| left.kind.cmp(&right.kind));
     ProbeBatch {
         results,

--- a/crates/rimz/src/sidebar/refresh/cohort_spend.rs
+++ b/crates/rimz/src/sidebar/refresh/cohort_spend.rs
@@ -15,7 +15,7 @@ use crate::{RuntimePaths, StatePaths};
 
 use super::super::timing::COHORT_SPEND_TTL;
 
-pub const COHORT_SPEND_CACHE_VERSION: u32 = 2;
+pub(crate) const COHORT_SPEND_CACHE_VERSION: u32 = 2;
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct CohortSpendCache {

--- a/crates/rimz/src/sidebar/refresh/cohort_spend.rs
+++ b/crates/rimz/src/sidebar/refresh/cohort_spend.rs
@@ -15,7 +15,7 @@ use crate::{RuntimePaths, StatePaths};
 
 use super::super::timing::COHORT_SPEND_TTL;
 
-pub(crate) const COHORT_SPEND_CACHE_VERSION: u32 = 2;
+pub(in crate::sidebar) const COHORT_SPEND_CACHE_VERSION: u32 = 2;
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct CohortSpendCache {
@@ -43,7 +43,7 @@ fn cache_due(cache: &CohortSpendCache, now_ms: u64) -> bool {
         || now_ms.saturating_sub(cache.refreshed_at_ms) > COHORT_SPEND_TTL.as_millis() as u64
 }
 
-pub(crate) fn refresh_cohort_spend_for(
+pub(super) fn refresh_cohort_spend_for(
     snapshot: &SidebarSnapshot,
     state: &StatePaths,
     runtime: &RuntimePaths,

--- a/crates/rimz/src/sidebar/refresh/credits.rs
+++ b/crates/rimz/src/sidebar/refresh/credits.rs
@@ -20,13 +20,13 @@ use crate::store::snapshot::{SidebarSnapshot, format_plan_label};
 
 /// Shared provider extra-credits cache, keyed by agent kind.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-pub(crate) struct CreditsCache {
+pub(super) struct CreditsCache {
     pub refreshed_at_ms: u64,
     pub entries: BTreeMap<String, ProviderCreditsEntry>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
-pub(crate) struct ProviderCreditsEntry {
+pub(super) struct ProviderCreditsEntry {
     #[serde(default)]
     pub scope: ProviderAccountScope,
     pub observed_at_ms: u64,
@@ -195,7 +195,7 @@ fn fill_missing_display_fields(entry: &mut ProviderCreditsEntry, prior: &Provide
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct DirectQueryClaim {
+pub(super) struct DirectQueryClaim {
     pub nonce: Uuid,
     pub claimed_at_ms: u64,
     pub requested_scope: ProviderAccountScope,
@@ -214,11 +214,11 @@ pub(super) struct AccountUsageCompletion {
     pub account_changed: bool,
 }
 
-pub(crate) fn read_credits_cache(path: &Path) -> CreditsCache {
+pub(super) fn read_credits_cache(path: &Path) -> CreditsCache {
     super::runner::read_json_cache(path)
 }
 
-pub(crate) fn write_credits_cache(path: &Path, cache: &CreditsCache) {
+pub(super) fn write_credits_cache(path: &Path, cache: &CreditsCache) {
     if let Err(err) = crate::store::atomic::write_temp_then_rename_cache(path, cache) {
         tracing::warn!(
             path = %path.display(),
@@ -557,7 +557,7 @@ fn entry_is_displayable(entry: &ProviderCreditsEntry, now_ms: u64) -> bool {
         && now_ms.saturating_sub(entry.observed_at_ms) <= CREDITS_DISPLAY_MAX_AGE.as_millis() as u64
 }
 
-pub(crate) fn apply_credits_cache(
+pub(in crate::sidebar) fn apply_credits_cache(
     snapshot: &mut SidebarSnapshot,
     runtime: &RuntimePaths,
     accounts: &AccountsConfig,

--- a/crates/rimz/src/sidebar/refresh/credits.rs
+++ b/crates/rimz/src/sidebar/refresh/credits.rs
@@ -20,13 +20,13 @@ use crate::store::snapshot::{SidebarSnapshot, format_plan_label};
 
 /// Shared provider extra-credits cache, keyed by agent kind.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-pub struct CreditsCache {
+pub(crate) struct CreditsCache {
     pub refreshed_at_ms: u64,
     pub entries: BTreeMap<String, ProviderCreditsEntry>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ProviderCreditsEntry {
+pub(crate) struct ProviderCreditsEntry {
     #[serde(default)]
     pub scope: ProviderAccountScope,
     pub observed_at_ms: u64,
@@ -60,7 +60,7 @@ pub struct ProviderCreditsEntry {
 
 impl ProviderCreditsEntry {
     /// Complete one matching account-usage claim without I/O or clock reads.
-    pub(crate) fn complete_account_usage(
+    pub(super) fn complete_account_usage(
         self,
         nonce: Uuid,
         probe: AccountUsageProbe,
@@ -195,7 +195,7 @@ fn fill_missing_display_fields(entry: &mut ProviderCreditsEntry, prior: &Provide
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DirectQueryClaim {
+pub(crate) struct DirectQueryClaim {
     pub nonce: Uuid,
     pub claimed_at_ms: u64,
     pub requested_scope: ProviderAccountScope,
@@ -208,7 +208,7 @@ pub struct DirectQueryClaim {
 }
 
 #[derive(Debug)]
-pub struct AccountUsageCompletion {
+pub(super) struct AccountUsageCompletion {
     pub identity: AccountUsageIdentity,
     pub snapshot: Option<AccountUsageSnapshot>,
     pub account_changed: bool,
@@ -230,24 +230,6 @@ pub(crate) fn write_credits_cache(path: &Path, cache: &CreditsCache) {
             "sidebar credits cache write failed",
         );
     }
-}
-
-/// Merge one provider's paid-usage reading into the shared cache. Best-effort:
-/// another producer may win the lock first, and the next due helper converges.
-pub fn merge_provider_credits(
-    runtime: &RuntimePaths,
-    kind: &str,
-    extra_credits: Option<ExtraCredits>,
-) {
-    merge_provider_realtime_usage(
-        runtime,
-        kind,
-        ProviderAccountScope::KindWide,
-        AccountUsageSnapshot {
-            extra_credits,
-            ..Default::default()
-        },
-    );
 }
 
 pub fn merge_provider_realtime_usage(
@@ -273,7 +255,7 @@ pub fn merge_provider_realtime_usage(
 }
 
 /// Claim one due direct account-usage read under the shared credits lock.
-pub fn claim_provider_account_usage(
+pub(super) fn claim_provider_account_usage(
     runtime: &RuntimePaths,
     kind: &str,
     cached_hint: Option<AccountUsageIdentity>,
@@ -361,7 +343,7 @@ fn cache_derived_claim_identity(
     hint
 }
 
-pub fn account_usage_claim_matches(runtime: &RuntimePaths, kind: &str, nonce: Uuid) -> bool {
+pub(super) fn account_usage_claim_matches(runtime: &RuntimePaths, kind: &str, nonce: Uuid) -> bool {
     read_credits_cache(&runtime.shared_credits_path())
         .entries
         .get(kind)
@@ -371,7 +353,7 @@ pub fn account_usage_claim_matches(runtime: &RuntimePaths, kind: &str, nonce: Uu
 
 /// Renew the matching live direct-query lease immediately before direct
 /// provider work. A replaced claim or contended credits lock cannot be renewed.
-pub(crate) fn renew_provider_account_usage_claim(
+pub(super) fn renew_provider_account_usage_claim(
     runtime: &RuntimePaths,
     kind: &str,
     nonce: Uuid,
@@ -408,7 +390,7 @@ fn renew_provider_account_usage_claim_at(
     true
 }
 
-pub fn cancel_provider_account_usage_claim(
+pub(super) fn cancel_provider_account_usage_claim(
     runtime: &RuntimePaths,
     kind: &str,
     nonce: Uuid,
@@ -434,7 +416,7 @@ pub fn cancel_provider_account_usage_claim(
     true
 }
 
-pub fn complete_provider_account_usage(
+pub(super) fn complete_provider_account_usage(
     runtime: &RuntimePaths,
     kind: &str,
     nonce: Uuid,
@@ -465,7 +447,7 @@ fn account_usage_credit_fields(
     (plan, extra_credits, reset_credits)
 }
 
-pub(crate) fn merge_provider_credits_entry(
+pub(super) fn merge_provider_credits_entry(
     runtime: &RuntimePaths,
     kind: &str,
     entry: ProviderCreditsEntry,
@@ -514,7 +496,7 @@ pub(crate) fn merge_provider_credits_entry(
     write_credits_cache(&path, &cache);
 }
 
-pub fn invalidate_oauth_read(runtime: &RuntimePaths, kind: &str) {
+pub(super) fn invalidate_oauth_read(runtime: &RuntimePaths, kind: &str) {
     let path = runtime.shared_credits_path();
     let Some(_guard) =
         crate::store::lock::WorkspaceLock::try_acquire(&runtime.shared_credits_lock())

--- a/crates/rimz/src/sidebar/refresh/credits.rs
+++ b/crates/rimz/src/sidebar/refresh/credits.rs
@@ -215,10 +215,7 @@ pub(super) struct AccountUsageCompletion {
 }
 
 pub(crate) fn read_credits_cache(path: &Path) -> CreditsCache {
-    std::fs::read(path)
-        .ok()
-        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
-        .unwrap_or_default()
+    super::runner::read_json_cache(path)
 }
 
 pub(crate) fn write_credits_cache(path: &Path, cache: &CreditsCache) {

--- a/crates/rimz/src/sidebar/refresh/daemon_reap.rs
+++ b/crates/rimz/src/sidebar/refresh/daemon_reap.rs
@@ -25,11 +25,11 @@ pub struct CodexDaemonReap {
     pub loaded: Option<BTreeSet<String>>,
 }
 
-pub(crate) fn codex_daemon_reap_path(runtime: &RuntimePaths) -> PathBuf {
+pub(in crate::sidebar) fn codex_daemon_reap_path(runtime: &RuntimePaths) -> PathBuf {
     runtime.root.join("codex-daemon-reap.json")
 }
 
-pub(crate) fn write_codex_daemon_reap(
+pub(in crate::sidebar) fn write_codex_daemon_reap(
     runtime: &RuntimePaths,
     cache: &CodexDaemonReap,
 ) -> crate::store::atomic::Result<()> {
@@ -41,7 +41,7 @@ pub fn read_codex_daemon_reap(runtime: &RuntimePaths) -> Option<CodexDaemonReap>
     serde_json::from_slice(&bytes).ok()
 }
 
-pub(crate) fn daemon_reap_due(cache: &Option<CodexDaemonReap>, now_ms: u64) -> bool {
+fn daemon_reap_due(cache: &Option<CodexDaemonReap>, now_ms: u64) -> bool {
     cache.as_ref().is_none_or(|cache| {
         now_ms.saturating_sub(cache.produced_at_ms) > CODEX_DAEMON_REAP_TTL.as_millis() as u64
     })
@@ -56,7 +56,7 @@ fn should_probe_codex_daemon_reap(agents: &[AgentState], codex_rc_enabled: bool)
         })
 }
 
-pub(crate) fn refresh_codex_daemon_reap_cache(
+pub(super) fn refresh_codex_daemon_reap_cache(
     agents: &[AgentState],
     runtime: &RuntimePaths,
     now_ms: u64,

--- a/crates/rimz/src/sidebar/refresh/daemon_reap.rs
+++ b/crates/rimz/src/sidebar/refresh/daemon_reap.rs
@@ -29,7 +29,7 @@ pub(crate) fn codex_daemon_reap_path(runtime: &RuntimePaths) -> PathBuf {
     runtime.root.join("codex-daemon-reap.json")
 }
 
-pub fn write_codex_daemon_reap(
+pub(crate) fn write_codex_daemon_reap(
     runtime: &RuntimePaths,
     cache: &CodexDaemonReap,
 ) -> crate::store::atomic::Result<()> {

--- a/crates/rimz/src/sidebar/refresh/git_stats.rs
+++ b/crates/rimz/src/sidebar/refresh/git_stats.rs
@@ -230,10 +230,6 @@ pub(crate) fn refresh_diff_stats_for(
 /// stabler than any one row's cwd: a root-keyed pod's rows can sit in
 /// different subdirs of one checkout. A non-path key (`branch:…`, the
 /// `external` catch-all) falls back to the rows' shared path.
-pub(crate) fn worktree_group_path(group: &SidebarWorktreeGroup) -> Option<&str> {
-    worktree_group_path_fields(&group.key, &group.rows)
-}
-
 pub(crate) fn worktree_group_path_fields<'a>(
     key: &'a str,
     rows: &'a [crate::store::snapshot::SidebarRow],
@@ -269,7 +265,7 @@ pub(crate) fn needed_worktree_paths(snapshot: &SidebarSnapshot) -> Vec<String> {
 /// worktree marker whose name matches the lane label before they inherit that
 /// checkout's git story.
 pub(crate) fn git_backed_worktree_path(group: &SidebarWorktreeGroup) -> Option<String> {
-    let path = worktree_group_path(group)?;
+    let path = worktree_group_path_fields(&group.key, &group.rows)?;
     if !Path::new(path).is_dir() {
         return None;
     }

--- a/crates/rimz/src/sidebar/refresh/git_stats.rs
+++ b/crates/rimz/src/sidebar/refresh/git_stats.rs
@@ -500,13 +500,18 @@ fn refresh_entries(
     if paths.is_empty() {
         return Vec::new();
     }
-    super::runner::bounded_map(MAX_PARALLEL_GIT, paths, |(path, due)| {
-        let prior = cache.entries.get(path.as_str()).cloned();
-        let prior_memo = prior_memos.get(path.as_str()).cloned().unwrap_or_default();
-        let (entry, memo) =
-            refresh_entry_with_memo(path, prior.as_ref(), *due, configured_trunk, &prior_memo);
-        (path.clone(), entry, memo)
-    })
+    super::runner::bounded_map(
+        crate::lane::current(),
+        MAX_PARALLEL_GIT,
+        paths,
+        |(path, due)| {
+            let prior = cache.entries.get(path.as_str()).cloned();
+            let prior_memo = prior_memos.get(path.as_str()).cloned().unwrap_or_default();
+            let (entry, memo) =
+                refresh_entry_with_memo(path, prior.as_ref(), *due, configured_trunk, &prior_memo);
+            (path.clone(), entry, memo)
+        },
+    )
 }
 
 /// Produce a merged diff-stats entry for one worktree path. The trunk and

--- a/crates/rimz/src/sidebar/refresh/git_stats.rs
+++ b/crates/rimz/src/sidebar/refresh/git_stats.rs
@@ -182,7 +182,7 @@ impl DiffStatsCacheEntry {
 /// Whether `branch` names this repository's trunk checkout. `main` remains a
 /// trunk name even when the repository resolves a different configured or
 /// remote-default trunk.
-pub(crate) fn is_trunk_branch(branch: &str, trunk: Option<&str>) -> bool {
+pub(in crate::sidebar) fn is_trunk_branch(branch: &str, trunk: Option<&str>) -> bool {
     branch == "main"
         || trunk.map(|trunk| trunk.strip_prefix("origin/").unwrap_or(trunk)) == Some(branch)
 }
@@ -195,7 +195,7 @@ pub fn read_diff_stats_cache(path: &Path) -> DiffStatsCache {
 /// producer's job — consumers and the fetch worker project the published cache
 /// without reaching here. `configured_trunk` is the per-machine `[sidebar] trunk`
 /// preference the trunk ladder tries first.
-pub(crate) fn refresh_diff_stats_for(
+pub(super) fn refresh_diff_stats_for(
     snapshot: &SidebarSnapshot,
     runtime: &crate::RuntimePaths,
     configured_trunk: Option<&str>,
@@ -226,7 +226,7 @@ pub(crate) fn refresh_diff_stats_for(
 /// stabler than any one row's cwd: a root-keyed pod's rows can sit in
 /// different subdirs of one checkout. A non-path key (`branch:…`, the
 /// `external` catch-all) falls back to the rows' shared path.
-pub(crate) fn worktree_group_path_fields<'a>(
+pub(in crate::sidebar) fn worktree_group_path_fields<'a>(
     key: &'a str,
     rows: &'a [crate::store::snapshot::SidebarRow],
 ) -> Option<&'a str> {
@@ -243,7 +243,7 @@ pub(crate) fn worktree_group_path_fields<'a>(
 /// The live worktree paths this snapshot needs git facts for: a git-backed
 /// group whose recovered path is a live directory, de-duplicated so two
 /// branch-split groups for one dir share a single git read.
-pub(crate) fn needed_worktree_paths(snapshot: &SidebarSnapshot) -> Vec<String> {
+pub(in crate::sidebar) fn needed_worktree_paths(snapshot: &SidebarSnapshot) -> Vec<String> {
     let mut needed: Vec<String> = Vec::new();
     for group in &snapshot.worktree_groups {
         let Some(path) = git_backed_worktree_path(group) else {
@@ -260,7 +260,7 @@ pub(crate) fn needed_worktree_paths(snapshot: &SidebarSnapshot) -> Vec<String> {
 /// worktree groups trust their path; channel groups must carry the RimZ
 /// worktree marker whose name matches the lane label before they inherit that
 /// checkout's git story.
-pub(crate) fn git_backed_worktree_path(group: &SidebarWorktreeGroup) -> Option<String> {
+fn git_backed_worktree_path(group: &SidebarWorktreeGroup) -> Option<String> {
     let path = worktree_group_path_fields(&group.key, &group.rows)?;
     if !Path::new(path).is_dir() {
         return None;
@@ -282,7 +282,7 @@ fn is_worktree_channel(path: &str, label: &str) -> bool {
 }
 
 /// The worktree paths whose git facts refresh on the fast [`DIFF_STATS_TTL`].
-pub(crate) fn hot_worktree_paths(snapshot: &SidebarSnapshot) -> BTreeSet<String> {
+pub(in crate::sidebar) fn hot_worktree_paths(snapshot: &SidebarSnapshot) -> BTreeSet<String> {
     let window = SignedDuration::try_from(crate::sidebar::timing::GIT_ACTIVITY_WINDOW)
         .unwrap_or(SignedDuration::MAX);
     let mut hot = BTreeSet::new();
@@ -304,7 +304,7 @@ pub(crate) fn hot_worktree_paths(snapshot: &SidebarSnapshot) -> BTreeSet<String>
 
 /// The worktree paths whose edit-sensitive git facts refresh on the focused
 /// tier.
-pub(crate) fn focused_worktree_paths(snapshot: &SidebarSnapshot) -> BTreeSet<String> {
+pub(in crate::sidebar) fn focused_worktree_paths(snapshot: &SidebarSnapshot) -> BTreeSet<String> {
     let viewed: HashSet<&PaneId> = snapshot.viewed_panes.iter().collect();
     let mut focused = BTreeSet::new();
     for group in &snapshot.worktree_groups {

--- a/crates/rimz/src/sidebar/refresh/git_stats.rs
+++ b/crates/rimz/src/sidebar/refresh/git_stats.rs
@@ -8,7 +8,6 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, SystemTime};
 
 use jiff::SignedDuration;
@@ -189,10 +188,7 @@ pub(crate) fn is_trunk_branch(branch: &str, trunk: Option<&str>) -> bool {
 }
 
 pub fn read_diff_stats_cache(path: &Path) -> DiffStatsCache {
-    let Ok(bytes) = std::fs::read(path) else {
-        return DiffStatsCache::default();
-    };
-    serde_json::from_slice(&bytes).unwrap_or_default()
+    super::runner::read_json_cache(path)
 }
 
 /// Refresh the producer's per-worktree git facts. The git forks are the
@@ -504,44 +500,13 @@ fn refresh_entries(
     if paths.is_empty() {
         return Vec::new();
     }
-    let lane = crate::lane::current();
-    let next = AtomicUsize::new(0);
-    let workers = MAX_PARALLEL_GIT.min(paths.len());
-    let mut out = Vec::with_capacity(paths.len());
-    std::thread::scope(|scope| {
-        let handles: Vec<_> = (0..workers)
-            .map(|_| {
-                scope.spawn(|| {
-                    crate::lane::set(lane);
-                    let mut local = Vec::new();
-                    loop {
-                        let idx = next.fetch_add(1, Ordering::Relaxed);
-                        let Some((path, due)) = paths.get(idx) else {
-                            break;
-                        };
-                        let prior = cache.entries.get(path.as_str()).cloned();
-                        let prior_memo =
-                            prior_memos.get(path.as_str()).cloned().unwrap_or_default();
-                        let (entry, memo) = refresh_entry_with_memo(
-                            path,
-                            prior.as_ref(),
-                            *due,
-                            configured_trunk,
-                            &prior_memo,
-                        );
-                        local.push((path.clone(), entry, memo));
-                    }
-                    local
-                })
-            })
-            .collect();
-        for handle in handles {
-            if let Ok(local) = handle.join() {
-                out.extend(local);
-            }
-        }
-    });
-    out
+    super::runner::bounded_map(MAX_PARALLEL_GIT, paths, |(path, due)| {
+        let prior = cache.entries.get(path.as_str()).cloned();
+        let prior_memo = prior_memos.get(path.as_str()).cloned().unwrap_or_default();
+        let (entry, memo) =
+            refresh_entry_with_memo(path, prior.as_ref(), *due, configured_trunk, &prior_memo);
+        (path.clone(), entry, memo)
+    })
 }
 
 /// Produce a merged diff-stats entry for one worktree path. The trunk and

--- a/crates/rimz/src/sidebar/refresh/inputs.rs
+++ b/crates/rimz/src/sidebar/refresh/inputs.rs
@@ -1,0 +1,22 @@
+//! Producer-published files read by consumer folds.
+
+use std::path::PathBuf;
+
+use crate::RuntimePaths;
+
+pub(crate) fn published_lane_inputs(runtime: &RuntimePaths) -> [PathBuf; 8] {
+    [
+        runtime.diff_stats_path(),
+        runtime.cohort_spend_path(),
+        runtime.pr_state_path(),
+        runtime.shared_accounts_path(),
+        runtime.shared_rate_limits_path(),
+        runtime.shared_credits_path(),
+        runtime.shared_provider_spending_path(),
+        super::daemon_reap::codex_daemon_reap_path(runtime),
+    ]
+}
+
+pub(crate) fn is_workspace_spending_file(name: &str) -> bool {
+    name.starts_with("workspace-spending.") && name.ends_with(".json")
+}

--- a/crates/rimz/src/sidebar/refresh/inputs.rs
+++ b/crates/rimz/src/sidebar/refresh/inputs.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use crate::RuntimePaths;
 
-pub(crate) fn published_lane_inputs(runtime: &RuntimePaths) -> [PathBuf; 8] {
+pub(in crate::sidebar) fn published_lane_inputs(runtime: &RuntimePaths) -> [PathBuf; 8] {
     [
         runtime.diff_stats_path(),
         runtime.cohort_spend_path(),
@@ -17,6 +17,6 @@ pub(crate) fn published_lane_inputs(runtime: &RuntimePaths) -> [PathBuf; 8] {
     ]
 }
 
-pub(crate) fn is_workspace_spending_file(name: &str) -> bool {
+pub(in crate::sidebar) fn is_workspace_spending_file(name: &str) -> bool {
     name.starts_with("workspace-spending.") && name.ends_with(".json")
 }

--- a/crates/rimz/src/sidebar/refresh/live_spend.rs
+++ b/crates/rimz/src/sidebar/refresh/live_spend.rs
@@ -9,7 +9,7 @@ use crate::agents::spending::{
 use crate::store::snapshot::SidebarSnapshot;
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct LiveCardSpend {
+struct LiveCardSpend {
     pub(crate) session_keys: Vec<String>,
     pub(crate) cost_usd: f64,
 }
@@ -55,7 +55,7 @@ fn live_spend_addback(snapshot: &SidebarSnapshot, workspace: &WorkspaceSpendingC
 /// baseline keys. Rows without an absolute worktree path, a matching agent
 /// state, an absolute transcript path, or a finite cost are omitted so the
 /// overlay stays aligned with the workspace-scoped transcript tally.
-pub(crate) fn live_card_sessions(snapshot: &SidebarSnapshot) -> Vec<LiveCardSpend> {
+fn live_card_sessions(snapshot: &SidebarSnapshot) -> Vec<LiveCardSpend> {
     let scope = SpendScope::for_workspace(
         snapshot.project_root.as_deref(),
         &snapshot.worktree_roots,

--- a/crates/rimz/src/sidebar/refresh/mod.rs
+++ b/crates/rimz/src/sidebar/refresh/mod.rs
@@ -32,14 +32,13 @@ mod trace;
 pub mod usage;
 
 pub use accounts::{AccountsCache, ProviderRecord, ProviderStatus, query_provider_accounts};
-pub use credits::{
-    CreditsCache, DirectQueryClaim, ProviderCreditsEntry, merge_provider_credits,
-    merge_provider_realtime_usage,
-};
-pub use daemon_reap::{CodexDaemonReap, read_codex_daemon_reap, write_codex_daemon_reap};
+pub use credits::merge_provider_realtime_usage;
+#[cfg(test)]
+pub(crate) use daemon_reap::write_codex_daemon_reap;
+pub use daemon_reap::{CodexDaemonReap, read_codex_daemon_reap};
 pub use live_spend::{apply_live_day_spend, apply_live_today_spend};
 pub use pr::{PrLink, PrStateCache};
-pub use rate_limits::{drop_kind_rate_limits, merge_account_rate_limits};
+pub use rate_limits::merge_account_rate_limits;
 pub use sessions::{
     ForcedSessionRefresh, force_refresh_session_context, refresh_session_transcript_context,
     refresh_session_transcript_context_from_watch,

--- a/crates/rimz/src/sidebar/refresh/mod.rs
+++ b/crates/rimz/src/sidebar/refresh/mod.rs
@@ -24,9 +24,11 @@ pub mod credits;
 pub mod daemon_reap;
 mod git_refs;
 pub mod git_stats;
+pub(crate) mod inputs;
 pub mod live_spend;
 pub mod pr;
 pub mod rate_limits;
+mod runner;
 pub mod sessions;
 mod trace;
 pub mod usage;
@@ -166,9 +168,7 @@ fn sole_published_workspace_cache(runtime: &RuntimePaths) -> Option<WorkspaceSpe
         .filter(|path| {
             path.file_name()
                 .and_then(|name| name.to_str())
-                .is_some_and(|name| {
-                    name.starts_with("workspace-spending.") && name.ends_with(".json")
-                })
+                .is_some_and(inputs::is_workspace_spending_file)
         });
     let candidate = published.next()?;
     if published.next().is_some() {

--- a/crates/rimz/src/sidebar/refresh/mod.rs
+++ b/crates/rimz/src/sidebar/refresh/mod.rs
@@ -38,7 +38,7 @@ pub use credits::merge_provider_realtime_usage;
 pub use daemon_reap::{CodexDaemonReap, read_codex_daemon_reap};
 pub use live_spend::{apply_live_day_spend, apply_live_today_spend};
 pub use pr::{PrLink, PrStateCache};
-pub use rate_limits::merge_account_rate_limits;
+pub(crate) use rate_limits::merge_account_rate_limits;
 pub use sessions::{
     ForcedSessionRefresh, force_refresh_session_context, refresh_session_transcript_context,
     refresh_session_transcript_context_from_watch,
@@ -53,7 +53,7 @@ use self::cohort_spend::refresh_cohort_spend_for;
 use self::daemon_reap::refresh_codex_daemon_reap_cache;
 use self::git_stats::refresh_diff_stats_for;
 use self::pr::produce_pr_states;
-use self::rate_limits::apply_rate_limit_cache;
+use self::rate_limits::refresh_rate_limits;
 use self::sessions::refresh_live_sessions;
 use self::usage::refresh_account_usage;
 use super::enrich::{
@@ -239,7 +239,7 @@ pub fn refresh_heavy_lanes(
         // This scoped fold is not returned as the final snapshot.
         RemoteControlServerHealth::default(),
     );
-    apply_rate_limit_cache(&mut panels, runtime, true);
+    refresh_rate_limits(&mut panels, runtime);
     // `with_provider_aggregates` rebuilds panels with empty credit fields; the
     // scoped producer fold must reapply the shared cache before auto-redeem can
     // evaluate the already-known reset credits.

--- a/crates/rimz/src/sidebar/refresh/mod.rs
+++ b/crates/rimz/src/sidebar/refresh/mod.rs
@@ -35,8 +35,6 @@ pub mod usage;
 
 pub use accounts::{AccountsCache, ProviderRecord, ProviderStatus, query_provider_accounts};
 pub use credits::merge_provider_realtime_usage;
-#[cfg(test)]
-pub(crate) use daemon_reap::write_codex_daemon_reap;
 pub use daemon_reap::{CodexDaemonReap, read_codex_daemon_reap};
 pub use live_spend::{apply_live_day_spend, apply_live_today_spend};
 pub use pr::{PrLink, PrStateCache};

--- a/crates/rimz/src/sidebar/refresh/mod.rs
+++ b/crates/rimz/src/sidebar/refresh/mod.rs
@@ -107,7 +107,7 @@ fn compute_fleet_spending_via_service(
 }
 
 /// Read producer-published spending without opening transcript or cursor data.
-pub(crate) fn consumer_spending_caches(
+pub(super) fn consumer_spending_caches(
     runtime: &RuntimePaths,
     snapshot: &SidebarSnapshot,
 ) -> SpendingCaches {

--- a/crates/rimz/src/sidebar/refresh/pr.rs
+++ b/crates/rimz/src/sidebar/refresh/pr.rs
@@ -669,50 +669,40 @@ fn probe_due_repos(
         .iter()
         .filter(|(repo_key, _)| due.contains(*repo_key))
         .collect::<Vec<_>>();
-    for chunk in due_groups.chunks(MAX_PARALLEL_PR_PROBES) {
-        std::thread::scope(|scope| {
-            let handles = chunk
-                .iter()
-                .map(|(repo_key, group)| {
-                    scope.spawn(move || {
-                        probe_repo_group(repo_key, group, &prior.states, &prior.branch_ci)
-                    })
-                })
-                .collect::<Vec<_>>();
-            for handle in handles {
-                if let Ok(result) = handle.join() {
-                    for target in &result.targets {
-                        cache.states.remove(&target.path);
-                        cache.branch_ci.remove(&target.path);
-                        cache.head_seen.insert(
-                            target.path.clone(),
-                            target.head_sha.clone().unwrap_or_default(),
-                        );
-                        cache
-                            .path_repos
-                            .insert(target.path.clone(), target.repo_key.clone());
-                    }
-                    for (path, state) in result.states {
-                        cache.states.insert(path, state);
-                    }
-                    for (path, ci) in result.branch_ci {
-                        cache.branch_ci.insert(path, ci);
-                    }
-                    let repo_key = result.repo_key.clone();
-                    cache.repos.insert(
-                        repo_key.clone(),
-                        RepoProbe {
-                            refreshed_at_ms: now_ms,
-                            ok: result.ok,
-                            consecutive_failures: next_consecutive_failures(
-                                prior.repos.get(&repo_key),
-                                result.ok,
-                            ),
-                        },
-                    );
-                }
-            }
+    let results =
+        super::runner::bounded_map(MAX_PARALLEL_PR_PROBES, &due_groups, |(repo_key, group)| {
+            probe_repo_group(repo_key, group, &prior.states, &prior.branch_ci)
         });
+    for result in results {
+        for target in &result.targets {
+            cache.states.remove(&target.path);
+            cache.branch_ci.remove(&target.path);
+            cache.head_seen.insert(
+                target.path.clone(),
+                target.head_sha.clone().unwrap_or_default(),
+            );
+            cache
+                .path_repos
+                .insert(target.path.clone(), target.repo_key.clone());
+        }
+        for (path, state) in result.states {
+            cache.states.insert(path, state);
+        }
+        for (path, ci) in result.branch_ci {
+            cache.branch_ci.insert(path, ci);
+        }
+        let repo_key = result.repo_key.clone();
+        cache.repos.insert(
+            repo_key.clone(),
+            RepoProbe {
+                refreshed_at_ms: now_ms,
+                ok: result.ok,
+                consecutive_failures: next_consecutive_failures(
+                    prior.repos.get(&repo_key),
+                    result.ok,
+                ),
+            },
+        );
     }
     let active_repo_keys = active_repo_keys(&cache);
     cache
@@ -1163,10 +1153,7 @@ fn command_stdout(worktree: &Path, program: &str, args: &[&str]) -> Option<Strin
 }
 
 pub(crate) fn read_pr_state_cache(path: &Path) -> PrStateCache {
-    std::fs::read(path)
-        .ok()
-        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
-        .unwrap_or_default()
+    super::runner::read_json_cache(path)
 }
 
 fn write_pr_state_cache(path: &Path, cache: &PrStateCache) {

--- a/crates/rimz/src/sidebar/refresh/pr.rs
+++ b/crates/rimz/src/sidebar/refresh/pr.rs
@@ -39,16 +39,16 @@ pub struct PrStateCache {
     pub branch_ci: BTreeMap<String, WorktreePrCi>,
     /// Probe freshness by origin repo key.
     #[serde(default)]
-    pub(crate) repos: BTreeMap<String, RepoProbe>,
+    repos: BTreeMap<String, RepoProbe>,
     /// Last HEAD SHA observed when a worktree's repo was probed.
     #[serde(default)]
-    pub(crate) head_seen: BTreeMap<String, String>,
+    head_seen: BTreeMap<String, String>,
     /// Last repo classification seen for a worktree. Supported repos store
     /// their repo key; unsupported/undiscoverable paths store an empty marker.
     /// This preserves the no-fork fresh path: per-repo TTL can be evaluated
     /// before shelling out for branch/remote metadata.
     #[serde(default)]
-    pub(crate) path_repos: BTreeMap<String, String>,
+    path_repos: BTreeMap<String, String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -73,7 +73,7 @@ pub struct PrLink {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct RepoProbe {
+struct RepoProbe {
     pub refreshed_at_ms: u64,
     /// Whether the last repo probe completed without an infrastructure
     /// failure. A logged-in repo with no PR is a success and keeps an empty map.
@@ -147,7 +147,7 @@ fn pr_state_failure_ttl(consecutive_failures: u32, cap: Duration) -> Duration {
     Duration::from_millis(retry_ms.saturating_mul(factor).min(cap_ms))
 }
 
-pub(crate) fn produce_pr_states(
+pub(super) fn produce_pr_states(
     snapshot: &SidebarSnapshot,
     runtime: &RuntimePaths,
 ) -> PrStateCache {

--- a/crates/rimz/src/sidebar/refresh/pr.rs
+++ b/crates/rimz/src/sidebar/refresh/pr.rs
@@ -39,16 +39,16 @@ pub struct PrStateCache {
     pub branch_ci: BTreeMap<String, WorktreePrCi>,
     /// Probe freshness by origin repo key.
     #[serde(default)]
-    pub repos: BTreeMap<String, RepoProbe>,
+    pub(crate) repos: BTreeMap<String, RepoProbe>,
     /// Last HEAD SHA observed when a worktree's repo was probed.
     #[serde(default)]
-    pub head_seen: BTreeMap<String, String>,
+    pub(crate) head_seen: BTreeMap<String, String>,
     /// Last repo classification seen for a worktree. Supported repos store
     /// their repo key; unsupported/undiscoverable paths store an empty marker.
     /// This preserves the no-fork fresh path: per-repo TTL can be evaluated
     /// before shelling out for branch/remote metadata.
     #[serde(default)]
-    pub path_repos: BTreeMap<String, String>,
+    pub(crate) path_repos: BTreeMap<String, String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -73,7 +73,7 @@ pub struct PrLink {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RepoProbe {
+pub(crate) struct RepoProbe {
     pub refreshed_at_ms: u64,
     /// Whether the last repo probe completed without an infrastructure
     /// failure. A logged-in repo with no PR is a success and keeps an empty map.

--- a/crates/rimz/src/sidebar/refresh/pr.rs
+++ b/crates/rimz/src/sidebar/refresh/pr.rs
@@ -669,6 +669,8 @@ fn probe_due_repos(
         .iter()
         .filter(|(repo_key, _)| due.contains(*repo_key))
         .collect::<Vec<_>>();
+    // PR probes stay on `Other`: their gh/tea/git forks have never counted against
+    // the tick spawn budget in `meter.rs`, which is calibrated without them.
     let results = super::runner::bounded_map(
         crate::lane::WorkLane::Other,
         MAX_PARALLEL_PR_PROBES,

--- a/crates/rimz/src/sidebar/refresh/pr.rs
+++ b/crates/rimz/src/sidebar/refresh/pr.rs
@@ -669,10 +669,12 @@ fn probe_due_repos(
         .iter()
         .filter(|(repo_key, _)| due.contains(*repo_key))
         .collect::<Vec<_>>();
-    let results =
-        super::runner::bounded_map(MAX_PARALLEL_PR_PROBES, &due_groups, |(repo_key, group)| {
-            probe_repo_group(repo_key, group, &prior.states, &prior.branch_ci)
-        });
+    let results = super::runner::bounded_map(
+        crate::lane::WorkLane::Other,
+        MAX_PARALLEL_PR_PROBES,
+        &due_groups,
+        |(repo_key, group)| probe_repo_group(repo_key, group, &prior.states, &prior.branch_ci),
+    );
     for result in results {
         for target in &result.targets {
             cache.states.remove(&target.path);

--- a/crates/rimz/src/sidebar/refresh/rate_limits.rs
+++ b/crates/rimz/src/sidebar/refresh/rate_limits.rs
@@ -145,7 +145,7 @@ pub fn merge_account_rate_limits(
 /// Drop one provider kind's account-scoped windows after the local OAuth account
 /// key changes. The detached writer waits for normal producer contention; a
 /// real lock acquisition failure or absent kind is a no-op.
-pub fn drop_kind_rate_limits(runtime: &RuntimePaths, kind: &str) {
+pub(super) fn drop_kind_rate_limits(runtime: &RuntimePaths, kind: &str) {
     let path = runtime.shared_rate_limits_path();
     let Some(_guard) = acquire_rate_limits_cache_lock(
         &runtime.shared_rate_limits_lock(),
@@ -159,17 +159,6 @@ pub fn drop_kind_rate_limits(runtime: &RuntimePaths, kind: &str) {
     }
     cache.refreshed_at_ms = unix_now_ms();
     write_rate_limits_cache(&path, &cache);
-}
-
-/// Project a budget window's reset-to-max roll forward to `now`: the timestamp-
-/// aware refill the dashboard and the window-priming guard share. Before the
-/// reset the last-known (most-drained) reading stands unchanged; once `now`
-/// reaches the reset the window has refilled, so synthesize a full window (0%
-/// used) with its reset rolled its own `duration_mins` forward, so the countdown
-/// reads sensibly until a live reading overwrites it. A window with no reset, or
-/// no known duration to roll by, shows as-is.
-pub(crate) fn project_window(cached: RateLimitWindow, now: Timestamp) -> RateLimitWindow {
-    cached.projected_at(now)
 }
 
 /// Whether the cached account reading has aged past its longest freshness
@@ -482,7 +471,7 @@ fn apply_rate_limit_cache_with(
                 if cache_unknown || expired_named_quota {
                     unknown_idle_window(window)
                 } else {
-                    project_window(window, now)
+                    window.projected_at(now)
                 }
             })
             .collect();

--- a/crates/rimz/src/sidebar/refresh/rate_limits.rs
+++ b/crates/rimz/src/sidebar/refresh/rate_limits.rs
@@ -128,6 +128,7 @@ pub(crate) fn merge_account_rate_limits(
     let index = WindowIndex::new(prior_entry, windows.windows);
     let mut fused = Vec::with_capacity(index.live.len());
     let mut pending = Vec::new();
+    // Authoritative reads are complete snapshots: live-only keys prune omitted windows.
     for (key, live) in index.live {
         let (truth, refill) = fuse_window(
             index.prior.get(&key),
@@ -227,7 +228,10 @@ fn unknown_idle_window(cached: RateLimitWindow) -> RateLimitWindow {
 
 /// Project persisted account windows onto consumer panels without changing the
 /// shared cache, tracing fusion, confirming a refill, or forcing OAuth reads.
-pub(crate) fn apply_cached_rate_limits(snapshot: &mut SidebarSnapshot, runtime: &RuntimePaths) {
+pub(in crate::sidebar) fn apply_cached_rate_limits(
+    snapshot: &mut SidebarSnapshot,
+    runtime: &RuntimePaths,
+) {
     if snapshot.providers.is_empty() {
         return;
     }

--- a/crates/rimz/src/sidebar/refresh/rate_limits.rs
+++ b/crates/rimz/src/sidebar/refresh/rate_limits.rs
@@ -23,12 +23,12 @@ mod tests;
 /// same-epoch drop contested by stamped best-effort truth. Shorter, a single
 /// lagging or garbled sample could dip the bar; longer is needless lag on a real
 /// refill. Tuned against captured reset traces (see [`trace_rate_limits`]).
-pub(crate) const REFILL_CONFIRM_SECS: i64 = 120;
+const REFILL_CONFIRM_SECS: i64 = 120;
 /// Coarse backstop: a live candidate captured longer ago than this is ignored.
 /// Content-staleness is already caught upstream — the snapshot view drops a
 /// reading whose shortest applicable window has reset — so this only guards a
 /// wildly old reading slipping through.
-pub(crate) const LIVE_HORIZON_SECS: i64 = 6 * 3600;
+const LIVE_HORIZON_SECS: i64 = 6 * 3600;
 /// A later reset instant must beat the prior by more than this to count as a new
 /// window epoch; sub-second parse jitter between sessions never does.
 const RESET_ADVANCE_SECS: i64 = 60;
@@ -43,7 +43,7 @@ const REFILL_FLOOR_PCT: u8 = 25;
 /// Publish the rate-limit window cache for every tab to read, atomically so a
 /// reader never observes a half-written file. Best-effort: a write failure logs
 /// and leaves the prior cache in place.
-pub(crate) fn write_rate_limits_cache(path: &Path, cache: &RateLimitsCache) {
+fn write_rate_limits_cache(path: &Path, cache: &RateLimitsCache) {
     if let Err(err) = crate::store::atomic::write_temp_then_rename_cache(path, cache) {
         tracing::warn!(
             path = %path.display(),
@@ -51,6 +51,30 @@ pub(crate) fn write_rate_limits_cache(path: &Path, cache: &RateLimitsCache) {
             error = &err as &dyn std::error::Error,
             "sidebar rate-limits cache write failed",
         );
+    }
+}
+
+struct WindowIndex {
+    prior: BTreeMap<RateLimitWindowKey, RateLimitWindow>,
+    pending: BTreeMap<RateLimitWindowKey, PendingRefill>,
+    live: BTreeMap<RateLimitWindowKey, RateLimitWindow>,
+}
+
+impl WindowIndex {
+    fn new(prior: Option<&RateLimitCacheEntry>, live: Vec<RateLimitWindow>) -> Self {
+        let windows = prior.map_or(&[][..], |entry| entry.limits.windows.as_slice());
+        let refills = prior.map_or(&[][..], |entry| entry.pending.as_slice());
+        Self {
+            prior: BTreeMap::from_iter(windows.iter().map(|window| (window.key(), window.clone()))),
+            pending: BTreeMap::from_iter(
+                refills.iter().map(|refill| (refill.key(), refill.clone())),
+            ),
+            live: BTreeMap::from_iter(live.into_iter().map(|window| (window.key(), window))),
+        }
+    }
+
+    fn projection_keys(&self) -> BTreeSet<RateLimitWindowKey> {
+        self.live.keys().chain(self.prior.keys()).cloned().collect()
     }
 }
 
@@ -63,7 +87,7 @@ pub(crate) fn write_rate_limits_cache(path: &Path, cache: &RateLimitsCache) {
 /// section so an accepted OAuth observation is published before its five-minute
 /// attempt throttle advances. Used by the detached `rimz agents refresh-usage`
 /// helper, never on the per-tick path.
-pub fn merge_account_rate_limits(
+pub(crate) fn merge_account_rate_limits(
     runtime: &RuntimePaths,
     kind: &str,
     identity: AccountUsageIdentity,
@@ -101,27 +125,14 @@ pub fn merge_account_rate_limits(
         .unwrap_or(prior_fused);
     complete_omitted_duration_windows(prior_bound, &mut windows);
     let bound_limits = identity.account_key.is_some().then(|| windows.clone());
-    let prior: BTreeMap<RateLimitWindowKey, RateLimitWindow> = prior_fused
-        .iter()
-        .map(|window| (window.key(), window.clone()))
-        .collect();
-    let prior_pending: BTreeMap<RateLimitWindowKey, PendingRefill> = prior_entry
-        .into_iter()
-        .flat_map(|entry| entry.pending.iter())
-        .map(|pending| (pending.key(), pending.clone()))
-        .collect();
-    let live: BTreeMap<RateLimitWindowKey, RateLimitWindow> = windows
-        .windows
-        .into_iter()
-        .map(|window| (window.key(), window))
-        .collect();
-    let mut fused = Vec::with_capacity(live.len());
+    let index = WindowIndex::new(prior_entry, windows.windows);
+    let mut fused = Vec::with_capacity(index.live.len());
     let mut pending = Vec::new();
-    for (key, live) in live {
+    for (key, live) in index.live {
         let (truth, refill) = fuse_window(
-            prior.get(&key),
+            index.prior.get(&key),
             Some(&live),
-            prior_pending.get(&key),
+            index.pending.get(&key),
             observed_at,
             true,
         );
@@ -214,66 +225,44 @@ fn unknown_idle_window(cached: RateLimitWindow) -> RateLimitWindow {
     }
 }
 
-/// Fold the persisted account-scoped windows onto the resolved provider panels:
-/// a kind with no live reading this frame paints its last-known bars (projected
-/// through [`project_window`]'s reset-to-max rule) instead of an empty
-/// dashboard. Once the account freshness ceiling has reset with no live reading,
-/// the display switches all cached windows to unknown bars until a provider
-/// refresh succeeds. Reconciled per stable window identity, so each budget is
-/// carried forward independently while the cache remains current. On the producer
-/// (`persist`) the live readings are written back — and only the live ground
-/// truth, never the synthesized full or unknown windows — so budgets survive a
-/// session ending or going idle. The written cache tracks login: it is rebuilt
-/// from the panels alone, so a logged-out kind (no panel) drops out. A consumer
-/// reads the same cache but never writes it.
-pub(crate) fn apply_rate_limit_cache(
-    snapshot: &mut SidebarSnapshot,
-    runtime: &RuntimePaths,
-    persist: bool,
-) {
-    // No dashboard: nothing to project onto and nothing to fall back to. A
-    // consumer is done — the same idle-room gate the context/activity reads use.
-    // The producer must still reap the cache once *every* provider has logged
-    // out: with no surviving panel to rebuild from, the per-panel reap below
-    // never runs, so a stale cache would flash old budgets on a later re-login.
-    // The reap is a no-op on an already-empty cache, keeping a logged-out room
-    // off the per-tick write path.
+/// Project persisted account windows onto consumer panels without changing the
+/// shared cache, tracing fusion, confirming a refill, or forcing OAuth reads.
+pub(crate) fn apply_cached_rate_limits(snapshot: &mut SidebarSnapshot, runtime: &RuntimePaths) {
     if snapshot.providers.is_empty() {
-        if persist {
-            reset_logged_out_rate_limits_cache(runtime);
-        }
         return;
     }
+    let cached = read_rate_limits_cache(&runtime.shared_rate_limits_path());
+    let _ = project_rate_limits(snapshot, &cached, false, None);
+}
 
+/// Fuse live account windows into the shared cache and project producer panels.
+/// The cache is rebuilt from current panels, so a logged-out kind drops out.
+pub(super) fn refresh_rate_limits(snapshot: &mut SidebarSnapshot, runtime: &RuntimePaths) {
+    if snapshot.providers.is_empty() {
+        reset_logged_out_rate_limits_cache(runtime);
+        return;
+    }
     let path = runtime.shared_rate_limits_path();
-    if persist {
-        let reset_kinds = {
-            let Some(_guard) =
-                crate::store::lock::WorkspaceLock::try_acquire(&runtime.shared_rate_limits_lock())
-                    .ok()
-                    .flatten()
-            else {
-                let cached = read_rate_limits_cache(&path);
-                let _ = apply_rate_limit_cache_with(snapshot, &cached, false, None);
-                return;
-            };
-            let cached = read_rate_limits_cache(&path);
-            let trace = rate_limits_trace_path(runtime);
-            let (next, reset_kinds) =
-                apply_rate_limit_cache_with(snapshot, &cached, true, trace.as_deref());
-            if let Some(next) = next {
-                write_rate_limits_cache(&path, &next);
-            }
-            reset_kinds
+    let reset_kinds = {
+        let Some(_guard) =
+            crate::store::lock::WorkspaceLock::try_acquire(&runtime.shared_rate_limits_lock())
+                .ok()
+                .flatten()
+        else {
+            apply_cached_rate_limits(snapshot, runtime);
+            return;
         };
-        for kind in reset_kinds {
-            super::credits::invalidate_oauth_read(runtime, &kind);
+        let cached = read_rate_limits_cache(&path);
+        let trace = rate_limits_trace_path(runtime);
+        let (next, reset_kinds) = project_rate_limits(snapshot, &cached, true, trace.as_deref());
+        if let Some(next) = next {
+            write_rate_limits_cache(&path, &next);
         }
-        return;
+        reset_kinds
+    };
+    for kind in reset_kinds {
+        super::credits::invalidate_oauth_read(runtime, &kind);
     }
-
-    let cached = read_rate_limits_cache(&path);
-    let _ = apply_rate_limit_cache_with(snapshot, &cached, false, None);
 }
 
 /// Clear the published cache once every provider has logged out, so a later
@@ -363,10 +352,10 @@ fn complete_omitted_duration_windows(prior: &[RateLimitWindow], current: &mut Ag
     );
 }
 
-fn apply_rate_limit_cache_with(
+fn project_rate_limits(
     snapshot: &mut SidebarSnapshot,
     cached: &RateLimitsCache,
-    persist: bool,
+    producer: bool,
     trace: Option<&Path>,
 ) -> (Option<RateLimitsCache>, Vec<String>) {
     // The snapshot's single projection clock, so the idle-window reset
@@ -399,26 +388,7 @@ fn apply_rate_limit_cache_with(
             .or_else(|| prior_entry.map(|entry| entry.limits.windows.as_slice()))
             .unwrap_or_default();
         complete_omitted_duration_windows(prior_authoritative, &mut live_limits);
-        let live: BTreeMap<RateLimitWindowKey, RateLimitWindow> = live_limits
-            .windows
-            .into_iter()
-            .map(|window| (window.key(), window))
-            .collect();
-        let prev: BTreeMap<RateLimitWindowKey, RateLimitWindow> = prior_entry
-            .into_iter()
-            .flat_map(|entry| entry.limits.windows.iter())
-            .map(|window| (window.key(), window.clone()))
-            .collect();
-        let prev_pending: BTreeMap<RateLimitWindowKey, PendingRefill> = cached
-            .entries
-            .get(&panel.kind)
-            .filter(|entry| entry.scope == panel.account_scope)
-            .into_iter()
-            .flat_map(|entry| entry.pending.iter())
-            .map(|refill| (refill.key(), refill.clone()))
-            .collect();
-        let window_keys: BTreeSet<RateLimitWindowKey> =
-            live.keys().chain(prev.keys()).cloned().collect();
+        let index = WindowIndex::new(prior_entry, live_limits.windows);
 
         // Fuse each duration to its ground truth and carry or advance its
         // debounce marker. A live reading drives the fusion; absent one, the
@@ -426,33 +396,34 @@ fn apply_rate_limit_cache_with(
         let mut truth: BTreeMap<RateLimitWindowKey, RateLimitWindow> = BTreeMap::new();
         let mut pending: Vec<PendingRefill> = Vec::new();
         let mut kind_reset_advanced = false;
-        for key in &window_keys {
+        for key in index.projection_keys() {
             let (window, refill) = fuse_window(
-                prev.get(key),
-                live.get(key),
-                prev_pending.get(key),
+                index.prior.get(&key),
+                index.live.get(&key),
+                index.pending.get(&key),
                 now,
-                persist,
+                producer,
             );
             if let (Some(window), Some(path)) = (window.as_ref(), trace) {
-                trace_rate_limits(path, &panel.kind, live.get(key), window, now);
+                trace_rate_limits(path, &panel.kind, index.live.get(&key), window, now);
             }
             if let Some(window) = window {
-                if persist
-                    && prev
-                        .get(key)
+                if producer
+                    && index
+                        .prior
+                        .get(&key)
                         .is_some_and(|prev| reset_advanced(prev.resets_at, window.resets_at))
                 {
                     kind_reset_advanced = true;
                 }
-                truth.insert(key.clone(), window);
+                truth.insert(key, window);
             }
             if let Some(refill) = refill {
                 pending.push(refill);
             }
         }
-        let cache_unknown = live.is_empty() && longest_cached_window_expired(&truth, now);
-        if persist && !cache_unknown && kind_reset_advanced {
+        let cache_unknown = index.live.is_empty() && longest_cached_window_expired(&truth, now);
+        if producer && !cache_unknown && kind_reset_advanced {
             refresh_kinds.insert(panel.kind.clone());
         }
 
@@ -486,7 +457,7 @@ fn apply_rate_limit_cache_with(
         // the durable claim keeps the fetch itself single-flight, and completion
         // restamps the read on success and failure alike, so a provider that
         // stays unreachable falls back to ordinary throttling.
-        let display_unknown = persist
+        let display_unknown = producer
             && display
                 .iter()
                 .all(|window| window.used_percentage.is_none());
@@ -503,7 +474,7 @@ fn apply_rate_limit_cache_with(
         // Persist fused truth, including authoritative lifted rows, any in-flight
         // refill, and the open unknown episode's marker. Display-only reset
         // projections and unknown windows are recomputed each frame.
-        if persist && (!truth.is_empty() || !pending.is_empty() || unknown_since_ms.is_some()) {
+        if producer && (!truth.is_empty() || !pending.is_empty() || unknown_since_ms.is_some()) {
             let limits = AgentRateLimits {
                 windows: truth.values().cloned().collect(),
             };
@@ -533,7 +504,10 @@ fn apply_rate_limit_cache_with(
         }
     }
 
-    (persist.then_some(next), refresh_kinds.into_iter().collect())
+    (
+        producer.then_some(next),
+        refresh_kinds.into_iter().collect(),
+    )
 }
 
 /// Fuse one stable window identity's prior truth with this frame's live reading
@@ -557,7 +531,7 @@ fn apply_rate_limit_cache_with(
 ///
 /// `allow_confirm` is the producer flag — a consumer never lowers the bar on its
 /// own, it mirrors the producer's persisted truth.
-pub(crate) fn fuse_window(
+fn fuse_window(
     prior: Option<&RateLimitWindow>,
     live: Option<&RateLimitWindow>,
     pending: Option<&PendingRefill>,

--- a/crates/rimz/src/sidebar/refresh/rate_limits/tests.rs
+++ b/crates/rimz/src/sidebar/refresh/rate_limits/tests.rs
@@ -105,7 +105,7 @@ fn scoped_quota_windows_fuse_and_expire_independently() {
             ],
         )],
     );
-    apply_rate_limit_cache(&mut producer, &runtime, true);
+    refresh_rate_limits(&mut producer, &runtime);
     let cache = read_rate_limits_cache(&runtime.shared_rate_limits_path());
     assert_eq!(
         cache_window(
@@ -142,7 +142,7 @@ fn scoped_quota_windows_fuse_and_expire_independently() {
         ),
     );
     let mut consumer = snapshot_with_panels(workspace, vec![provider_panel("plugin", Vec::new())]);
-    apply_rate_limit_cache(&mut consumer, &runtime, false);
+    apply_cached_rate_limits(&mut consumer, &runtime);
     let build = consumer.providers[0]
         .windows
         .iter()
@@ -167,14 +167,14 @@ fn producer_persisted_windows_feed_idle_consumers() {
         workspace.clone(),
         vec![provider_panel("claude", vec![rl_window(60, Some(future))])],
     );
-    apply_rate_limit_cache(&mut producer, &runtime, true);
+    refresh_rate_limits(&mut producer, &runtime);
     let cache = read_rate_limits_cache(&runtime.shared_rate_limits_path());
     assert_eq!(
         cache_window(&cache, "claude", RateLimitWindowKey::Duration(Some(300))).used_percentage,
         Some(60)
     );
     let mut consumer = snapshot_with_panels(workspace, vec![provider_panel("claude", Vec::new())]);
-    apply_rate_limit_cache(&mut consumer, &runtime, false);
+    apply_cached_rate_limits(&mut consumer, &runtime);
     assert_eq!(consumer.providers[0].windows[0].used_percentage, Some(60));
 }
 
@@ -209,7 +209,7 @@ fn account_scope_isolates_cached_windows() {
     let mut matching = provider_panel("qwen", Vec::new());
     matching.account_scope = international.clone();
     let mut matching = snapshot_with_panels(workspace.clone(), vec![matching]);
-    apply_rate_limit_cache(&mut matching, &runtime, false);
+    apply_cached_rate_limits(&mut matching, &runtime);
     assert_eq!(
         matching.providers[0]
             .windows
@@ -221,7 +221,7 @@ fn account_scope_isolates_cached_windows() {
     let mut mismatched = provider_panel("qwen", Vec::new());
     mismatched.account_scope = china.clone();
     let mut mismatched = snapshot_with_panels(workspace.clone(), vec![mismatched]);
-    apply_rate_limit_cache(&mut mismatched, &runtime, false);
+    apply_cached_rate_limits(&mut mismatched, &runtime);
     assert!(mismatched.providers[0].windows.is_empty());
     assert_eq!(
         read_rate_limits_cache(&runtime.shared_rate_limits_path()).entries["qwen"].scope,
@@ -231,7 +231,7 @@ fn account_scope_isolates_cached_windows() {
     let mut switched = provider_panel("qwen", vec![rl_window_mins(55, None, 43_200)]);
     switched.account_scope = china.clone();
     let mut switched = snapshot_with_panels(workspace, vec![switched]);
-    apply_rate_limit_cache(&mut switched, &runtime, true);
+    refresh_rate_limits(&mut switched, &runtime);
     let cache = read_rate_limits_cache(&runtime.shared_rate_limits_path());
     assert_eq!(cache.entries["qwen"].scope, china);
     assert_eq!(cache.entries["qwen"].limits.windows.len(), 1);
@@ -285,7 +285,7 @@ fn reset_epoch_invalidates_oauth_usage_throttle() {
         workspace,
         vec![provider_panel("codex", vec![rl_window(1, Some(new_reset))])],
     );
-    apply_rate_limit_cache(&mut frame, &runtime, true);
+    refresh_rate_limits(&mut frame, &runtime);
 
     let credits =
         crate::sidebar::refresh::credits::read_credits_cache(&runtime.shared_credits_path());
@@ -336,7 +336,7 @@ fn unknown_display_forces_immediate_account_refresh() {
     seed_settled_credits(&runtime, "claude", 1_700_000_000_000);
 
     let mut frame = snapshot_with_panels(workspace, vec![provider_panel("claude", Vec::new())]);
-    apply_rate_limit_cache(&mut frame, &runtime, true);
+    refresh_rate_limits(&mut frame, &runtime);
 
     // The display went unknown, so the settled read is dropped and the next
     // claim is due immediately rather than an hour from now.
@@ -361,7 +361,7 @@ fn unknown_display_forces_refresh_once_per_episode() {
         workspace.clone(),
         vec![provider_panel("claude", Vec::new())],
     );
-    apply_rate_limit_cache(&mut first, &runtime, true);
+    refresh_rate_limits(&mut first, &runtime);
     assert_eq!(oauth_read_at_ms(&runtime, "claude"), 0);
     let forced_at = unknown_since_ms(&runtime, "claude").expect("episode marker");
 
@@ -370,7 +370,7 @@ fn unknown_display_forces_refresh_once_per_episode() {
     // with nothing to report costs one fetch rather than one per frame.
     seed_settled_credits(&runtime, "claude", 1_700_000_500_000);
     let mut second = snapshot_with_panels(workspace, vec![provider_panel("claude", Vec::new())]);
-    apply_rate_limit_cache(&mut second, &runtime, true);
+    refresh_rate_limits(&mut second, &runtime);
 
     assert_eq!(oauth_read_at_ms(&runtime, "claude"), 1_700_000_500_000);
     assert_eq!(unknown_since_ms(&runtime, "claude"), Some(forced_at));
@@ -388,7 +388,7 @@ fn usable_window_rearms_the_unknown_refresh() {
         workspace.clone(),
         vec![provider_panel("claude", Vec::new())],
     );
-    apply_rate_limit_cache(&mut unknown, &runtime, true);
+    refresh_rate_limits(&mut unknown, &runtime);
     assert!(unknown_since_ms(&runtime, "claude").is_some());
 
     // A live reading paints a real value again, closing the episode so the next
@@ -402,7 +402,7 @@ fn usable_window_rearms_the_unknown_refresh() {
             vec![rl_window_mins(35, Some(future), 300)],
         )],
     );
-    apply_rate_limit_cache(&mut known, &runtime, true);
+    refresh_rate_limits(&mut known, &runtime);
 
     assert_eq!(known.providers[0].windows[0].used_percentage, Some(35));
     assert_eq!(unknown_since_ms(&runtime, "claude"), None);
@@ -416,7 +416,7 @@ fn cold_start_without_cached_windows_forces_refresh() {
     // No rate-limit cache at all: nothing expires, so the aged-out path never
     // trips, yet the dashboard is just as blank.
     let mut frame = snapshot_with_panels(workspace, vec![provider_panel("claude", Vec::new())]);
-    apply_rate_limit_cache(&mut frame, &runtime, true);
+    refresh_rate_limits(&mut frame, &runtime);
 
     assert!(frame.providers[0].windows.is_empty());
     assert_eq!(oauth_read_at_ms(&runtime, "claude"), 0);
@@ -436,7 +436,7 @@ fn elapsed_short_idle_window_shows_full_without_persisting_projection() {
         ],
     );
     let mut idle = snapshot_with_panels(workspace, vec![provider_panel("claude", Vec::new())]);
-    apply_rate_limit_cache(&mut idle, &runtime, true);
+    refresh_rate_limits(&mut idle, &runtime);
     assert_eq!(idle.providers[0].windows[0].used_percentage, Some(0));
     assert_eq!(idle.providers[0].windows[1].used_percentage, Some(70));
 
@@ -459,7 +459,7 @@ fn elapsed_long_live_window_rolls_forward_without_persisting_projection() {
             ],
         )],
     );
-    apply_rate_limit_cache(&mut frame, &runtime, true);
+    refresh_rate_limits(&mut frame, &runtime);
     assert_eq!(frame.providers[0].windows[0].used_percentage, Some(40));
     assert_eq!(frame.providers[0].windows[1].used_percentage, Some(0));
     assert!(
@@ -484,7 +484,7 @@ fn elapsed_longest_idle_cache_shows_unknown_without_persisting_projection() {
         ],
     );
     let mut idle = snapshot_with_panels(workspace, vec![provider_panel("claude", Vec::new())]);
-    apply_rate_limit_cache(&mut idle, &runtime, true);
+    refresh_rate_limits(&mut idle, &runtime);
     let shown = &idle.providers[0].windows;
     assert!(
         shown
@@ -528,7 +528,7 @@ fn shortest_elapsed_undated_window_opens_unknown_refresh_episode() {
 
     let mut idle = snapshot_with_panels(workspace, vec![provider_panel("claude", Vec::new())]);
     idle.now = observed_at + SignedDuration::from_mins(301);
-    apply_rate_limit_cache(&mut idle, &runtime, true);
+    refresh_rate_limits(&mut idle, &runtime);
 
     assert!(
         idle.providers[0]
@@ -553,7 +553,7 @@ fn lone_undated_weekly_window_keeps_its_weeklong_ceiling() {
 
     let mut idle = snapshot_with_panels(workspace, vec![provider_panel("claude", Vec::new())]);
     idle.now = observed_at + SignedDuration::from_hours(6 * 24);
-    apply_rate_limit_cache(&mut idle, &runtime, true);
+    refresh_rate_limits(&mut idle, &runtime);
 
     assert_eq!(idle.providers[0].windows[0].used_percentage, Some(4));
     assert_eq!(unknown_since_ms(&runtime, "claude"), None);
@@ -592,7 +592,7 @@ fn dated_long_window_keeps_undated_lifted_window_cache_fresh() {
     );
 
     let mut idle = snapshot_with_panels(workspace, vec![provider_panel("codex", Vec::new())]);
-    apply_rate_limit_cache(&mut idle, &runtime, true);
+    refresh_rate_limits(&mut idle, &runtime);
 
     assert!(idle.providers[0].windows[0].lifted);
     assert_eq!(
@@ -616,24 +616,24 @@ fn producer_cache_tracks_logged_in_panels() {
             provider_panel("codex", vec![rl_window(30, Some(future))]),
         ],
     );
-    apply_rate_limit_cache(&mut seeded, &runtime, true);
+    refresh_rate_limits(&mut seeded, &runtime);
 
     let mut partial = snapshot_with_panels(
         workspace.clone(),
         vec![provider_panel("claude", vec![rl_window(40, Some(future))])],
     );
-    apply_rate_limit_cache(&mut partial, &runtime, true);
+    refresh_rate_limits(&mut partial, &runtime);
     let cache = read_rate_limits_cache(&runtime.shared_rate_limits_path());
     assert!(cache.entries.contains_key("claude"));
     assert!(!cache.entries.contains_key("codex"));
 
     let mut consumer = snapshot_with_panels(workspace.clone(), Vec::new());
-    apply_rate_limit_cache(&mut consumer, &runtime, false);
+    apply_cached_rate_limits(&mut consumer, &runtime);
     let cache = read_rate_limits_cache(&runtime.shared_rate_limits_path());
     assert!(cache.entries.contains_key("claude"));
 
     let mut producer = snapshot_with_panels(workspace, Vec::new());
-    apply_rate_limit_cache(&mut producer, &runtime, true);
+    refresh_rate_limits(&mut producer, &runtime);
     assert!(
         read_rate_limits_cache(&runtime.shared_rate_limits_path())
             .entries
@@ -698,7 +698,7 @@ fn account_merge_fuses_authoritative_drops_and_confirms_persistent_readings() {
             ],
         )],
     );
-    apply_rate_limit_cache(&mut producer, &runtime, true);
+    refresh_rate_limits(&mut producer, &runtime);
     let climbed = read_rate_limits_cache(&runtime.shared_rate_limits_path());
     assert_eq!(climbed.entries["claude"].account_key, identity.account_key);
     assert_eq!(
@@ -891,7 +891,7 @@ fn authoritative_account_identity_survives_publication_and_rotates_by_key() {
         vec![provider_panel("qwen", vec![rl_window_mins(10, None, 300)])],
     );
     snapshot.providers[0].account_scope = scope;
-    apply_rate_limit_cache(&mut snapshot, &runtime, true);
+    refresh_rate_limits(&mut snapshot, &runtime);
     let after_display_fusion = read_rate_limits_cache(&runtime.shared_rate_limits_path());
     assert_eq!(
         after_display_fusion.entries["qwen"].account_key.as_deref(),
@@ -992,7 +992,7 @@ fn omission_completion_requires_matching_authoritative_duration_truth() {
     let mut matching = provider_panel("pi", vec![weekly.clone()]);
     matching.account_scope = openai;
     let mut matching = snapshot_with_panels(workspace.clone(), vec![matching]);
-    apply_rate_limit_cache(&mut matching, &runtime, false);
+    apply_cached_rate_limits(&mut matching, &runtime);
     assert!(
         matching.providers[0]
             .windows
@@ -1003,7 +1003,7 @@ fn omission_completion_requires_matching_authoritative_duration_truth() {
     let mut mismatched = provider_panel("pi", vec![weekly]);
     mismatched.account_scope = ProviderAccountScope::sub_provider("anthropic", "oauth");
     let mut mismatched = snapshot_with_panels(workspace, vec![mismatched]);
-    apply_rate_limit_cache(&mut mismatched, &runtime, false);
+    apply_cached_rate_limits(&mut mismatched, &runtime);
     assert_eq!(mismatched.providers[0].windows.len(), 1);
     assert!(
         mismatched.providers[0]
@@ -1085,7 +1085,7 @@ fn producer_lock_contention_degrades_to_read_only() {
         workspace,
         vec![provider_panel("codex", vec![rl_window(55, None)])],
     );
-    apply_rate_limit_cache(&mut contending, &runtime, true);
+    refresh_rate_limits(&mut contending, &runtime);
     let cache = read_rate_limits_cache(&runtime.shared_rate_limits_path());
     assert_eq!(
         cache_window(&cache, "claude", RateLimitWindowKey::Duration(Some(300))).used_percentage,

--- a/crates/rimz/src/sidebar/refresh/runner.rs
+++ b/crates/rimz/src/sidebar/refresh/runner.rs
@@ -14,6 +14,7 @@ pub(super) fn read_json_cache<T: Default + DeserializeOwned>(path: &Path) -> T {
 }
 
 pub(super) fn bounded_map<T: Sync, R: Send>(
+    work_lane: crate::lane::WorkLane,
     max_workers: usize,
     items: &[T],
     map: impl Fn(&T) -> R + Sync,
@@ -21,7 +22,6 @@ pub(super) fn bounded_map<T: Sync, R: Send>(
     if items.is_empty() {
         return Vec::new();
     }
-    let lane = crate::lane::current();
     let next = AtomicUsize::new(0);
     let results = Mutex::new((0..items.len()).map(|_| None).collect::<Vec<_>>());
     std::thread::scope(|scope| {
@@ -29,7 +29,7 @@ pub(super) fn bounded_map<T: Sync, R: Send>(
         let handles = (0..workers)
             .map(|_| {
                 scope.spawn(|| {
-                    crate::lane::set(lane);
+                    crate::lane::set(work_lane);
                     loop {
                         let index = next.fetch_add(1, Ordering::Relaxed);
                         let Some(item) = items.get(index) else {

--- a/crates/rimz/src/sidebar/refresh/runner.rs
+++ b/crates/rimz/src/sidebar/refresh/runner.rs
@@ -1,0 +1,57 @@
+//! Shared mechanics for independent refresh-lane work.
+
+use std::path::Path;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use serde::de::DeserializeOwned;
+
+pub(super) fn read_json_cache<T: Default + DeserializeOwned>(path: &Path) -> T {
+    std::fs::read(path)
+        .ok()
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+        .unwrap_or_default()
+}
+
+pub(super) fn bounded_map<T: Sync, R: Send>(
+    max_workers: usize,
+    items: &[T],
+    map: impl Fn(&T) -> R + Sync,
+) -> Vec<R> {
+    if items.is_empty() {
+        return Vec::new();
+    }
+    let lane = crate::lane::current();
+    let next = AtomicUsize::new(0);
+    let results = Mutex::new((0..items.len()).map(|_| None).collect::<Vec<_>>());
+    std::thread::scope(|scope| {
+        let workers = max_workers.max(1).min(items.len());
+        let handles = (0..workers)
+            .map(|_| {
+                scope.spawn(|| {
+                    crate::lane::set(lane);
+                    loop {
+                        let index = next.fetch_add(1, Ordering::Relaxed);
+                        let Some(item) = items.get(index) else {
+                            break;
+                        };
+                        let result = map(item);
+                        results
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)[index] =
+                            Some(result);
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        for handle in handles {
+            let _ = handle.join();
+        }
+    });
+    results
+        .into_inner()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .into_iter()
+        .flatten()
+        .collect()
+}

--- a/crates/rimz/src/sidebar/refresh/sessions.rs
+++ b/crates/rimz/src/sidebar/refresh/sessions.rs
@@ -31,7 +31,7 @@ type SessionRefreshResult<T> = std::result::Result<T, crate::store::atomic::Atom
 /// producer. Inline transcript reads run first with their adapter stat gate;
 /// detached helpers run on a coarse per-session cadence for richer realtime
 /// channels.
-pub(crate) fn refresh_live_sessions(snapshot: &SidebarSnapshot, runtime: &RuntimePaths) {
+pub(super) fn refresh_live_sessions(snapshot: &SidebarSnapshot, runtime: &RuntimePaths) {
     for refresh in live_session_refreshes(snapshot) {
         refresh_session_transcript_context_with_snapshot(
             Some(snapshot),
@@ -334,13 +334,13 @@ fn codex_turn_death_retry_due(kind: &str, error: &AgentTurnError, now: Timestamp
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct LiveSessionRefresh {
+struct LiveSessionRefresh {
     pub kind: String,
     pub session_id: String,
     pub model_hint: Option<String>,
 }
 
-pub(crate) fn live_session_refreshes(snapshot: &SidebarSnapshot) -> Vec<LiveSessionRefresh> {
+fn live_session_refreshes(snapshot: &SidebarSnapshot) -> Vec<LiveSessionRefresh> {
     snapshot
         .agents
         .iter()
@@ -361,7 +361,7 @@ pub(crate) fn live_session_refreshes(snapshot: &SidebarSnapshot) -> Vec<LiveSess
 /// Throttle one session's detached context refresh via a marker file under the
 /// runtime root: skip when the last attempt is younger than the interval, touch
 /// it before spawning.
-pub(crate) fn session_probe_due(runtime: &RuntimePaths, kind: &str, session_id: &str) -> bool {
+fn session_probe_due(runtime: &RuntimePaths, kind: &str, session_id: &str) -> bool {
     let path = session_probe_marker(runtime, kind, session_id);
     let due = std::fs::metadata(&path)
         .and_then(|meta| meta.modified())
@@ -375,11 +375,7 @@ pub(crate) fn session_probe_due(runtime: &RuntimePaths, kind: &str, session_id: 
     due
 }
 
-pub(crate) fn session_probe_marker(
-    runtime: &RuntimePaths,
-    kind: &str,
-    session_id: &str,
-) -> PathBuf {
+fn session_probe_marker(runtime: &RuntimePaths, kind: &str, session_id: &str) -> PathBuf {
     let mut hasher = Sha256::new();
     hasher.update(b"session-context");
     hasher.update([0]);

--- a/crates/rimz/src/sidebar/refresh/usage.rs
+++ b/crates/rimz/src/sidebar/refresh/usage.rs
@@ -22,8 +22,9 @@ use super::credits::{
     complete_provider_account_usage, merge_provider_realtime_usage,
     renew_provider_account_usage_claim,
 };
+use super::rate_limits::drop_kind_rate_limits;
 use super::trace::{TraceEvent, duration_ms};
-use super::{drop_kind_rate_limits, merge_account_rate_limits, trace};
+use super::{merge_account_rate_limits, trace};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AccountUsageRefreshRequest {

--- a/crates/rimz/src/sidebar/refresh/usage.rs
+++ b/crates/rimz/src/sidebar/refresh/usage.rs
@@ -34,7 +34,7 @@ pub struct AccountUsageRefreshRequest {
 }
 
 /// Claim and spawn each metered provider's direct account-usage refresh.
-pub(crate) fn refresh_account_usage(snapshot: &SidebarSnapshot, runtime: &RuntimePaths) {
+pub(super) fn refresh_account_usage(snapshot: &SidebarSnapshot, runtime: &RuntimePaths) {
     refresh_account_usage_with(snapshot, runtime, spawn_usage_refresh);
 }
 

--- a/crates/rimz/src/sidebar/refresh/usage/tests.rs
+++ b/crates/rimz/src/sidebar/refresh/usage/tests.rs
@@ -317,7 +317,7 @@ fn authoritative_direct_completion_survives_live_session_exit() {
         runtime.workspace_id.clone(),
         vec![provider_panel("claude", Vec::new())],
     );
-    super::super::apply_rate_limit_cache(&mut idle, &runtime, false);
+    super::super::rate_limits::apply_cached_rate_limits(&mut idle, &runtime);
     assert_eq!(
         idle.providers[0]
             .windows

--- a/crates/rimz/src/sidebar/tests/mod.rs
+++ b/crates/rimz/src/sidebar/tests/mod.rs
@@ -237,14 +237,13 @@ fn younger_yields_to_live_elder_eldest_survives() {
     h.write_sidebar_for(&elder);
     h.write_sidebar_for(&middle);
     h.write_sidebar_for(&younger);
+    let younger_tracker = ProducerElectionTracker::new(h.runtime.clone(), younger);
+    let elder_tracker = ProducerElectionTracker::new(h.runtime.clone(), elder.clone());
+    let now = SystemTime::now();
     // The younger sees an older live instance and yields; the eldest finds no
     // elder and stays, so exactly one survives.
-    assert!(elder_sidebar_present(&h.runtime, &younger));
-    assert_eq!(
-        elder_sidebar_instance(&h.runtime, &younger),
-        Some(elder.clone())
-    );
-    assert!(!elder_sidebar_present(&h.runtime, &elder));
+    assert_eq!(younger_tracker.elder_instance_at(now), Some(elder.clone()));
+    assert_eq!(elder_tracker.elder_instance_at(now), None);
 }
 
 #[test]
@@ -379,7 +378,9 @@ fn no_elder_when_alone() {
     let h = Harness::new();
     let only = instance("05");
     h.write_sidebar_for(&only);
-    assert!(!elder_sidebar_present(&h.runtime, &only));
+    let tracker = ProducerElectionTracker::new(h.runtime.clone(), only);
+    let now = SystemTime::now();
+    assert_eq!(tracker.elder_instance_at(now), None);
 }
 
 #[test]
@@ -392,7 +393,9 @@ fn stale_or_wrong_protocol_elder_is_not_honored() {
     make_stale(&h.write_sidebar_for(&stale_elder));
     // A wrong-protocol lower id is not a peer we hand off to.
     h.write_sidebar("sidebar.0000000000000008.json", "rimz.plugin.v0");
-    assert!(!elder_sidebar_present(&h.runtime, &younger));
+    let tracker = ProducerElectionTracker::new(h.runtime.clone(), younger);
+    let now = SystemTime::now();
+    assert_eq!(tracker.elder_instance_at(now), None);
 }
 
 #[test]

--- a/crates/rimz/src/sidebar/workspace_projection/tests.rs
+++ b/crates/rimz/src/sidebar/workspace_projection/tests.rs
@@ -3,7 +3,7 @@ use jiff::Timestamp;
 use super::*;
 use crate::agents::AgentStatus;
 use crate::ids::WorkspaceId;
-use crate::sidebar::consumer::{ConsumerSnapshotSource, PublishedSnapshotReader};
+use crate::sidebar::consumer::PublishedSnapshotReader;
 use crate::sidebar::enrich::{FoldOpts, enrich_workspace};
 use crate::store::snapshot::SidebarSnapshot;
 
@@ -214,9 +214,7 @@ fn quiet_time_transition_republishes_and_reaches_a_cached_adopter() {
     );
     let mut reader = PublishedSnapshotReader::new(runtime.clone(), "rimz-test", None);
     let first = reader.read_adopting(&state).unwrap();
-    assert_eq!(first.source, ConsumerSnapshotSource::Adoption);
-    assert_eq!(status(&first.snapshot), Some(AgentStatus::Running));
-    let slim_before = crate::sidebar::consumer::consumer_projection_inputs_stamp(&state, &runtime);
+    assert_eq!(status(&first), Some(AgentStatus::Running));
 
     assert_eq!(
         publisher
@@ -225,12 +223,6 @@ fn quiet_time_transition_republishes_and_reaches_a_cached_adopter() {
         WorkspaceProjectionPublish::Published,
         "the skipped projection clock still changes its serialized verdict",
     );
-    assert_ne!(
-        crate::sidebar::consumer::consumer_projection_inputs_stamp(&state, &runtime),
-        slim_before,
-        "the slim memo notices an unchanged-source content publication",
-    );
     let second = reader.read_adopting(&state).unwrap();
-    assert_eq!(second.source, ConsumerSnapshotSource::Adoption);
-    assert_eq!(status(&second.snapshot), Some(AgentStatus::Failed));
+    assert_eq!(status(&second), Some(AgentStatus::Failed));
 }

--- a/crates/rimz/src/sidebar_pane/app.rs
+++ b/crates/rimz/src/sidebar_pane/app.rs
@@ -569,6 +569,7 @@ fn spawn_pane_focus(
                 &session_name,
                 &pane_id,
                 nonce,
+                Default::default(),
             ) {
                 Ok(true) => (Some(nonce), "accepted_unconfirmed", None),
                 Ok(false) => (

--- a/crates/rimz/src/sidebar_pane/app/fetch.rs
+++ b/crates/rimz/src/sidebar_pane/app/fetch.rs
@@ -1,10 +1,11 @@
 //! The off-thread fetch machinery: the two-speed fetch cycle (the in-process
 //! consumer fast lane plus the elder's in-process produce, sharing one warm
 //! [`PublishedSnapshotReader`]), and its single-flight request coalescing.
-//! `FetchWorker` owns cadence, election, memoization, notification state, and
-//! typed result publication. Everything here runs on a worker thread so the
-//! render/input loop never blocks on pane production; heavy git/spend/account
-//! refreshes run on the cache refresher.
+//! `FetchWorker` owns cadence, election, request coalescing, notification state,
+//! and typed result publication; the reader owns consumer fold memoization.
+//! Everything here runs on a worker thread so the render/input loop never
+//! blocks on pane production; heavy git/spend/account refreshes run on the
+//! cache refresher.
 
 use std::collections::HashMap;
 use std::os::unix::net::UnixDatagram;
@@ -16,9 +17,7 @@ use crate::config::NotificationsPrefs;
 use crate::diag::record::TickLoop;
 use crate::ids::{PaneId, SidebarInstanceId};
 use crate::sidebar::ProducerElectionTracker;
-use crate::sidebar::consumer::{
-    ConsumerFoldInputsStamp, ConsumerSnapshotSource, PublishedSnapshotReader, RollupCursor,
-};
+use crate::sidebar::consumer::{PublishedSnapshotReader, RollupCursor};
 use crate::sidebar::events::SidebarEvent;
 use crate::sidebar::meter::TickMeter;
 use crate::sidebar::notify::{LinkAlert, LinkNotificationState, Notification, NotificationState};
@@ -193,38 +192,6 @@ impl FetchUpdate {
 /// single-flight loser wait was shorter than a `list-panes`, so every loser
 /// timed out into its own uncached produce). A lone renderer is its own
 /// next-eldest, so it still self-heals through the producer branch.
-const CONSUMER_UNCHANGED_BACKSTOP_MS: u64 = 30_000;
-
-#[derive(Default)]
-struct ConsumerFoldMemo {
-    last_ok: Option<(ConsumerFoldInputsStamp, u64, bool)>,
-}
-
-impl ConsumerFoldMemo {
-    fn should_skip(&self, stamp: &ConsumerFoldInputsStamp, now_ms: u64) -> bool {
-        self.last_ok
-            .as_ref()
-            .is_some_and(|(last, folded_at_ms, _)| {
-                last == stamp
-                    && now_ms.saturating_sub(*folded_at_ms) < CONSUMER_UNCHANGED_BACKSTOP_MS
-            })
-    }
-
-    fn record(&mut self, stamp: ConsumerFoldInputsStamp, at_ms: u64, adopted: bool) {
-        self.last_ok = Some((stamp, at_ms, adopted));
-    }
-
-    fn last_was_adoption(&self) -> bool {
-        self.last_ok
-            .as_ref()
-            .is_some_and(|(_, _, adopted)| *adopted)
-    }
-
-    fn clear(&mut self) {
-        self.last_ok = None;
-    }
-}
-
 /// Decides whether a cycle pays the produce from cheap pre-reads. The producer
 /// runs on a hard refresh, on a producer-only topology refresh, or when the
 /// published frame outlived one data tick (`None` age = no usable frame — cold
@@ -325,7 +292,6 @@ struct FetchWorker {
     diag: crate::diag::DiagSink,
     election: ProducerElectionTracker,
     reader: PublishedSnapshotReader,
-    consumer_memo: ConsumerFoldMemo,
     producer_cadence: ProducerCadence,
     notifications: NotificationState,
     link_notifications: LinkNotificationState,
@@ -340,9 +306,6 @@ struct FastFold {
     role: FetchRole,
     produce: bool,
     pane_frame: PaneFrame,
-    stamp: Option<ConsumerFoldInputsStamp>,
-    now_ms: u64,
-    adopted: bool,
 }
 
 impl FetchWorker {
@@ -366,7 +329,6 @@ impl FetchWorker {
             diag,
             election,
             reader,
-            consumer_memo: ConsumerFoldMemo::default(),
             producer_cadence: ProducerCadence::default(),
             notifications: NotificationState::default(),
             link_notifications: LinkNotificationState::default(),
@@ -382,57 +344,37 @@ impl FetchWorker {
         let now_ms = crate::sidebar::timing::unix_now_ms();
         let frame_stamps =
             crate::sidebar::cache::published_frame_stamps(&self.runtime, &self.config.session_name);
-        let last_was_adoption = self.consumer_memo.last_was_adoption();
-        let mut fold_stamp = consumer_stamp_recordable(request, role.is_producer()).then(|| {
-            if last_was_adoption {
-                self.reader.projection_inputs_stamp(state)
-            } else {
-                self.reader.inputs_stamp(state)
-            }
-        });
-        if self.consumer_fold_unchanged(request, role, fold_stamp.as_ref(), now_ms) {
+        let recordable = consumer_stamp_recordable(request, role.is_producer());
+        let unchanged = recordable && self.reader.fold_unchanged(state, now_ms);
+        if consumer_stamp_skippable(request, role.is_producer()) && unchanged {
             sink.publish(FetchUpdate::Unchanged { role });
             return;
         }
 
-        let (fast, adopted) = if role.is_producer() {
-            (self.read_and_publish_workspace(state), false)
+        let fast = if role.is_producer() {
+            self.read_and_publish_workspace(state)
         } else {
-            match self.reader.read_adopting(state) {
-                Ok(read) => (
-                    Ok(read.snapshot),
-                    read.source == ConsumerSnapshotSource::Adoption,
-                ),
-                Err(err) => (Err(err), false),
-            }
+            self.reader.read_adopting(state)
         };
-        if consumer_stamp_recordable(request, role.is_producer()) && adopted != last_was_adoption {
-            fold_stamp = Some(if adopted {
-                self.reader.projection_inputs_stamp(state)
-            } else {
-                self.reader.inputs_stamp(state)
-            });
-        }
         let produce = self.start_produce_if_due(request, role, frame_stamps, &fast, now_ms);
         let pane_frame = fast_pane_frame(request, frame_stamps, &fast);
-        let folded_consumer_ok = self.publish_fast_fold(
+        let fast_fold_ok = self.publish_fast_fold(
             state,
             FastFold {
                 result: fast,
                 role,
                 produce,
                 pane_frame,
-                stamp: fold_stamp.take(),
-                now_ms,
-                adopted,
             },
             sink,
         );
+        if fast_fold_ok && recordable {
+            self.reader.record_fold(state, now_ms);
+        } else {
+            self.reader.clear_fold();
+        }
         if produce {
             self.publish_produced_fold(state, request, role, sink);
-        }
-        if !folded_consumer_ok {
-            self.consumer_memo.clear();
         }
     }
 
@@ -469,17 +411,6 @@ impl FetchWorker {
             frame.as_deref(),
             self.config.own_pane.as_ref(),
         ))
-    }
-
-    fn consumer_fold_unchanged(
-        &self,
-        request: FetchRequest,
-        role: FetchRole,
-        stamp: Option<&ConsumerFoldInputsStamp>,
-        now_ms: u64,
-    ) -> bool {
-        consumer_stamp_skippable(request, role.is_producer())
-            && stamp.is_some_and(|stamp| self.consumer_memo.should_skip(stamp, now_ms))
     }
 
     fn start_produce_if_due(
@@ -530,11 +461,7 @@ impl FetchWorker {
                     },
                     sink,
                 );
-                if let Some(stamp) = fold.stamp {
-                    self.consumer_memo.record(stamp, fold.now_ms, fold.adopted);
-                    return true;
-                }
-                false
+                true
             }
             Err(err) if !fold.produce => {
                 sink.publish(FetchUpdate::Failed {

--- a/crates/rimz/src/sidebar_pane/app/fetch.rs
+++ b/crates/rimz/src/sidebar_pane/app/fetch.rs
@@ -156,42 +156,6 @@ impl FetchUpdate {
     }
 }
 
-/// One fetch cycle, posting one or two outcomes. Runs on the fetch worker
-/// thread, keeping the produce's `list-panes` + git round-trips off the
-/// render/input loop so animation never stalls on it. `state` is resolved per
-/// cycle by the worker loop, so a `workspace migrate` lands without a restart.
-///
-/// **Fast lane (every cycle, producer and consumer alike):** fold the
-/// event-fresh store rollup over the published pane frame entirely in process
-/// ([`crate::sidebar::consumer::read_published_snapshot`]) — no `list-panes`,
-/// no git. This is the paint that lands a status flip or a cost update within
-/// one wakeup, in single-digit milliseconds — and it runs even over an aged
-/// pane frame, so a dead producer stales only pane *presence* while status
-/// keeps flowing. On cold start, before any usable frame exists, this still
-/// returns a frameless rollup snapshot so startup waits do not read as refresh
-/// failures; the produce below recovers the pane frame.
-///
-/// **Produce lane (the elder's reconciliation):**
-/// [`crate::sidebar::produce::produce_snapshot`] runs in process on this same
-/// worker — same thread, same warm cursor as the fast lane, so the rollup
-/// fold stays O(new log bytes) and promotion to producer is warm by
-/// construction. It refreshes pane truth and roots, then publishes the shared
-/// frame every other tab reads. One producer per
-/// workspace — the eldest live instance — and on it the produce is gated to
-/// the data tick: a store-delta storm paints per delta but produces at most
-/// once per tick. Heavy git/spend/account lanes are refreshed by the elder's
-/// cache refresher and projected here, so this worker stays responsible for
-/// pane truth, roots, notifications, and publish order. Topology freshness is
-/// producer-only: consumers wait for the
-/// producer's `PaneFramePublished` event and fold the new cache without
-/// locally producing. Only a hard refresh (reload/manual recovery) lets a
-/// consumer produce. Stale-frame recovery belongs to the election, not the
-/// consumers — a dead elder's heartbeat ages out within one TTL and the
-/// next-eldest *becomes* the producer, so a wedged producer costs one handoff,
-/// never an every-consumer produce storm (the old self-heal, whose
-/// single-flight loser wait was shorter than a `list-panes`, so every loser
-/// timed out into its own uncached produce). A lone renderer is its own
-/// next-eldest, so it still self-heals through the producer branch.
 /// Decides whether a cycle pays the produce from cheap pre-reads. The producer
 /// runs on a hard refresh, on a producer-only topology refresh, or when the
 /// published frame outlived one data tick (`None` age = no usable frame — cold
@@ -339,6 +303,42 @@ impl FetchWorker {
         }
     }
 
+    /// One fetch cycle, posting one or two outcomes. Runs on the fetch worker
+    /// thread, keeping the produce's `list-panes` + git round-trips off the
+    /// render/input loop so animation never stalls on it. `state` is resolved per
+    /// cycle by the worker loop, so a `workspace migrate` lands without a restart.
+    ///
+    /// **Fast lane (every cycle, producer and consumer alike):** fold the
+    /// event-fresh store rollup over the published pane frame entirely in process
+    /// ([`crate::sidebar::consumer::read_published_snapshot`]) — no `list-panes`,
+    /// no git. This is the paint that lands a status flip or a cost update within
+    /// one wakeup, in single-digit milliseconds — and it runs even over an aged
+    /// pane frame, so a dead producer stales only pane *presence* while status
+    /// keeps flowing. On cold start, before any usable frame exists, this still
+    /// returns a frameless rollup snapshot so startup waits do not read as refresh
+    /// failures; the produce below recovers the pane frame.
+    ///
+    /// **Produce lane (the elder's reconciliation):**
+    /// [`crate::sidebar::produce::produce_snapshot`] runs in process on this same
+    /// worker — same thread, same warm cursor as the fast lane, so the rollup
+    /// fold stays O(new log bytes) and promotion to producer is warm by
+    /// construction. It refreshes pane truth and roots, then publishes the shared
+    /// frame every other tab reads. One producer per
+    /// workspace — the eldest live instance — and on it the produce is gated to
+    /// the data tick: a store-delta storm paints per delta but produces at most
+    /// once per tick. Heavy git/spend/account lanes are refreshed by the elder's
+    /// cache refresher and projected here, so this worker stays responsible for
+    /// pane truth, roots, notifications, and publish order. Topology freshness is
+    /// producer-only: consumers wait for the
+    /// producer's `PaneFramePublished` event and fold the new cache without
+    /// locally producing. Only a hard refresh (reload/manual recovery) lets a
+    /// consumer produce. Stale-frame recovery belongs to the election, not the
+    /// consumers — a dead elder's heartbeat ages out within one TTL and the
+    /// next-eldest *becomes* the producer, so a wedged producer costs one handoff,
+    /// never an every-consumer produce storm (the old self-heal, whose
+    /// single-flight loser wait was shorter than a `list-panes`, so every loser
+    /// timed out into its own uncached produce). A lone renderer is its own
+    /// next-eldest, so it still self-heals through the producer branch.
     fn run_cycle(&mut self, state: &StatePaths, request: FetchRequest, sink: &mut ResultSink) {
         let role = self.observe_role();
         let now_ms = crate::sidebar::timing::unix_now_ms();

--- a/crates/rimz/src/sidebar_pane/app/fetch/tests.rs
+++ b/crates/rimz/src/sidebar_pane/app/fetch/tests.rs
@@ -630,6 +630,52 @@ fn unchanged_consumer_inputs_skip_the_second_fold() {
 }
 
 #[test]
+fn failed_consumer_fold_clears_warm_unchanged_memo() {
+    let fixture = ConsumerFixture::new();
+    fixture.write_pane_frame();
+    let mut rollup = SidebarSnapshot::build(
+        fixture.workspace_id.clone(),
+        Vec::new(),
+        jiff::Timestamp::now(),
+    );
+    rollup.reflects_log = Some(crate::store::event_log::LogExtent {
+        generation: 0,
+        offset: 0,
+    });
+    std::fs::write(
+        &fixture.state.latest_snapshot,
+        serde_json::to_vec(&rollup).unwrap(),
+    )
+    .unwrap();
+    let mut worker = fixture.worker();
+
+    assert!(matches!(
+        fixture.run_with(FetchRequest::default(), &mut worker)[0],
+        FetchUpdate::Snapshot { .. }
+    ));
+    assert!(matches!(
+        fixture.run_with(FetchRequest::default(), &mut worker)[0],
+        FetchUpdate::Unchanged { .. }
+    ));
+
+    std::fs::create_dir_all(&fixture.state.events_log).unwrap();
+    assert!(matches!(
+        fixture.run_with(FetchRequest::default(), &mut worker)[0],
+        FetchUpdate::Failed { .. }
+    ));
+    std::fs::remove_dir_all(&fixture.state.events_log).unwrap();
+
+    assert!(matches!(
+        fixture.run_with(FetchRequest::default(), &mut worker)[0],
+        FetchUpdate::Snapshot { .. }
+    ));
+    assert!(matches!(
+        fixture.run_with(FetchRequest::default(), &mut worker)[0],
+        FetchUpdate::Unchanged { .. }
+    ));
+}
+
+#[test]
 fn producer_fast_fold_publishes_workspace_content_without_a_pane_refresh() {
     let fixture = ConsumerFixture::new();
     fixture.write_pane_frame();
@@ -715,7 +761,6 @@ fn adopted_consumer_uses_slim_stamp_until_truth_moves() {
         fixture.run_with(FetchRequest::default(), &mut worker)[0],
         FetchUpdate::Snapshot { .. }
     ));
-    assert!(worker.consumer_memo.last_was_adoption());
 
     std::fs::write(fixture.runtime.diff_stats_path(), b"producer-owned-change").unwrap();
     assert!(matches!(
@@ -735,10 +780,22 @@ fn adopted_consumer_uses_slim_stamp_until_truth_moves() {
         fixture.run_with(FetchRequest::default(), &mut worker)[0],
         FetchUpdate::Snapshot { .. }
     ));
+    std::fs::write(
+        fixture.runtime.diff_stats_path(),
+        b"fallback-owned-change-with-longer-content",
+    )
+    .unwrap();
     assert!(
-        !worker.consumer_memo.last_was_adoption(),
-        "a stale projection falls back and restores the full stamp"
+        matches!(
+            fixture.run_with(FetchRequest::default(), &mut worker)[0],
+            FetchUpdate::Snapshot { .. }
+        ),
+        "fallback restores full-stamp invalidation",
     );
+    assert!(matches!(
+        fixture.run_with(FetchRequest::default(), &mut worker)[0],
+        FetchUpdate::Unchanged { .. }
+    ));
 }
 
 #[test]

--- a/docs/internals/sidebar/sidebar.md
+++ b/docs/internals/sidebar/sidebar.md
@@ -57,7 +57,7 @@ The contract types are [`view.rs`](../../../crates/rimz/src/store/snapshot/view.
 | module | owns |
 |---|---|
 | [`app.rs`](../../../crates/rimz/src/sidebar_pane/app.rs), [`app/loop_state.rs`](../../../crates/rimz/src/sidebar_pane/app/loop_state.rs) | the fixed-timestep serve loop and its wakeup dispatch |
-| [`app/fetch.rs`](../../../crates/rimz/src/sidebar_pane/app/fetch.rs) | the off-thread fetch worker: cadence, election, memoization, and single-flight coalescing ([state.md](./state.md#one-fetch-cycle)) |
+| [`app/fetch.rs`](../../../crates/rimz/src/sidebar_pane/app/fetch.rs) | the off-thread fetch worker: cadence, election, request coalescing, notification state, and publication ([state.md](./state.md#one-fetch-cycle)) |
 | [`app/selection.rs`](../../../crates/rimz/src/sidebar_pane/app/selection.rs) | the identity-keyed highlight, the browse layer, and the key and mouse handlers |
 | [`app/gate.rs`](../../../crates/rimz/src/sidebar_pane/app/gate.rs) | the last-resort hold that refuses a regressive frame |
 | [`app/health.rs`](../../../crates/rimz/src/sidebar_pane/app/health.rs) | failure debounce, the sticky alert, and the give-up rule |

--- a/docs/internals/sidebar/state.md
+++ b/docs/internals/sidebar/state.md
@@ -54,7 +54,7 @@ Reading and folding:
 
 | Module | What it owns |
 | --- | --- |
-| [`consumer.rs`](../../../crates/rimz/src/sidebar/consumer.rs) | The consumer read: event-fresh rollup over the published pane frame, projection adoption, and the fold-skip input stamps. |
+| [`consumer.rs`](../../../crates/rimz/src/sidebar/consumer.rs) | The consumer read: event-fresh rollup over the published pane frame, projection adoption, fold-skip input stamps, and memo lifecycle. |
 | [`enrich.rs`](../../../crates/rimz/src/sidebar/enrich.rs) | The ordered fold spine both producer and consumer run, so the two paths cannot drift. |
 | [`frame.rs`](../../../crates/rimz/src/sidebar/frame.rs) | `PaneFrame`, the typed pane topology the producer publishes. |
 | [`cache.rs`](../../../crates/rimz/src/sidebar/cache.rs) | The pane-frame cache read, its freshness verdict, and the presence and topology hint files. |

--- a/docs/internals/sidebar/state.md
+++ b/docs/internals/sidebar/state.md
@@ -64,7 +64,7 @@ Producing and publishing, all producer-only:
 | Module | What it owns |
 | --- | --- |
 | [`produce/`](../../../crates/rimz/src/sidebar/produce/mod.rs) | The producer read. `panes.rs` assembles and publishes the pane frame behind a single flight, `metrics.rs` samples per-pane `/proc`, `git.rs` enumerates worktree roots. |
-| [`refresh/`](../../../crates/rimz/src/sidebar/refresh/mod.rs) | The heavy lanes, each self-gated on its own TTL: `git_stats.rs`, `pr.rs`, `accounts.rs`, `usage.rs`, `credits.rs`, `rate_limits.rs`, `sessions.rs`, `live_spend.rs`, `cohort_spend.rs`, `daemon_reap.rs`. `git_refs.rs` reads ref files in process to skip a `git` fork, and `trace.rs` is the opt-in account-refresh timing trace. |
+| [`refresh/`](../../../crates/rimz/src/sidebar/refresh/mod.rs) | The heavy lanes, each self-gated on its own TTL: `git_stats.rs`, `pr.rs`, `accounts.rs`, `usage.rs`, `credits.rs`, `rate_limits.rs`, `sessions.rs`, `live_spend.rs`, `cohort_spend.rs`, `daemon_reap.rs`. `runner.rs` shares bounded worker and cache-read mechanics, `inputs.rs` lists consumer-fold cache inputs, `git_refs.rs` reads ref files in process to skip a `git` fork, and `trace.rs` is the opt-in account-refresh timing trace. |
 | [`workspace_projection.rs`](../../../crates/rimz/src/sidebar/workspace_projection.rs) | The renderer-independent fold publication and the consumer's adoption check. |
 | [`agent_projection.rs`](../../../crates/rimz/src/sidebar/agent_projection.rs) | Published adapter wiring and provider-local session discovery. |
 

--- a/refactor-target.toml
+++ b/refactor-target.toml
@@ -453,7 +453,7 @@ allowed-imports = [
     "workspace",
     "worktree",
 ]
-surface-budget = 481
+surface-budget = 479
 
 [[module]]
 path = "crates/rimz/src/sidebar_pane"

--- a/refactor-target.toml
+++ b/refactor-target.toml
@@ -453,7 +453,7 @@ allowed-imports = [
     "workspace",
     "worktree",
 ]
-surface-budget = 530
+surface-budget = 482
 
 [[module]]
 path = "crates/rimz/src/sidebar_pane"

--- a/refactor-target.toml
+++ b/refactor-target.toml
@@ -453,7 +453,7 @@ allowed-imports = [
     "workspace",
     "worktree",
 ]
-surface-budget = 482
+surface-budget = 481
 
 [[module]]
 path = "crates/rimz/src/sidebar_pane"

--- a/refactor-target.toml
+++ b/refactor-target.toml
@@ -453,7 +453,7 @@ allowed-imports = [
     "workspace",
     "worktree",
 ]
-surface-budget = 479
+surface-budget = 476
 
 [[module]]
 path = "crates/rimz/src/sidebar_pane"

--- a/refactor-target.toml
+++ b/refactor-target.toml
@@ -453,7 +453,7 @@ allowed-imports = [
     "workspace",
     "worktree",
 ]
-surface-budget = 476
+surface-budget = 440
 
 [[module]]
 path = "crates/rimz/src/sidebar_pane"


### PR DESCRIPTION
## Context

The sidebar subsystem had accreted interface: modules published types and helpers their callers no longer needed, and knowledge that belonged inside a module leaked out to whoever called it. This branch is five behavior-preserving passes over that surface, each one chosen against a measured budget rather than a hunch, each committed on its own. The fifth closes the program.

Behavior is unchanged throughout. No flag, option, or file was added by any pass.

## Target shape

Every pass moves toward the same shape: a narrow interface with the complexity behind it, so a caller stops needing to know how the module works.

- **Refresh** — one shared inputs bundle and one worker-pool owner instead of per-lane plumbing; one focus dispatch interface; fold, pane assembly, and lifecycle internals private. Callers stop threading lane-specific arguments.
- **Rate-limit projection** — one projection entry point instead of two modes plus a `persist` flag. Callers stop deciding whether a projection writes.
- **Producer election** — one tracker owns the election. Callers stop having a second, uncached way to ask who the elder is.
- **Consumer read** — `PublishedSnapshotReader` owns the fold-skip memo: adoption/fallback source, full vs slim input-stamp selection, prepared-stamp reuse, and the 30-second backstop. The fetch worker keeps request eligibility and stops importing stamp and source types entirely.
- **Refresh visibility** — every refresh declaration is visible only to the callers it actually has: private, refresh-parent, or sidebar scope. Nothing in `refresh/` reaches the rest of the crate unless something outside sidebar genuinely calls it.

## Implementation

Five passes, plus two fix commits from review and one behavior fix.

- **Refresh surface** — centralized refresh inputs and worker pools, collapsed focus dispatch to one interface, made fold/pane-assembly/lifecycle internals private, removed a test-only re-export. A lane-attribution regression introduced mid-pass (`WorkLane::Other` on the PR probe) was caught and fixed inside the branch, so it nets to zero.
- **Rate-limit projection modes** — deleted the duplicated window indexes and the caller-facing `persist` flag, narrowed five declarations. Review found `apply_cached_rate_limits` still over-published and one load-bearing key-set asymmetry undocumented; both were fixed in the follow-up commit.
- **Election vestiges** — deleted two uncached scan interfaces superseded by `ProducerElectionTracker`. They had no caller in any Cargo target, production or test, and the three scenarios that exercised them were ported onto the tracker with fixed timestamps.
- **Consumer memo** — moved the memo lifecycle into the reader behind three `pub(crate)` methods (`fold_unchanged`, `record_fold`, `clear_fold`), replacing six exposed declarations. Deviation from the plan: an all-target compile found three adoption callers in `benches/hotpath.rs`, so `read_adopting` stays public and returns the snapshot directly rather than a wrapper — the benchmarks keep measuring the real adoption path, and the source stays private reader state. Two coverage gaps the pass exposed were closed: a fixed-time backstop test pinning the skip window against the last *successful* fold, and an end-to-end test proving a failed fold clears a warm memo. Review found the memo's documentation left behind by the move; the follow-up commit re-homed the fetch-cycle contract onto `run_cycle`, documented the backstop and the three lifecycle methods, and corrected both internals module maps.
- **Visibility ratchet** — 36 declarations narrowed to their compiler-minimal scope, plus three `PrStateCache` bookkeeping fields and `RepoProbe` made private. Visibility tokens only: stripping the qualifier from every changed line leaves identical pairs, apart from one signature rustfmt rewrapped once it fit on a line. Serialization is untouched — serde derives read field idents, not visibility. This pass deliberately buys no line deletion; the deliverable is reach.

## Surface removed

Against the merge base, 45 files: production Rust +495/−644 (net **−149**); tests +166/−101; benchmarks +1/−5; docs and config +4/−4. Tests are split by path because some live under source paths.

Atlas source lines per pass: −80 (refresh), −10 (rate-limit), −12 (election), −35 (consumer memo), −4 (visibility ratchet, entirely a rustfmt reflow). The sidebar `surface-budget` ratcheted 530 → 440 and `atlas conform` equals budget after every pass. Over the last pass alone, sidebar escaping declarations fell 479 → 457 and public declarations by 9; `over_published` under `refresh/` fell 38 → 14.

Interfaces gone:

- `persist` mode flag and the `apply_rate_limit_cache` entry point; `REFILL_CONFIRM_SECS`, `LIVE_HORIZON_SECS`, `write_rate_limits_cache`, and `fuse_window` now file-private; `merge_account_rate_limits` crate-only; consumer projection scoped to `crate::sidebar`.
- `elder_sidebar_instance` and `elder_sidebar_present`.
- `inputs_stamp`, `projection_inputs_stamp`, public `ConsumerFoldInputsStamp`, public `ConsumerSnapshotSource`, `ConsumerSnapshotRead`, and crate-wide `consumer_projection_inputs_stamp` — replaced by three crate-internal lifecycle methods.
- Crate-wide reach for 36 refresh declarations across `accounts`, `cohort_spend`, `credits`, `daemon_reap`, `git_stats`, `inputs`, `live_spend`, `pr`, `sessions`, and `usage`; eight of them are now file-private, and `RepoProbe` plus three `PrStateCache` fields no longer leave PR bookkeeping.
- A test-only refresh re-export, plus the first pass's lane, fold, pane-assembly, and lifecycle narrowings.

## Verification

`cargo xtask gate` (5,769 tests), `RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --all-features`, `cargo xtask invariants`, `cargo xtask docs-links`, `cargo xtask atlas conform` (sidebar 440/440, every rule ok), `cargo xtask atlas api --module refresh` (14 residual `over_published` rows, the pre-accepted set), and the focused rate-limit, usage, account, auto-redeem, sidebar, producer-election, consumer, enrich, refresh, and fetch suites. Both new consumer-memo tests were mutation-proven red before they went green. Review reproduced every published number independently; each narrowed declaration was confirmed to have a real caller requiring exactly the scope it was given.

## Advisories

Not gating, carried for whoever picks the area up next.

- Eleven refresh declarations keep a wider scope than their production callers need, because sibling and child *test* modules exercise them (`COHORT_SPEND_CACHE_VERSION`, `codex_daemon_reap_path`, `write_codex_daemon_reap`, the three worktree-path helpers, and five credits types). Moving tests purely to clear the flags was rejected as metric gaming; this is the ceiling on any further ratchet of the module.
- Three structs made private in the last pass keep field visibility they can no longer grant (`live_spend.rs` `LiveCardSpend`, `sessions.rs` `LiveSessionRefresh`, `pr.rs` `RepoProbe`). Inert tokens, local precedent exists, worth tidying next time those files are open.
- `merge_account_rate_limits` keeps a redundant re-export in `refresh/mod.rs`.
- `consumer.rs` holds the same stamp/source pair in two tuples with opposite field order three lines apart — matching the order would remove the trap for free next time either is touched.
- Consumer-memo test SLOC grew +50 against the plan's 15–35 estimate, driven by the end-to-end failure-reset test; the production floor still cleared by a wide margin.
- Pre-existing, untouched here: a vacuous wrong-protocol clause in `stale_or_wrong_protocol_elder_is_not_honored`, a duplicated election test harness in `producer_election_tests.rs`, and `fuse_window` named in `docs/internals/agents/providers.md`.
- Tooling friction worth fixing: the retained-surface ledger is still assembled by hand because Atlas emits no Cargo-target classification; `atlas rank --since <merge-base>` hangs over a range this long; and `cargo xtask gate` fails with a reaper `ENOENT` when an earlier step rebuilds the `xtask` binary mid-run.
- The sidebar refactor program closes here. The remaining original pass sketches are stale structural aspirations without current net-deletion evidence, and PR-state acceptance, Codex turn-death policy, and pane assembly were each inspected and rejected on the current code. Separate behavior and tooling bugs stay separate work.

<details>
<summary>Implemented by <a href="https://github.com/rimio-ai/rimz">RimZ</a> agents · 4 agents · 4h30m active · $139.18 · 42 messages (15 from you)</summary>

**mill team**

- **architect** — Codex `gpt-5.6-sol@xhigh`
  - effort: 1h02m active · $20.86
  - calls: 208 tool calls · 3 compactions
  - messages: 11 from you · 7 from teammates · 6 to teammates
  - tokens: 1.3m input, 111.8k output, 21.9m cache read
- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 2h08m active · $56.32
  - calls: 393 tool calls · 2 compactions
  - messages: 2 from you · 10 from teammates · 13 to teammates
  - tokens: 1.2m input, 157.7k output, 91.5m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 1h20m active · $27.34
  - calls: 278 tool calls · 1 compaction
  - messages: 10 from teammates · 8 to teammates
  - tokens: 548 input, 227.6k output, 722.4k cache write, 28.8m cache read

**Other agents**

- **@claude-47** — Claude `claude-fable-5@high`
  - effort: $34.66 incl. subagents
  - calls: 1 ask · 29 tool calls · 1 compaction
  - messages: 2 from you
  - tokens: 244 input, 192.8k output, 867.1k cache write, 12.9m cache read
  - subagents: 5 × general-purpose ($25.41)

</details>