### PR TITLE
fix(xtask): retry the install-dev Sentry debug-file upload

### DIFF
--- a/docs/internals/diagnostics.md
+++ b/docs/internals/diagnostics.md
@@ -262,7 +262,7 @@ Without the feature, [`observability`](../../crates/rimz/src/observability.rs) i
 
 ### Opting in
 
-`cargo xtask install-dev` is the contributor shortcut: it installs the Cargo tools listed in [`scripts/install-dev-tools.sh`](../../scripts/install-dev-tools.sh), including `cargo-insta` for reviewing and accepting snapshot changes, then installs the optimized `profiling` host profile with the feature on and, when `sentry-cli` is installed and authenticated, best-effort uploads that binary's debug files.
+`cargo xtask install-dev` is the contributor shortcut: it installs the Cargo tools listed in [`scripts/install-dev-tools.sh`](../../scripts/install-dev-tools.sh), including `cargo-insta` for reviewing and accepting snapshot changes, then installs the optimized `profiling` host profile with the feature on and, when `sentry-cli` is installed and authenticated, retries a failed upload of that binary's debug files up to three times. The upload stays best-effort: an unavailable Sentry service never turns a successful binary install into a failed command.
 
 Reporting turns on when a DSN resolves from `RIMZ_SENTRY_DSN` or the per-machine `[sentry]` config, with the env value winning and an empty value counting as unset. The DSN lives per-machine, never in the committed `.rimz/config.toml`, so a clone or pull cannot redirect a contributor's telemetry, and the DSN stays off the [project trust surface](./harness/trust.md).
 

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -4,7 +4,8 @@ use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process;
-use std::process::Command;
+use std::process::{Command, ExitStatus};
+use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
@@ -20,6 +21,9 @@ const PROFILING_RUSTFLAGS: &str = "-C force-frame-pointers=yes -C symbol-manglin
 const BUILD_PROFILE_OVERRIDE_ENV: &str = "RIMZ_BUILD_PROFILE_OVERRIDE";
 const BUILD_VERSION_OVERRIDE_ENV: &str = "RIMZ_BUILD_VERSION_OVERRIDE";
 const STABLE_CHECKOUT_BUILD_ATTEMPTS: usize = 3;
+const SENTRY_UPLOAD_RETRIES: usize = 3;
+const SENTRY_UPLOAD_ATTEMPTS: usize = SENTRY_UPLOAD_RETRIES + 1;
+const SENTRY_UPLOAD_RETRY_DELAY: Duration = Duration::from_secs(1);
 pub(crate) const WASM_MAGIC: [u8; 4] = *b"\0asm";
 const ENCODED_RUSTFLAGS_SEPARATOR: &str = "\x1f";
 const CANONICAL_REGISTRY_SOURCE_ROOT: &str = "/cargo/registry/src";
@@ -627,7 +631,8 @@ pub(crate) fn install_dev(root: &Path) -> Result<()> {
     run(root, "sh", ["scripts/install-dev-tools.sh"])?;
     let stage = stage_dev_install(root)?;
     install_from_stage(&stage)?;
-    upload_debug_files(&stage.join("rimz"))
+    upload_debug_files(&stage.join("rimz"));
+    Ok(())
 }
 
 /// Build an optimized host `rimz` with line-tables debug info, frame pointers,
@@ -708,27 +713,77 @@ fn report_install(version: &str, paths: &[PathBuf]) {
     clippy::print_stderr,
     reason = "install-dev reports optional Sentry debug-file enrichment"
 )]
-fn upload_debug_files(binary: &Path) -> Result<()> {
-    match Command::new("sentry-cli")
-        .args(["debug-files", "upload"])
-        .arg(binary)
-        .status()
-    {
-        Ok(status) if status.success() => {
-            println!("Uploaded Sentry debug files for {}", binary.display());
-        }
-        Ok(status) => {
+fn upload_debug_files(binary: &Path) {
+    let result = retry_debug_file_upload(
+        || {
+            let status = Command::new("sentry-cli")
+                .args(["debug-files", "upload"])
+                .arg(binary)
+                .status()
+                .map_err(SentryUploadFailure::CouldNotStart)?;
+            status
+                .success()
+                .then_some(())
+                .ok_or(SentryUploadFailure::Failed(status))
+        },
+        SentryUploadFailure::retryable,
+        |next_attempt, failure| {
             eprintln!(
-                "warning: sentry-cli debug-files upload failed with status {status}; install still succeeded"
+                "warning: sentry-cli debug-files upload {failure}; retrying (attempt {next_attempt} of {SENTRY_UPLOAD_ATTEMPTS})"
             );
-        }
-        Err(err) => {
-            eprintln!(
-                "warning: sentry-cli debug-files upload could not start: {err}; install still succeeded"
-            );
+            std::thread::sleep(SENTRY_UPLOAD_RETRY_DELAY);
+        },
+    );
+
+    match result {
+        Ok(()) => println!("Uploaded Sentry debug files for {}", binary.display()),
+        Err(SentryUploadFailure::CouldNotStart(error)) => eprintln!(
+            "warning: sentry-cli debug-files upload could not start: {error}; install still succeeded"
+        ),
+        Err(SentryUploadFailure::Failed(status)) => eprintln!(
+            "warning: sentry-cli debug-files upload failed with status {status} after {SENTRY_UPLOAD_ATTEMPTS} attempts; install still succeeded"
+        ),
+    }
+}
+
+enum SentryUploadFailure {
+    CouldNotStart(std::io::Error),
+    Failed(ExitStatus),
+}
+
+impl SentryUploadFailure {
+    fn retryable(&self) -> bool {
+        matches!(self, Self::Failed(_))
+    }
+}
+
+impl std::fmt::Display for SentryUploadFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CouldNotStart(error) => write!(formatter, "could not start: {error}"),
+            Self::Failed(status) => write!(formatter, "failed with status {status}"),
         }
     }
-    Ok(())
+}
+
+fn retry_debug_file_upload<E>(
+    mut upload: impl FnMut() -> Result<(), E>,
+    mut retryable: impl FnMut(&E) -> bool,
+    mut before_retry: impl FnMut(usize, &E),
+) -> Result<(), E> {
+    let mut attempt = 1;
+    loop {
+        match upload() {
+            Ok(()) => return Ok(()),
+            Err(failure) if attempt == SENTRY_UPLOAD_ATTEMPTS || !retryable(&failure) => {
+                return Err(failure);
+            }
+            Err(failure) => {
+                attempt += 1;
+                before_retry(attempt, &failure);
+            }
+        }
+    }
 }
 
 #[expect(

