### PR TITLE
build(deps): consolidate the pending Rust dependency updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,9 +226,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bit-set"
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive 4.6.4",
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -447,11 +447,11 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.8"
+version = "4.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
 dependencies = [
- "clap 4.6.4",
+ "clap 4.6.6",
  "clap_lex 1.1.0",
  "is_executable",
  "shlex",
@@ -479,7 +479,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1051,7 +1051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a405457ec78b8fe08b0e32b4a3570ab5dff6dd16eb9e76a5ee0a9d9cbd898933"
 dependencies = [
  "cfg-if",
- "clap 4.6.4",
+ "clap 4.6.6",
  "condtype",
  "divan-macros",
  "libc",
@@ -1770,7 +1770,7 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
- "similar",
+ "similar 2.7.0",
  "strip-ansi-escapes 0.2.1",
  "tempfile",
 ]
@@ -3268,9 +3268,9 @@ dependencies = [
  "anstyle",
  "anyhow",
  "assert_cmd",
- "base64 0.23.0",
- "clap 4.6.4",
- "clap_complete 4.6.8",
+ "base64 0.23.1",
+ "clap 4.6.6",
+ "clap_complete 4.6.9",
  "colorchoice",
  "crc32fast",
  "divan",
@@ -3304,7 +3304,7 @@ dependencies = [
  "sha2 0.11.0",
  "shlex",
  "signal-hook",
- "similar",
+ "similar 3.1.2",
  "sysinfo",
  "tar",
  "tempfile",
@@ -3780,6 +3780,12 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "similar"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ee016af5d736b69fc89e19254540fa4b5f5492853fb5503920f084011c78b6"
 dependencies = [
  "bstr",
  "unicode-segmentation",
@@ -4002,9 +4008,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4224,7 +4230,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5324,7 +5330,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "syn 3.0.2",
+ "syn 3.0.3",
  "tempfile",
  "toml",
  "ureq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ jiff = { version = "0.2", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env", "unstable-ext", "wrap_help"] }
 # Dynamic completion is still feature-gated as unstable, so pin its API until
 # clap stabilizes the environment-driven engine.
-clap_complete = { version = "=4.6.8", features = ["unstable-dynamic"] }
+clap_complete = { version = "=4.6.9", features = ["unstable-dynamic"] }
 # Layout launch flags are authored as shell-like strings in TOML but launched as
 # direct argv, so RimZ needs quote removal without invoking a shell. `shlex` is a
 # tiny POSIX-compatible splitter already present through the build graph and
@@ -111,8 +111,9 @@ unicode-width = "0.2"
 # the config install gate. It is already in the tree transitively via `insta`;
 # making it direct lets the user-visible security diff use the library rather
 # than a hand-rolled approximation.
-# Held on 2.x because `insta` still requires `similar ^2`; bump with insta to avoid a duplicate tree entry.
-similar = { version = "2", features = ["unicode"] }
+# `insta` still requires `similar ^2`, so its dev-only copy remains alongside
+# the direct 3.x dependency until insta follows the new major line.
+similar = { version = "3", features = ["unicode"] }
 
 # HTTP — pricing refresh: the runtime LiteLLM/models.dev fetch and the
 # release-time generated snapshot both GET static JSON documents. `ureq` is a

--- a/deny.toml
+++ b/deny.toml
@@ -56,7 +56,7 @@ skip = [
     { crate = "rand_core@0.9.5", reason = "proptest and sentry's rand 0.9 pins rand_core 0.9; tungstenite carries 0.10" },
     # `thiserror-impl` 2.0.19 leads the proc-macro stack onto syn 3; every other
     # derive crate still carries syn 2. Drop when the rest follow.
-    { crate = "syn@3.0.2", reason = "thiserror-impl 2.0.19 pins syn 3; the rest of the proc-macro stack carries syn 2" },
+    { crate = "syn@3.0.3", reason = "thiserror-impl 2.0.19 pins syn 3; the rest of the proc-macro stack carries syn 2" },
     # `toml_edit`/`indexmap` has moved to hashbrown 0.17 while the ratatui
     # stack still carries 0.16; drop when either upstream converges.
     { crate = "hashbrown@0.17.1", reason = "toml_edit/indexmap pins hashbrown 0.17; ratatui stack pins 0.16" },

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -97,7 +97,7 @@ version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.base64]]
-version = "0.23.0"
+version = "0.23.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.bitflags]]
@@ -153,11 +153,11 @@ version = "3.2.25"
 criteria = "safe-to-run"
 
 [[exemptions.clap]]
-version = "4.6.4"
+version = "4.6.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_builder]]
-version = "4.6.2"
+version = "4.6.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_complete]]
@@ -165,7 +165,7 @@ version = "3.2.5"
 criteria = "safe-to-run"
 
 [[exemptions.clap_complete]]
-version = "4.6.8"
+version = "4.6.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_derive]]
@@ -1172,6 +1172,10 @@ criteria = "safe-to-deploy"
 version = "0.3.9"
 criteria = "safe-to-deploy"
 
+[[exemptions.similar]]
+version = "3.1.2"
+criteria = "safe-to-deploy"
+
 [[exemptions.siphasher]]
 version = "1.0.3"
 criteria = "safe-to-deploy"
@@ -1249,7 +1253,7 @@ version = "2.0.118"
 criteria = "safe-to-deploy"
 
 [[exemptions.syn]]
-version = "3.0.2"
+version = "3.0.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.sysinfo]]


### PR DESCRIPTION
## Context

Dependabot had two open pull requests against `main`, #204 (`syn`, `base64`, `clap`, `clap_complete`) and #205 (`similar`). Both touched only `Cargo.toml` and `Cargo.lock`, which leaves the repository's dependency policy references behind: the exact-version `cargo-deny` duplicate allowance and the `cargo-vet` exemptions still named the pre-bump versions, so either PR merging alone would have taken the `deny`/`vet` gates red. This branch replaces both with one maintained change that carries the upgrades and the policy references together. #204 and #205 are closed in favour of it.

## Implementation

One commit, `build(deps): consolidate pending Rust updates`, over `Cargo.toml`, `Cargo.lock`, `deny.toml`, and `supply-chain/config.toml`.

| crate | from | to | policy references updated |
| --- | --- | --- | --- |
| `syn` | 3.0.2 | 3.0.3 | `deny.toml` duplicate skip, vet exemption |
| `base64` | 0.23.0 | 0.23.1 | vet exemption |
| `clap` | 4.6.4 | 4.6.6 | vet exemption |
| `clap_builder` (transitive) | 4.6.2 | 4.6.6 | vet exemption |
| `clap_complete` | 4.6.8 | 4.6.9 | exact pin advanced, vet exemption |
| `similar` | 2.7.0 | 3.1.2 | new vet exemption |

Beyond what the two source PRs carried:

- **Policy references realigned.** Neither Dependabot PR touches `deny.toml` or `supply-chain/config.toml`; both are updated here so the resolved lockfile is what the gates actually check.
- **`clap_complete` stays exactly pinned.** The pin exists because dynamic completion is still feature-gated as unstable, so the version advanced one patch rather than relaxing the constraint. 4.6.9's one behavioural change names the emitted bash completion function after `fn_name` for POSIX-bash sourceability; `COMPLETE=bash rimz` emits `_clap_complete_rimz` and sources cleanly, so the `docs/guide/setup.md` instruction is unaffected.
- **`similar` moves to 3.x with the 2.x copy left to `insta`.** `insta` 1.48.0 still requires `similar ^2`, so the lockfile now carries both: 3.1.2 for the runtime, 2.7.0 confined to snapshot-test tooling. The manifest comment records the condition for collapsing them. No `deny.toml` skip and no vet exemption are needed for the dev-only 2.7.0 copy — cargo-deny's graph never sees it (a probe skip entry reports `unmatched-skip`), and cargo-vet covers it through the imported embark/mozilla audits.

No source changes were required: the `similar` 3.x API RimZ uses (`TextDiff::from_lines`, `TextDiff::from_unicode_words`, `iter_all_changes`, `unified_diff`) survives the major bump, and the 3.0 removals are not used here. `similar` 3.0's MSRV floor of Rust 1.85 sits well under the workspace's 1.95.

## Verification

`cargo xtask check`, `cargo xtask gate`, `cargo xtask deny`, `cargo xtask vet`, and `cargo xtask externals` all pass. Independently re-run in review: `cargo check --workspace --all-features --all-targets` clean, `cargo xtask test` 5898 passed, `cargo deny check -D warnings` green on advisories/bans/licenses/sources, `cargo vet --locked` succeeded (176 fully audited, 2 partially, 386 exempted) — `--locked` passing also confirms the lockfile is exactly what Cargo resolves.

Two behavioural surfaces were checked directly rather than by proxy. `similar` 3.0 changed diff compaction and 3.1.x fixed `DiffOp` cursor positions, both of which can move rendered hunks on the hook-install consent diff and the trust diff; their covering tests pass unchanged. `clap` 4.6.5 changed help rendering for `value_names` under `num_args`; the CLI surface snapshot is unchanged, and it excludes help prose by design.

## Advisories

- **The `similar` bump reverses a hold the manifest had written down.** The replaced comment read "Held on 2.x because `insta` still requires `similar ^2`; bump with insta to avoid a duplicate tree entry." Consolidating #205 knowingly accepts that duplicate. Nothing breaks — no gate reference is needed and the cost is one extra crate compiled for the test profile — but it is a recorded policy being reversed deliberately, and it stands until `insta` follows onto `similar` 3.x. Dropping `similar` from this consolidation and leaving #205 open is the alternative if the hold should stand.

<details>
<summary>Implemented by <a href="https://github.com/rimio-ai/rimz">RimZ</a> agents · 3 agents · 19m active · $7.40 · 5 messages (4 from you)</summary>

**spot team**

- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 10m active · $2.75
  - calls: 32 tool calls
  - messages: 1 from you · 1 to teammates
  - tokens: 122.6k input, 10.1k output, 3.7m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 8m active · $2.37
  - calls: 49 tool calls
  - messages: 1 from teammates
  - tokens: 82 input, 26.6k output, 65.7k cache write, 2.1m cache read

**Other agents**

- **@sol** — Codex `gpt-5.6-sol@xhigh`
  - effort: $2.28
  - calls: 43 tool calls
  - messages: 3 from you
  - tokens: 114.8k input, 11.1k output, 2.7m cache read

</details>