### PR TITLE
build(deps): upgrade rusqlite, thiserror, and ureq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1450,7 +1450,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tungstenite 0.29.0",
  "url",
  "which",
@@ -1957,7 +1957,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2042,9 +2042,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.1"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2132,7 +2132,7 @@ dependencies = [
  "log-mdc",
  "mock_instant",
  "parking_lot",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "thread-id",
  "unicode-segmentation",
 ]
@@ -3119,7 +3119,7 @@ dependencies = [
  "palette",
  "serde",
  "strum 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.2",
@@ -3222,7 +3222,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3309,7 +3309,7 @@ dependencies = [
  "tar",
  "tempfile",
  "terminal_size 0.4.4",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "toml",
  "toml_edit",
@@ -3354,14 +3354,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "rusqlite"
-version = "0.40.1"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
  "bitflags 2.13.0",
  "fallible-iterator",
@@ -3575,7 +3575,7 @@ dependencies = [
  "rand 0.9.4",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "url",
  "uuid",
@@ -4204,11 +4204,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -4224,9 +4224,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4485,7 +4485,7 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1 0.10.7",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4501,7 +4501,7 @@ dependencies = [
  "log",
  "rand 0.10.2",
  "sha1 0.11.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4577,11 +4577,11 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "flate2",
  "log",
  "percent-encoding",
@@ -4595,11 +4595,11 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "http 1.4.2",
  "httparse",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,9 @@ resolver = "2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/rimio-ai/rimz"
-# True floor for the current lock: libsqlite3-sys 0.38.1 (via rusqlite 0.40,
-# bundled sqlite) uses the cfg_select! macro, stable since Rust 1.95 — above the
-# let-chains/dep-declared 1.88. Verify with `cargo +1.95 check --locked`.
-rust-version = "1.95"
+# True floor for the current source: store locking uses `std::fs::File` locking,
+# stable since Rust 1.89. Verify with `cargo +1.89 check --locked`.
+rust-version = "1.89"
 version = "0.4.3"
 
 [workspace.lints.clippy]

--- a/deny.toml
+++ b/deny.toml
@@ -41,9 +41,6 @@ deny = [
     { name = "fs2", reason = "unmaintained; use std `File` locking instead" },
 ]
 skip = [
-    # The HTTP stack and headless browser fixture still pin base64 0.22 while
-    # RimZ's direct browser-input codec tracks 0.23; drop when those roots move.
-    { crate = "base64@0.22.1", reason = "ureq and headless_chrome pin base64 0.22; workspace direct dependency is 0.23" },
     # The `ring` crypto backend reached via `ureq`/`rustls` pins older support
     # crates than the rest of the tree; isolated to the TLS stack, drop when ring
     # catches up. (The former wit-bindgen and windows-sys skips left with the
@@ -54,9 +51,9 @@ skip = [
     { crate = "getrandom@0.3.4", reason = "proptest and sentry-core's rand 0.9 pin getrandom 0.3; uuid and tungstenite carry 0.4" },
     { crate = "rand@0.9.4", reason = "proptest and sentry retain rand 0.9; tungstenite carries rand 0.10" },
     { crate = "rand_core@0.9.5", reason = "proptest and sentry's rand 0.9 pins rand_core 0.9; tungstenite carries 0.10" },
-    # `thiserror-impl` 2.0.19 leads the proc-macro stack onto syn 3; every other
+    # `thiserror-impl` 2.0.20 leads the proc-macro stack onto syn 3; every other
     # derive crate still carries syn 2. Drop when the rest follow.
-    { crate = "syn@3.0.3", reason = "thiserror-impl 2.0.19 pins syn 3; the rest of the proc-macro stack carries syn 2" },
+    { crate = "syn@3.0.3", reason = "thiserror-impl 2.0.20 pins syn 3; the rest of the proc-macro stack carries syn 2" },
     # `toml_edit`/`indexmap` has moved to hashbrown 0.17 while the ratatui
     # stack still carries 0.16; drop when either upstream converges.
     { crate = "hashbrown@0.17.1", reason = "toml_edit/indexmap pins hashbrown 0.17; ratatui stack pins 0.16" },

--- a/docs/contributing/rust-conventions.md
+++ b/docs/contributing/rust-conventions.md
@@ -219,7 +219,7 @@ Rules:
 
 ## Toolchain
 
-Rust 1.97.1 is pinned exactly in `rust-toolchain.toml`; the workspace is edition 2024 and declares Rust 1.95 as its installable-crate floor. The pin, vendored presence wasm, and provenance sidecar move together: every toolchain bump runs `cargo xtask plugin-refresh` in the same commit. Required components: `rustfmt`, `clippy`, `llvm-tools-preview`, `rust-analyzer`. Required targets: `wasm32-wasip1` (the Zellij presence plugin) plus `aarch64-apple-darwin` and `x86_64-apple-darwin` (the [release cross-builds](#release-packaging)). rustup provisions all of them from the pin; `ci/Dockerfile` mirrors the list for CI.
+Rust 1.97.1 is pinned exactly in `rust-toolchain.toml`; the workspace is edition 2024 and declares Rust 1.89 as its installable-crate floor. The pin, vendored presence wasm, and provenance sidecar move together: every toolchain bump runs `cargo xtask plugin-refresh` in the same commit. Required components: `rustfmt`, `clippy`, `llvm-tools-preview`, `rust-analyzer`. Required targets: `wasm32-wasip1` (the Zellij presence plugin) plus `aarch64-apple-darwin` and `x86_64-apple-darwin` (the [release cross-builds](#release-packaging)). rustup provisions all of them from the pin; `ci/Dockerfile` mirrors the list for CI.
 
 Node.js 26 or newer is a development prerequisite for the gate-tier ttyd pixel-layer harness. The CI image supplies the same major version, and the integration test fails at entry with the install requirement when `node` is missing or older.
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -661,7 +661,7 @@ version = "0.1.18"
 criteria = "safe-to-run"
 
 [[exemptions.libsqlite3-sys]]
-version = "0.38.1"
+version = "0.38.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.libz-sys]]
@@ -1033,7 +1033,7 @@ version = "0.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.rusqlite]]
-version = "0.40.1"
+version = "0.40.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustc_version]]
@@ -1285,11 +1285,11 @@ version = "0.23.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror]]
-version = "2.0.19"
+version = "2.0.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror-impl]]
-version = "2.0.19"
+version = "2.0.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.thread-id]]
@@ -1393,11 +1393,11 @@ version = "0.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ureq]]
-version = "3.3.0"
+version = "3.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ureq-proto]]
-version = "0.6.0"
+version = "0.6.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.utf8-zero]]


### PR DESCRIPTION
## Context

PR #211 proposed three dependency updates, but its lockfile-only change leaves cargo-deny and cargo-vet policy stale, so the repository's externals gate cannot pass.

## Implementation

- Upgrade `rusqlite` to 0.40.2, `thiserror` to 2.0.20, and `ureq` to 3.4.0, including their transitive lockfile updates.
- Remove the obsolete `base64@0.22.1` duplicate-version exception and advance the matching cargo-vet exemptions.
- Restore Rust 1.89 as the installable-crate floor now that `libsqlite3-sys` no longer requires Rust 1.95, and align the contributor toolchain documentation.

## Verification

- `cargo +1.89 check --locked`
- `cargo xtask gate` — passed; 5,782 tests passed across 6 binaries.
- `cargo xtask externals` — passed; 176 fully audited, 2 partially audited, and 386 exempted crates.

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>spot</code> team · 1 agent · 18m active · $1.81 · 1 messages (1 from you)</summary>

- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 18m active · $1.81 incl. subagents
  - calls: 43 tool calls
  - messages: 1 from you
  - tokens: 102k input, 11k output, 2.9m cache read
  - subagents: 1 × reviewer

</details>