--- a/xtask/src/build/tests.rs
+++ b/xtask/src/build/tests.rs
@@ -215,6 +215,64 @@ fn install_keeps_a_real_build_failure_from_a_stable_checkout() {
 }
 
 #[test]
+fn debug_file_upload_retries_until_it_succeeds() {
+    let mut attempts = 0;
+    let mut retries = Vec::new();
+
+    let result = retry_debug_file_upload(
+        || {
+            attempts += 1;
+            if attempts < SENTRY_UPLOAD_ATTEMPTS {
+                Err("transient request failure")
+            } else {
+                Ok(())
+            }
+        },
+        |_| true,
+        |next_attempt, _| retries.push(next_attempt),
+    );
+
+    assert_eq!(result, Ok(()));
+    assert_eq!(attempts, SENTRY_UPLOAD_ATTEMPTS);
+    assert_eq!(retries, vec![2, 3, 4]);
+    assert_eq!(retries.len(), SENTRY_UPLOAD_RETRIES);
+}
+
+#[test]
+fn debug_file_upload_stops_after_the_attempt_budget() {
+    let mut attempts = 0;
+
+    let result = retry_debug_file_upload(
+        || {
+            attempts += 1;
+            Err::<(), _>("persistent request failure")
+        },
+        |_| true,
+        |_, _| {},
+    );
+
+    assert_eq!(result, Err("persistent request failure"));
+    assert_eq!(attempts, SENTRY_UPLOAD_ATTEMPTS);
+}
+
+#[test]
+fn debug_file_upload_does_not_retry_a_start_failure() {
+    let mut attempts = 0;
+
+    let result = retry_debug_file_upload(
+        || {
+            attempts += 1;
+            Err::<(), _>("missing sentry-cli")
+        },
+        |_| false,
+        |_, _| {},
+    );
+
+    assert_eq!(result, Err("missing sentry-cli"));
+    assert_eq!(attempts, 1);
+}
+
+#[test]
 fn dev_install_builds_profiling_with_the_sentry_feature() {
     let args = host_build_args(HostProfile::Profiling, &["sentry"]);
 


### PR DESCRIPTION
## Context

`cargo xtask install-dev` uploads the profiling binary's debug files with `sentry-cli` as best-effort enrichment. The upload had no retry, so a single transient web-request failure lost that build's symbols. The non-fatal contract — a failed upload never fails the install — already held; this change adds the retry and makes that boundary explicit.

## Implementation

- A non-zero `sentry-cli debug-files upload` exit is retried three times after the initial attempt (four total), one second apart. Exhausting the budget stays a warning.
- Failing to start `sentry-cli` remains a single immediate warning: a missing or unexecutable binary will not recover inside the command.
- `upload_debug_files` now returns `()` and `install_dev` returns success after it, so the best-effort boundary is stated rather than resting on an always-`Ok` result.
- `docs/internals/diagnostics.md` records the retry and the non-fatal install contract.

Departures from the request: "retry up to three times" is read as three retries after the initial upload rather than three total attempts, and the delay is a fixed one second rather than backoff — enough to avoid an immediate burst without materially extending an install.

## Advisories

- `sentry-cli` exposes upload failures only as a non-zero exit here, so an authentication or org/project misconfiguration gets the same retry policy as a transient HTTP failure: three extra attempts, three seconds, three warning lines. The common benign case is untouched — a path with no debug files exits 0 and never enters the loop.
- `Display for SentryUploadFailure` has an unreachable `CouldNotStart` arm; only the retryable `Failed` variant reaches the retry banner.
- The three loop tests inject literal predicates rather than `SentryUploadFailure::retryable`, so the shipped policy — a start failure is not retried — is not itself covered.
- The diagnostics line now describes the retry without restating that `install-dev` uploads debug files at all.

## Verification

`cargo xtask gate` (fmt, invariants, conform, docs-links, lint, 5782 tests) plus the three new retry-loop unit tests. Review independently re-ran those tests, `cargo clippy -p xtask --all-targets`, `cargo xtask invariants`, and `cargo xtask docs-links`.

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>spot</code> team · 2 agents · 19m active · $5.02 · 2 messages (1 from you)</summary>

- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 13m active · $3.61
  - calls: 37 tool calls
  - messages: 1 from you · 1 to teammates
  - tokens: 129.2k input, 16.1k output, 5m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 5m active · $1.41
  - calls: 26 tool calls
  - messages: 1 from teammates
  - tokens: 42 input, 21.7k output, 65.9k cache write, 917.5k cache read

</details>