### PR TITLE
Fail fast on nonexistent remote paths and hold connect errors in the recovery panel

### DIFF
--- a/crates/rimz/src/cli/loop_cmd/stop.rs
+++ b/crates/rimz/src/cli/loop_cmd/stop.rs
@@ -17,14 +17,19 @@ pub(super) fn stop(name: &str, globals: &GlobalFlags) -> Result<()> {
     }
 
     let root = entry.resolved_root();
-    let workspace = WorkspaceResolver::resolve(&root, None)
-        .with_context(|| format!("resolving project root at {}", root.display()))?;
-    let store = crate::cli::open_store(&workspace)?;
+    let (workspace, workspace_id) = stop_workspace(&root)?;
+    let paths = StatePaths::for_workspace(workspace_id.clone())?;
+    let runtime = RuntimePaths::for_workspace(workspace_id)?;
+    let store = rimz::Store::open(paths, runtime)?;
     let run = newest_active_run(store.paths(), name)?;
     if next_stop_action(&lock_state, run.is_some(), false, false) == StopAction::CancelRun
         && let Some(record) = &run
     {
-        crate::cli::supervised::stop_supervised_run(&workspace, &store, globals, record)?;
+        if let Some(workspace) = workspace.as_ref() {
+            crate::cli::supervised::stop_supervised_run(workspace, &store, globals, record)?;
+        } else {
+            crate::cli::supervised::cancel_supervised_run(&store, record)?;
+        }
     }
 
     if wait_for_run_lock_release(name, entry, STOP_GRACE)? {
@@ -65,6 +70,19 @@ pub(super) fn stop(name: &str, globals: &GlobalFlags) -> Result<()> {
     )
 }
 
+fn stop_workspace(root: &Path) -> Result<(Option<rimz::ResolvedWorkspace>, WorkspaceId)> {
+    let workspace = root
+        .exists()
+        .then(|| WorkspaceResolver::resolve(root, None))
+        .transpose()
+        .with_context(|| format!("resolving project root at {}", root.display()))?;
+    let workspace_id = match &workspace {
+        Some(workspace) => workspace.workspace_id.clone(),
+        None => WorkspaceResolver::persisted_workspace_id(root)?,
+    };
+    Ok((workspace, workspace_id))
+}
+
 fn lock_info(state: &RunLockState) -> Option<RunLockInfo> {
     match state {
         RunLockState::Held(info) => *info,
@@ -100,4 +118,20 @@ fn write_stopped(name: &str, run: Option<&RunRecord>, signaled: bool) -> std::io
         .unwrap_or_default();
     let backstop = if signaled { " · SIGTERM" } else { "" };
     writeln!(ui::out(), "loop `{name}`: stopped{run_id}{backstop}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vanished_task_root_keeps_its_persisted_workspace_identity() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().join("vanished");
+
+        let (workspace, workspace_id) = stop_workspace(&root).expect("resolve stop workspace");
+
+        assert!(workspace.is_none());
+        assert_eq!(workspace_id, WorkspaceId::from_project_root(&root));
+    }
 }

--- a/crates/rimz/src/cli/remote/outage_ui.rs
+++ b/crates/rimz/src/cli/remote/outage_ui.rs
@@ -186,6 +186,18 @@ impl OutageUi {
         }
     }
 
+    /// Hold a final failure frame long enough to read it before restoring the
+    /// main screen, where the caller will report the same error to scrollback.
+    pub(super) fn fail_hold(&mut self, headline: &str, details: &[String]) -> io::Result<()> {
+        let UiState::Panel(panel) = &mut self.state else {
+            return Ok(());
+        };
+        let rows = failure_rows(headline, details, &rimz::tui::captured_log_lines());
+        panel.draw_rows(&rows)?;
+        panel.wait_for_keypress()?;
+        self.release()
+    }
+
     pub(super) fn handoff(&mut self, frame: &RecoveryFrame) -> io::Result<bool> {
         match std::mem::replace(&mut self.state, UiState::Released) {
             UiState::Panel(panel) => {
@@ -292,6 +304,17 @@ impl OutagePanel {
         Ok(UiEvent::Continue)
     }
 
+    fn wait_for_keypress(&self) -> io::Result<()> {
+        loop {
+            let Event::Key(key) = event::read()? else {
+                continue;
+            };
+            if key.kind == KeyEventKind::Press {
+                return Ok(());
+            }
+        }
+    }
+
     fn release(mut self) -> io::Result<()> {
         drop(self.guard.take());
         Ok(())
@@ -321,6 +344,48 @@ struct DisplayRow {
     color: Color,
     bold: bool,
     dim: bool,
+}
+
+fn failure_rows(headline: &str, details: &[String], captured_logs: &[String]) -> Vec<DisplayRow> {
+    let mut rows = Vec::with_capacity(details.len() + captured_logs.len().min(5) + 4);
+    rows.push(DisplayRow {
+        text: format!("✗ {headline}"),
+        color: Color::Red,
+        bold: true,
+        dim: false,
+    });
+    rows.extend(details.iter().map(|detail| DisplayRow {
+        text: detail.clone(),
+        color: Color::Reset,
+        bold: false,
+        dim: false,
+    }));
+    rows.extend(
+        captured_logs
+            .iter()
+            .rev()
+            .take(5)
+            .rev()
+            .map(|line| DisplayRow {
+                text: format!("⚠  {line}"),
+                color: Color::DarkGrey,
+                bold: false,
+                dim: true,
+            }),
+    );
+    rows.push(DisplayRow {
+        text: String::new(),
+        color: Color::Reset,
+        bold: false,
+        dim: false,
+    });
+    rows.push(DisplayRow {
+        text: "press any key to exit".to_owned(),
+        color: Color::DarkGrey,
+        bold: false,
+        dim: true,
+    });
+    rows
 }
 
 fn display_rows(frame: &RecoveryFrame, frame_index: usize) -> Vec<DisplayRow> {
@@ -577,6 +642,38 @@ mod tests {
         assert_eq!(layout.x0, 14);
         assert_eq!(layout.first_y, 9);
         assert_eq!(layout.row_count, 2);
+    }
+
+    #[test]
+    fn failure_rows_hold_the_error_fix_and_recent_warnings() {
+        let details = [
+            "remote path: workspace/missing".to_owned(),
+            "fix alias".to_owned(),
+        ];
+        let logs = (1..=7)
+            .map(|index| format!("warning {index}"))
+            .collect::<Vec<_>>();
+
+        let rows = failure_rows("remote path does not exist", &details, &logs);
+        let text = rows.iter().map(|row| row.text.as_str()).collect::<Vec<_>>();
+
+        assert_eq!(text[0], "✗ remote path does not exist");
+        assert_eq!(text[1..3], details);
+        assert_eq!(
+            text[3..8],
+            [
+                "⚠  warning 3",
+                "⚠  warning 4",
+                "⚠  warning 5",
+                "⚠  warning 6",
+                "⚠  warning 7",
+            ]
+        );
+        assert_eq!(text[9], "press any key to exit");
+        assert!(rows[0].bold);
+        assert_eq!(rows[0].color, Color::Red);
+        assert!(rows[3..8].iter().all(|row| row.dim));
+        assert!(rows[9].dim);
     }
 
     fn stage(stage: RecoveryStage, status: StageStatus, label: &str, detail: &str) -> StageFrame {

--- a/crates/rimz/src/cli/remote/supervisor.rs
+++ b/crates/rimz/src/cli/remote/supervisor.rs
@@ -174,10 +174,7 @@ impl LinkSupervisor {
                 self.held_alt = held_alt;
                 Ok(true)
             }
-            WaitOutcome::Interrupted => {
-                let _ = writeln!(std::io::stderr().lock(), "rimz: reconnect stopped");
-                Ok(false)
-            }
+            WaitOutcome::Interrupted => Ok(false),
             WaitOutcome::NeedsInteractive => unreachable!("web recovery stays in batch mode"),
         }
     }
@@ -220,7 +217,7 @@ pub(super) fn supervise_remote(
     use rimz::remote::{ReconnectPolicy, ReconnectState, Verdict};
 
     let policy = ReconnectPolicy::from_env();
-    let mut reconnect = ReconnectState::new();
+    let mut reconnect = ReconnectState::default();
     let target = plan.target();
     let host = target.host_display();
     let dial_plan = resolve_dial_plan(target.ssh_destination().as_str());
@@ -340,7 +337,13 @@ pub(super) fn supervise_remote(
                     guard.reset_emulator();
                     bail!(
                         "{}",
-                        fatal_session_message(code, host, setup_hint, summary.as_deref())
+                        fatal_session_message(
+                            code,
+                            host,
+                            target.remote_path(),
+                            setup_hint,
+                            summary.as_deref()
+                        )
                     )
                 }
                 Verdict::Retry => {
@@ -405,7 +408,6 @@ pub(super) fn supervise_remote(
                 held_alt = next_held_alt;
             }
             WaitOutcome::Interrupted => {
-                let _ = writeln!(std::io::stderr().lock(), "rimz: reconnect stopped");
                 return Ok(());
             }
             // `wait_for_master` only requests an interactive fallback for an
@@ -423,10 +425,14 @@ enum RetryCause {
 pub(super) fn fatal_session_message(
     code: i32,
     host: &str,
+    remote_path: Option<&str>,
     setup_hint: &str,
     summary: Option<&str>,
 ) -> String {
     match code {
+        rimz::remote::REMOTE_PATH_MISSING_EXIT => {
+            remote_path_missing_message(host, remote_path, None)
+        }
         rimz::remote::REMOTE_RIMZ_MISSING_EXIT => format!(
             "rimz is not installed on {host}; install it over SSH with:\n    \
              rimz remote setup {setup_hint}"
@@ -448,6 +454,34 @@ pub(super) fn fatal_session_message(
             }
         }
     }
+}
+
+fn remote_path_missing_message(host: &str, path: Option<&str>, summary: Option<&str>) -> String {
+    let error = summary.map_or_else(
+        || match path {
+            Some(path) => format!("remote path does not exist on {host}: {path}"),
+            None => format!("remote path does not exist on {host}"),
+        },
+        str::to_owned,
+    );
+    format!(
+        "{error}\ncheck the target with `rimz remote list`, then correct the alias or remote path"
+    )
+}
+
+fn interrupted_message(
+    connect_stage: ConnectStage,
+    host: &str,
+    last_error: Option<&str>,
+) -> String {
+    let action = match connect_stage {
+        ConnectStage::Initial => "connect",
+        ConnectStage::Recovery => "reconnect",
+    };
+    let detail = last_error
+        .map(|error| format!(" — last error: {error}"))
+        .unwrap_or_default();
+    format!("rimz: {action} to {host} stopped{detail}")
 }
 
 fn run_ssh_session(
@@ -646,7 +680,17 @@ fn wait_for_master(
         reachability.poll(now).present(Some(&mut outage.panel), ui);
         if stop.is_some_and(|stop| stop.load(Ordering::SeqCst)) {
             drop(std::mem::take(&mut master));
+            let last_error = outage.panel.last_error().map(str::to_owned);
             ui.release()?;
+            let _ = writeln!(
+                std::io::stderr().lock(),
+                "{}",
+                interrupted_message(
+                    connect_stage,
+                    plan.target().host_display(),
+                    last_error.as_deref()
+                )
+            );
             return Ok(WaitOutcome::Interrupted);
         }
         reachability.schedule_probes(now);
@@ -681,6 +725,19 @@ fn wait_for_master(
                 }
             }
             MasterTick::Connected(guard) => {
+                if connect_stage == ConnectStage::Initial
+                    && let Some((spec, path)) = plan.path_preflight(control_path)
+                    && run_path_preflight(&spec)
+                {
+                    let fix = "check the target with `rimz remote list`, then correct the alias or remote path".to_owned();
+                    let details = [format!("{}: {path}", plan.target().host_display()), fix];
+                    let message =
+                        remote_path_missing_message(plan.target().host_display(), Some(path), None);
+                    outage.panel.note_ssh_error(Some(message.clone()));
+                    ui.fail_hold("Remote path does not exist", &details)?;
+                    drop(guard);
+                    return Err(anyhow::anyhow!(message));
+                }
                 let frame = outage
                     .panel
                     .frame(outage.elapsed(), FooterPhase::Connecting);
@@ -737,11 +794,45 @@ fn wait_for_master(
         )? == UiEvent::Interrupted
         {
             drop(std::mem::take(&mut master));
+            let last_error = outage.panel.last_error().map(str::to_owned);
             ui.release()?;
+            let _ = writeln!(
+                std::io::stderr().lock(),
+                "{}",
+                interrupted_message(
+                    connect_stage,
+                    plan.target().host_display(),
+                    last_error.as_deref()
+                )
+            );
             return Ok(WaitOutcome::Interrupted);
         }
         sleep_retry_wait(PANEL_TICK, stop);
     }
+}
+
+fn run_path_preflight(spec: &rimz::mux::CommandSpec) -> bool {
+    match spec
+        .to_command()
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+    {
+        Ok(status) => path_preflight_missing(status.code()),
+        Err(err) => {
+            tracing::debug!(
+                error = %err,
+                command = %rimz::remote::display_ssh_command(spec),
+                "remote path preflight unavailable"
+            );
+            false
+        }
+    }
+}
+
+fn path_preflight_missing(exit_code: Option<i32>) -> bool {
+    exit_code == Some(1)
 }
 
 fn note_master_failure(

--- a/crates/rimz/src/cli/remote/supervisor_tests.rs
+++ b/crates/rimz/src/cli/remote/supervisor_tests.rs
@@ -22,6 +22,7 @@ fn fatal_session_message_points_missing_remote_rimz_at_setup() {
     let message = fatal_session_message(
         rimz::remote::REMOTE_RIMZ_MISSING_EXIT,
         "dev-box",
+        None,
         "dev",
         None,
     );
@@ -39,7 +40,7 @@ fn fatal_session_message_points_missing_remote_rimz_at_setup() {
 
 #[test]
 fn fatal_session_message_reports_other_codes_without_setup_hint() {
-    let message = fatal_session_message(2, "dev-box", "dev", None);
+    let message = fatal_session_message(2, "dev-box", None, "dev", None);
 
     assert!(
         message.contains("ssh to dev-box exited with status 2"),
@@ -51,8 +52,13 @@ fn fatal_session_message_reports_other_codes_without_setup_hint() {
 
 #[test]
 fn fatal_session_message_includes_a_captured_attach_error() {
-    let message =
-        fatal_session_message(2, "dev-box", "dev", Some("SSH control connection dropped"));
+    let message = fatal_session_message(
+        2,
+        "dev-box",
+        None,
+        "dev",
+        Some("SSH control connection dropped"),
+    );
 
     assert!(
         message.ends_with("— SSH control connection dropped"),
@@ -89,6 +95,7 @@ fn fatal_session_message_explains_minor_version_bypass() {
     let message = fatal_session_message(
         rimz::remote::REMOTE_VERSION_SKEW_EXIT,
         "dev-box",
+        None,
         "dev",
         None,
     );
@@ -103,6 +110,7 @@ fn fatal_session_message_keeps_major_version_refusal_hard() {
     let message = fatal_session_message(
         rimz::remote::REMOTE_VERSION_INCOMPATIBLE_EXIT,
         "dev-box",
+        None,
         "dev",
         None,
     );
@@ -111,6 +119,72 @@ fn fatal_session_message_keeps_major_version_refusal_hard() {
     assert!(message.contains("upgrade required"), "{message}");
     assert!(message.contains("rimz remote setup dev"), "{message}");
     assert!(!message.contains("--force-version"), "{message}");
+}
+
+#[test]
+fn fatal_session_message_explains_a_missing_remote_path() {
+    let message = fatal_session_message(
+        rimz::remote::REMOTE_PATH_MISSING_EXIT,
+        "dev-box",
+        Some("workspace/missing"),
+        "dev",
+        Some(
+            "remote path does not exist on dev-box: workspace/mis…; check the target with `rimz remote list`",
+        ),
+    );
+
+    assert!(
+        message.contains("remote path does not exist on dev-box: workspace/missing"),
+        "{message}"
+    );
+    assert!(message.contains("rimz remote list"), "{message}");
+    assert_eq!(message.matches("rimz remote list").count(), 1, "{message}");
+}
+
+#[test]
+fn missing_path_sentinel_rebuilds_a_long_path_without_stderr() {
+    let path =
+        "workspace/projects/query-engine/with/a/very/long/path/that/exceeds/the/summary/limit";
+
+    let message = fatal_session_message(
+        rimz::remote::REMOTE_PATH_MISSING_EXIT,
+        "dev-box",
+        Some(path),
+        "dev",
+        None,
+    );
+
+    assert!(message.contains(path), "{message}");
+    assert_eq!(message.matches("rimz remote list").count(), 1, "{message}");
+}
+
+#[test]
+fn interrupted_message_preserves_the_last_ssh_error() {
+    assert_eq!(
+        interrupted_message(
+            ConnectStage::Initial,
+            "dev-box",
+            Some("Permission denied (publickey).")
+        ),
+        "rimz: connect to dev-box stopped — last error: Permission denied (publickey)."
+    );
+    assert_eq!(
+        interrupted_message(ConnectStage::Recovery, "dev-box", None),
+        "rimz: reconnect to dev-box stopped"
+    );
+}
+
+#[test]
+fn path_preflight_classifies_only_exit_one_as_missing() {
+    assert!(path_preflight_missing(Some(1)));
+    for code in [
+        Some(0),
+        Some(2),
+        Some(rimz::remote::SSH_TRANSPORT_EXIT),
+        None,
+    ] {
+        assert!(!path_preflight_missing(code));
+    }
 }
 
 #[test]

--- a/crates/rimz/src/cli/remote/web.rs
+++ b/crates/rimz/src/cli/remote/web.rs
@@ -130,6 +130,7 @@ fn run_direct_web(remote: &RemoteConnect, client_size: Option<(u16, u16)>) -> Re
         ),
         "preparing remote web access",
         remote.target.host_display(),
+        remote.target.remote_path(),
         remote.origin.as_str(),
     )?;
     let WebPrepOutcome::Ready(prep) = prep else {
@@ -172,7 +173,7 @@ fn run_supervised_web(remote: &RemoteConnect, client_size: Option<(u16, u16)>) -
     let control = rimz::remote::link::validated_control_path()
         .context("checking SSH ControlMaster socket path")?;
     let plan = remote.attach_plan(client_size)?;
-    let mut reconnect = rimz::remote::ReconnectState::new();
+    let mut reconnect = rimz::remote::ReconnectState::default();
     let host = remote.target.host_display();
     let Some(mut supervisor) = LinkSupervisor::connect(plan, control)? else {
         return Ok(());
@@ -193,6 +194,7 @@ fn run_supervised_web(remote: &RemoteConnect, client_size: Option<(u16, u16)>) -
             ),
             "preparing remote web access",
             host,
+            remote.target.remote_path(),
             remote.origin.as_str(),
         )?;
         let prep = match prep {
@@ -382,6 +384,7 @@ fn run_web_prep(
     spec: &rimz::mux::CommandSpec,
     label: &str,
     host: &str,
+    remote_path: Option<&str>,
     setup_hint: &str,
 ) -> Result<WebPrepOutcome> {
     let mut child = spec
@@ -417,11 +420,12 @@ fn run_web_prep(
             rimz::remote::REMOTE_RIMZ_MISSING_EXIT
                 | rimz::remote::REMOTE_VERSION_SKEW_EXIT
                 | rimz::remote::REMOTE_VERSION_INCOMPATIBLE_EXIT
+                | rimz::remote::REMOTE_PATH_MISSING_EXIT
         )
     {
         bail!(
             "{}",
-            super::supervisor::fatal_session_message(code, host, setup_hint, None)
+            super::supervisor::fatal_session_message(code, host, remote_path, setup_hint, None)
         );
     }
     bail!("{label} failed with {status}");
@@ -500,7 +504,7 @@ mod tests {
     fn web_exit_settlement_uses_master_or_port_establishment() {
         let settle = |exit_code, master_confirmed, port_ready| {
             settle_web_exit(
-                &mut rimz::remote::ReconnectState::new(),
+                &mut rimz::remote::ReconnectState::default(),
                 exit_code,
                 master_confirmed,
                 port_ready,

--- a/crates/rimz/src/cli/sessions/picker.rs
+++ b/crates/rimz/src/cli/sessions/picker.rs
@@ -137,19 +137,20 @@ pub(super) fn run(
             .context("session picker lost its terminal guard")?
             .handoff_keep_screen()
             .context("handing off the session picker")?;
-        let (target, outcome) = match launch {
-            Launch::Attach(session, display_name, spec) => {
-                write_session_sync(mode, Some((&session, &display_name)))?;
-                let outcome = spec
-                    .to_command()
-                    .spawn()
-                    .and_then(|mut child| child.wait())
-                    .map_err(anyhow::Error::from);
-                (Some((session, display_name)), outcome)
-            }
-            Launch::Create(path) => {
-                match crate::cli::room::ensure_workspace_room_detached(&path, globals, false, false)
-                {
+        let launched = (|| -> Result<_> {
+            Ok(match launch {
+                Launch::Attach(session, display_name, spec) => {
+                    write_session_sync(mode, Some((&session, &display_name)))?;
+                    let outcome = spec
+                        .to_command()
+                        .spawn()
+                        .and_then(|mut child| child.wait())
+                        .map_err(anyhow::Error::from);
+                    (Some((session, display_name)), outcome)
+                }
+                Launch::Create(path) => match crate::cli::room::ensure_workspace_room_detached(
+                    &path, globals, false, false,
+                ) {
                     Ok(context) => {
                         let session = context.session_name().to_owned();
                         let display_name = session_display_name(&session);
@@ -167,9 +168,11 @@ pub(super) fn run(
                         let error = err.context(format!("creating a room for {}", path.display()));
                         (None, Err(error))
                     }
-                }
-            }
-        };
+                },
+            })
+        })();
+        rimz::tui::finish_handoff(MouseCapture::Stdout, Screen::Alternate);
+        let (target, outcome) = launched?;
         guard = Some(
             TerminalModeGuard::enable(MouseCapture::Stdout, Screen::Alternate)
                 .context("restoring the session picker")?,

--- a/crates/rimz/src/cli/supervised.rs
+++ b/crates/rimz/src/cli/supervised.rs
@@ -103,9 +103,7 @@ pub(crate) fn stop_supervised_run(
     globals: &GlobalFlags,
     run: &RunRecord,
 ) -> Result<()> {
-    if !run.status.is_terminal() {
-        rimz::harness::run::cancel_and_wake(store, &run.run_id)?;
-    }
+    cancel_supervised_run(store, run)?;
     if let Ok(backend) = pane::backend_for_workspace_session(workspace, globals) {
         pane::close_stopped_run_pane_after_grace(
             backend.as_ref(),
@@ -114,6 +112,13 @@ pub(crate) fn stop_supervised_run(
             run,
             pane::STOP_BACKSTOP_GRACE,
         );
+    }
+    Ok(())
+}
+
+pub(crate) fn cancel_supervised_run(store: &rimz::Store, run: &RunRecord) -> Result<()> {
+    if !run.status.is_terminal() {
+        rimz::harness::run::cancel_and_wake(store, &run.run_id)?;
     }
     Ok(())
 }

--- a/crates/rimz/src/harness/schedule/catalog.rs
+++ b/crates/rimz/src/harness/schedule/catalog.rs
@@ -452,10 +452,10 @@ pub fn delivery_target_alive(
     target: &crate::config::TaskTarget,
 ) -> Result<bool> {
     let root = entry.resolved_root();
-    let workspace = WorkspaceResolver::resolve(&root, None)
-        .with_context(|| format!("resolving project root at {}", root.display()))?;
-    let paths = StatePaths::for_workspace(workspace.workspace_id.clone())?;
-    let runtime = RuntimePaths::for_workspace(workspace.workspace_id)?;
+    let workspace_id = WorkspaceResolver::persisted_workspace_id(&root)
+        .with_context(|| format!("resolving persisted project root at {}", root.display()))?;
+    let paths = StatePaths::for_workspace(workspace_id.clone())?;
+    let runtime = RuntimePaths::for_workspace(workspace_id)?;
     let store = Store::open(paths, runtime)?;
     let snapshot = store.snapshot_cached().context("reading agent snapshot")?;
     Ok(snapshot.agents.iter().any(|agent| {
@@ -583,5 +583,21 @@ mod tests {
         entry.every = Some("15m".to_owned());
         entry.deadline = Some(jiff::Timestamp::UNIX_EPOCH);
         assert!(super::super::TaskShape::compile("task", &entry).is_ephemeral());
+    }
+
+    #[test]
+    fn vanished_delivery_root_is_not_alive() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let entry = TaskEntry {
+            root: dir.path().join("vanished"),
+            ..TaskEntry::default()
+        };
+        let target = crate::config::TaskTarget {
+            kind: "claude".to_owned(),
+            session: "missing-session".to_owned(),
+            handle: "@claude".to_owned(),
+        };
+
+        assert!(!delivery_target_alive(&entry, &target).expect("check vanished target"));
     }
 }

--- a/crates/rimz/src/harness/schedule/runner.rs
+++ b/crates/rimz/src/harness/schedule/runner.rs
@@ -182,10 +182,10 @@ impl FireContext {
                 scope: None,
             });
         }
-        let workspace = WorkspaceResolver::resolve(&root, None)?;
-        let runtime = RuntimePaths::for_workspace(workspace.workspace_id.clone())?;
         let scope = match &action {
             TaskAction::Spawn(spec) => {
+                let workspace = WorkspaceResolver::resolve(&root, None)?;
+                let runtime = RuntimePaths::for_workspace(workspace.workspace_id.clone())?;
                 let resolved = crate::harness::plan::resolve_single_agent_launch(spec, &workspace)?;
                 let managed_launch =
                     resolve_managed_spawn_state(entry, &workspace, &resolved, config)?;
@@ -198,6 +198,8 @@ impl FireContext {
                 scope
             }
             TaskAction::Deliver(target) => {
+                let workspace_id = WorkspaceResolver::persisted_workspace_id(&root)?;
+                let runtime = RuntimePaths::for_workspace(workspace_id)?;
                 let mut scope = FireScope::new(
                     crate::ids::AgentKind::new_unchecked(target.kind.clone()),
                     runtime,
@@ -992,9 +994,9 @@ pub fn newest_active_run(paths: &StatePaths, name: &str) -> Result<Option<RunRec
 /// Resolve the task workspace before selecting its newest active run.
 pub fn newest_active_run_for_entry(name: &str, entry: &TaskEntry) -> Result<Option<RunRecord>> {
     let root = entry.resolved_root();
-    let workspace = WorkspaceResolver::resolve(&root, None)
-        .with_context(|| format!("resolving project root at {}", root.display()))?;
-    let paths = StatePaths::for_workspace(workspace.workspace_id)?;
+    let workspace_id = WorkspaceResolver::persisted_workspace_id(&root)
+        .with_context(|| format!("resolving persisted project root at {}", root.display()))?;
+    let paths = StatePaths::for_workspace(workspace_id)?;
     newest_active_run(&paths, name)
 }
 

--- a/crates/rimz/src/harness/schedule/runner/tests.rs
+++ b/crates/rimz/src/harness/schedule/runner/tests.rs
@@ -3,6 +3,35 @@ use std::path::Path;
 use super::*;
 
 #[test]
+fn vanished_delivery_root_still_resolves_and_finds_no_active_run() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().join("vanished");
+    let entry = TaskEntry {
+        root: root.clone(),
+        ..TaskEntry::default()
+    };
+    let target = TaskTarget {
+        kind: "claude".to_owned(),
+        session: "session".to_owned(),
+        handle: "@claude".to_owned(),
+    };
+
+    let context = FireContext::resolve(
+        &entry,
+        TaskAction::Deliver(target),
+        &MachineConfig::default(),
+    )
+    .expect("resolve persisted delivery root");
+
+    assert!(context.scope.is_some());
+    assert!(
+        newest_active_run_for_entry("vanished-root", &entry)
+            .expect("read persisted workspace runs")
+            .is_none()
+    );
+}
+
+#[test]
 fn spawn_timeout_prefers_task_then_config_then_builtin() {
     use LoopRunMode::{Manual, Scheduled};
     let task = Duration::from_secs(30);

--- a/crates/rimz/src/main.rs
+++ b/crates/rimz/src/main.rs
@@ -46,7 +46,7 @@ fn install_tracing(report_to_sentry: bool) {
     // The env filter is per-layer on the fmt sink, so rendered panes silence
     // stderr without gating the Sentry layer's own `WARN` capture.
     let fmt_layer = tracing_subscriber::fmt::layer()
-        .with_writer(std::io::stderr)
+        .with_writer(rimz::tui::TuiLogWriter)
         .with_filter(filter);
     let sentry_layer = report_to_sentry.then(observability::sentry_tracing_layer);
     tracing_subscriber::registry()

--- a/crates/rimz/src/remote/mod.rs
+++ b/crates/rimz/src/remote/mod.rs
@@ -71,6 +71,9 @@ pub const REMOTE_VERSION_SKEW_EXIT: i32 = 65;
 /// The remote host refused a hard major version mismatch.
 pub const REMOTE_VERSION_INCOMPATIBLE_EXIT: i32 = 66;
 
+/// The guarded snippet refused a remote workspace path that does not exist.
+pub const REMOTE_PATH_MISSING_EXIT: i32 = 67;
+
 /// What the part after the `:` names on the remote host.
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum RemoteSpec {
@@ -180,6 +183,14 @@ impl RemoteTarget {
     /// The SSH destination part of this target.
     pub fn ssh_destination(&self) -> &SshDestination {
         &self.destination
+    }
+
+    /// The remote workspace path, when this target births or enters by path.
+    pub fn remote_path(&self) -> Option<&str> {
+        match &self.spec {
+            RemoteSpec::Path(path) => Some(path),
+            RemoteSpec::Session(_) => None,
+        }
     }
 }
 
@@ -414,6 +425,39 @@ impl SshAttachPlan {
             .arg(format!("ControlPath={}", control_path.display()))
             .args(["--", self.options.target.ssh_destination().as_str()])
     }
+
+    /// Probe a path target over an established ControlMaster before the tty
+    /// attach. Session targets need no filesystem precondition.
+    pub fn path_preflight(&self, control_path: &Path) -> Option<CommandSpec> {
+        let path = self.options.target.remote_path()?;
+        Some(
+            CommandSpec::new(ssh_program())
+                .args(["-o", "BatchMode=yes", "-o", "ConnectTimeout=10"])
+                .args(control_options(control_path))
+                .args(["--", self.options.target.ssh_destination().as_str()])
+                .arg(format!("test -d {}", quote_remote_path(path))),
+        )
+    }
+}
+
+/// Result of the conservative remote-path preflight classification.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PathPreflight {
+    Exists,
+    Missing,
+    /// Transport and unexpected command failures belong to the attach path,
+    /// which can report them without misdiagnosing a missing directory.
+    Unknown,
+}
+
+impl PathPreflight {
+    pub fn classify(exit_code: Option<i32>) -> Self {
+        match exit_code {
+            Some(0) => Self::Exists,
+            Some(1) => Self::Missing,
+            _ => Self::Unknown,
+        }
+    }
 }
 
 impl SshAttachAttempt<'_> {
@@ -603,8 +647,21 @@ fn guarded_snippet(
     remote_exec_snippet(
         options.target.host_display(),
         &env_setup,
+        &remote_path_guard(&options.target),
         &format!("{rimz} -- {arg}"),
     )
+}
+
+fn remote_path_guard(target: &RemoteTarget) -> String {
+    let Some(path) = target.remote_path() else {
+        return String::new();
+    };
+    let arg = quote_remote_path(path);
+    let missing = sh_quote(&format!(
+        "remote path does not exist on {}: {path}; check the target with `rimz remote list`, then correct the alias or remote path",
+        target.host_display()
+    ));
+    format!("test -d {arg} || {{ echo {missing} >&2; exit {REMOTE_PATH_MISSING_EXIT}; }}; ")
 }
 
 fn client_size_env_setup(client_size: Option<(u16, u16)>) -> String {
@@ -613,14 +670,19 @@ fn client_size_env_setup(client_size: Option<(u16, u16)>) -> String {
     })
 }
 
-fn remote_exec_snippet(host_display: &str, env_setup: &str, rimz_command: &str) -> String {
+fn remote_exec_snippet(
+    host_display: &str,
+    env_setup: &str,
+    path_guard: &str,
+    rimz_command: &str,
+) -> String {
     let not_found = sh_quote(&format!(
         "rimz not found on {host_display} — run `rimz remote setup <alias-or-host>` locally, or install rimz manually",
     ));
     format!(
         "{}; \
          command -v rimz >/dev/null 2>&1 || {{ echo {not_found} >&2; exit {code}; }}; \
-         {env_setup}exec {rimz_command}",
+         {path_guard}{env_setup}exec {rimz_command}",
         remote_path_prefix(),
         code = REMOTE_RIMZ_MISSING_EXIT,
     )
@@ -925,7 +987,8 @@ impl ReconnectState {
             Some(
                 code @ (REMOTE_RIMZ_MISSING_EXIT
                 | REMOTE_VERSION_SKEW_EXIT
-                | REMOTE_VERSION_INCOMPATIBLE_EXIT),
+                | REMOTE_VERSION_INCOMPATIBLE_EXIT
+                | REMOTE_PATH_MISSING_EXIT),
             ) => Verdict::Fatal { code },
             Some(SSH_TRANSPORT_EXIT) if self.established => Verdict::Retry,
             Some(_)

--- a/crates/rimz/src/remote/mod.rs
+++ b/crates/rimz/src/remote/mod.rs
@@ -428,35 +428,14 @@ impl SshAttachPlan {
 
     /// Probe a path target over an established ControlMaster before the tty
     /// attach. Session targets need no filesystem precondition.
-    pub fn path_preflight(&self, control_path: &Path) -> Option<CommandSpec> {
+    pub fn path_preflight(&self, control_path: &Path) -> Option<(CommandSpec, &str)> {
         let path = self.options.target.remote_path()?;
-        Some(
-            CommandSpec::new(ssh_program())
-                .args(["-o", "BatchMode=yes", "-o", "ConnectTimeout=10"])
-                .args(control_options(control_path))
-                .args(["--", self.options.target.ssh_destination().as_str()])
-                .arg(format!("test -d {}", quote_remote_path(path))),
-        )
-    }
-}
-
-/// Result of the conservative remote-path preflight classification.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum PathPreflight {
-    Exists,
-    Missing,
-    /// Transport and unexpected command failures belong to the attach path,
-    /// which can report them without misdiagnosing a missing directory.
-    Unknown,
-}
-
-impl PathPreflight {
-    pub fn classify(exit_code: Option<i32>) -> Self {
-        match exit_code {
-            Some(0) => Self::Exists,
-            Some(1) => Self::Missing,
-            _ => Self::Unknown,
-        }
+        let spec = CommandSpec::new(ssh_program())
+            .args(["-o", "BatchMode=yes", "-o", "ConnectTimeout=10"])
+            .args(control_options(control_path))
+            .args(["--", self.options.target.ssh_destination().as_str()])
+            .arg(format!("test -d {}", quote_remote_path(path)));
+        Some((spec, path))
     }
 }
 
@@ -965,10 +944,6 @@ pub struct ReconnectState {
 }
 
 impl ReconnectState {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Settle one finished ssh process. Terminal attaches supply ControlMaster
     /// liveness and whether the foreground client lived past the gatetime;
     /// callers without a multiplexer client pass `None`.

--- a/crates/rimz/src/remote/recovery.rs
+++ b/crates/rimz/src/remote/recovery.rs
@@ -241,6 +241,11 @@ impl RecoveryPanel {
         })
     }
 
+    /// Most recent SSH error retained for final interrupt and failure output.
+    pub fn last_error(&self) -> Option<&str> {
+        self.last_error.as_deref()
+    }
+
     pub fn frame(&self, outage_for: Duration, phase: FooterPhase) -> RecoveryFrame {
         let mut rows = Vec::with_capacity(4);
         if let Some(checkpoint) = &self.internet {

--- a/crates/rimz/src/remote/tests.rs
+++ b/crates/rimz/src/remote/tests.rs
@@ -286,7 +286,7 @@ fn path_preflight_reuses_the_master_and_quotes_the_remote_path() {
         TermPlan::Keep,
         false,
     );
-    let spec = plan
+    let (spec, path) = plan
         .path_preflight(Path::new("/tmp/rimz.sock"))
         .expect("path target has a preflight");
 
@@ -308,7 +308,7 @@ fn path_preflight_reuses_the_master_and_quotes_the_remote_path() {
             "test -d \"$HOME\"'/code/query engine'",
         ]
     );
-    assert_eq!(plan.target().remote_path(), Some("$HOME/code/query engine"));
+    assert_eq!(path, "$HOME/code/query engine");
 
     let session = attach_plan("dev-box:query-engine", false, None, TermPlan::Keep, false);
     assert!(
@@ -316,16 +316,6 @@ fn path_preflight_reuses_the_master_and_quotes_the_remote_path() {
             .path_preflight(Path::new("/tmp/rimz.sock"))
             .is_none()
     );
-    assert_eq!(session.target().remote_path(), None);
-}
-
-#[test]
-fn path_preflight_classifies_only_exit_one_as_missing() {
-    assert_eq!(PathPreflight::classify(Some(0)), PathPreflight::Exists);
-    assert_eq!(PathPreflight::classify(Some(1)), PathPreflight::Missing);
-    for code in [Some(2), Some(SSH_TRANSPORT_EXIT), None] {
-        assert_eq!(PathPreflight::classify(code), PathPreflight::Unknown);
-    }
 }
 
 #[test]
@@ -822,7 +812,7 @@ fn verdict_and_backoff_classify_reconnects() {
     );
 
     let settle =
-        |exit_code, established| ReconnectState::new().settle(exit_code, established, None);
+        |exit_code, established| ReconnectState::default().settle(exit_code, established, None);
     assert_eq!(settle(Some(0), true), Verdict::CleanExit);
     assert_eq!(settle(Some(SSH_TRANSPORT_EXIT), true), Verdict::Retry);
     assert_eq!(
@@ -906,7 +896,7 @@ fn unreachable_retry_delay_uses_the_user_safety_ladder() {
 
 #[test]
 fn reconnect_state_settles_established_sessions_and_failures() {
-    let mut state = ReconnectState::new();
+    let mut state = ReconnectState::default();
 
     assert_eq!(
         state.settle(Some(SSH_TRANSPORT_EXIT), false, None),
@@ -943,14 +933,14 @@ fn reconnect_state_settles_established_sessions_and_failures() {
 #[test]
 fn attached_exit_uses_control_liveness_instead_of_mux_status() {
     let settle = |control_alive, lived_past_gatetime| {
-        ReconnectState::new().settle(Some(1), true, Some((control_alive, lived_past_gatetime)))
+        ReconnectState::default().settle(Some(1), true, Some((control_alive, lived_past_gatetime)))
     };
 
     assert_eq!(settle(true, true), Verdict::Reattach);
     assert_eq!(settle(false, true), Verdict::Retry);
     assert_eq!(settle(true, false), Verdict::Fatal { code: 1 });
     assert_eq!(
-        ReconnectState::new().settle(Some(REMOTE_VERSION_SKEW_EXIT), true, Some((true, true)),),
+        ReconnectState::default().settle(Some(REMOTE_VERSION_SKEW_EXIT), true, Some((true, true)),),
         Verdict::Fatal {
             code: REMOTE_VERSION_SKEW_EXIT
         }

--- a/crates/rimz/src/remote/tests.rs
+++ b/crates/rimz/src/remote/tests.rs
@@ -278,6 +278,57 @@ fn master_spec_pins_supervised_lifecycle_and_has_no_remote_command() {
 }
 
 #[test]
+fn path_preflight_reuses_the_master_and_quotes_the_remote_path() {
+    let plan = attach_plan(
+        "dev-box:~/code/query engine",
+        false,
+        None,
+        TermPlan::Keep,
+        false,
+    );
+    let spec = plan
+        .path_preflight(Path::new("/tmp/rimz.sock"))
+        .expect("path target has a preflight");
+
+    assert_eq!(
+        spec.args,
+        [
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=10",
+            "-o",
+            "ControlMaster=auto",
+            "-o",
+            "ControlPath=/tmp/rimz.sock",
+            "-o",
+            "ControlPersist=no",
+            "--",
+            "dev-box",
+            "test -d \"$HOME\"'/code/query engine'",
+        ]
+    );
+    assert_eq!(plan.target().remote_path(), Some("$HOME/code/query engine"));
+
+    let session = attach_plan("dev-box:query-engine", false, None, TermPlan::Keep, false);
+    assert!(
+        session
+            .path_preflight(Path::new("/tmp/rimz.sock"))
+            .is_none()
+    );
+    assert_eq!(session.target().remote_path(), None);
+}
+
+#[test]
+fn path_preflight_classifies_only_exit_one_as_missing() {
+    assert_eq!(PathPreflight::classify(Some(0)), PathPreflight::Exists);
+    assert_eq!(PathPreflight::classify(Some(1)), PathPreflight::Missing);
+    for code in [Some(2), Some(SSH_TRANSPORT_EXIT), None] {
+        assert_eq!(PathPreflight::classify(code), PathPreflight::Unknown);
+    }
+}
+
+#[test]
 fn ssh_error_summary_uses_the_last_open_ssh_line() {
     assert_eq!(
         ssh_error_summary("debug noise\nssh: connect to host dev port 22: Connection refused\n"),
@@ -440,7 +491,12 @@ fn ssh_attach_plan_compiles_session_path_flags_control_and_term() {
             truecolor: false,
             control: None,
             destination_index: 10,
-            snippet_contains: &["exec rimz start --attach -- \"$HOME\"'/code/query-engine'"],
+            snippet_contains: &[
+                "test -d \"$HOME\"'/code/query-engine'",
+                "remote path does not exist on dev-box: $HOME/code/query-engine",
+                "exit 67",
+                "exec rimz start --attach -- \"$HOME\"'/code/query-engine'",
+            ],
         },
         SpecCase {
             name: "no resume and mux",
@@ -586,6 +642,11 @@ fn ssh_attach_plan_compiles_session_path_flags_control_and_term() {
                 case.name
             );
         }
+        assert_eq!(
+            snippet.contains("test -d"),
+            case.target.contains('/'),
+            "only path targets carry the directory guard: {snippet}"
+        );
         assert!(
             !snippet.contains(crate::mux::CLIENT_SIZE_ENV),
             "{} has no client-size export: {snippet}",
@@ -774,6 +835,12 @@ fn verdict_and_backoff_classify_reconnects() {
         settle(Some(REMOTE_RIMZ_MISSING_EXIT), true),
         Verdict::Fatal {
             code: REMOTE_RIMZ_MISSING_EXIT
+        }
+    );
+    assert_eq!(
+        settle(Some(REMOTE_PATH_MISSING_EXIT), true),
+        Verdict::Fatal {
+            code: REMOTE_PATH_MISSING_EXIT
         }
     );
     assert_eq!(settle(None, true), Verdict::Fatal { code: 1 });

--- a/crates/rimz/src/remote/web.rs
+++ b/crates/rimz/src/remote/web.rs
@@ -10,7 +10,8 @@ use std::path::Path;
 
 use super::{
     REMOTE_CLIENT_VERSION_ENV, REMOTE_FORCE_VERSION_ENV, RemoteSpec, RemoteTarget,
-    client_size_env_setup, quote_remote_path, remote_exec_snippet, sh_quote, ssh_program,
+    client_size_env_setup, quote_remote_path, remote_exec_snippet, remote_path_guard, sh_quote,
+    ssh_program,
 };
 use crate::mux::CommandSpec;
 
@@ -169,7 +170,12 @@ fn web_snippet(
         env_setup.push_str(&format!("export {REMOTE_FORCE_VERSION_ENV}=1; "));
     }
     env_setup.push_str(&client_size_env_setup(client_size));
-    remote_exec_snippet(target.host_display(), &env_setup, rimz)
+    remote_exec_snippet(
+        target.host_display(),
+        &env_setup,
+        &remote_path_guard(target),
+        rimz,
+    )
 }
 
 #[cfg(test)]

--- a/crates/rimz/src/tui.rs
+++ b/crates/rimz/src/tui.rs
@@ -10,9 +10,136 @@ use ratatui::crossterm::execute;
 use ratatui::crossterm::queue;
 use ratatui::crossterm::style::Print;
 use ratatui::crossterm::{cursor, terminal};
+use tracing_subscriber::fmt::MakeWriter;
 
 type PanicHook = Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send + 'static>;
 type SharedPanicHook = Arc<Mutex<Option<PanicHook>>>;
+const LOG_CAPTURE_CAP: usize = 64 * 1024;
+
+#[derive(Default)]
+struct LogCapture {
+    depth: usize,
+    bytes: Vec<u8>,
+}
+
+fn log_capture() -> &'static Mutex<LogCapture> {
+    static CAPTURE: OnceLock<Mutex<LogCapture>> = OnceLock::new();
+    CAPTURE.get_or_init(|| Mutex::new(LogCapture::default()))
+}
+
+fn begin_log_capture() {
+    let mut capture = log_capture()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if capture.depth == 0 {
+        capture.bytes.clear();
+    }
+    capture.depth += 1;
+}
+
+fn end_log_capture() -> Option<Vec<u8>> {
+    let mut capture = log_capture()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if capture.depth == 0 {
+        return None;
+    }
+    capture.depth -= 1;
+    (capture.depth == 0).then(|| std::mem::take(&mut capture.bytes))
+}
+
+fn end_log_capture_flush() {
+    let Some(bytes) = end_log_capture() else {
+        return;
+    };
+    let mut stderr = io::stderr().lock();
+    let _ = stderr.write_all(&bytes);
+    let _ = stderr.flush();
+}
+
+/// Captured tracing lines for a full-screen surface to render without writing
+/// over its active terminal frame.
+pub fn captured_log_lines() -> Vec<String> {
+    let bytes = log_capture()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .bytes
+        .clone();
+    String::from_utf8_lossy(&bytes)
+        .lines()
+        .map(strip_ansi)
+        .collect()
+}
+
+fn strip_ansi(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut chars = line.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\x1b' {
+            if let Some('[') = chars.next() {
+                for escaped in chars.by_ref() {
+                    if matches!(escaped, '\x40'..='\x7e') {
+                        break;
+                    }
+                }
+            }
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// Tracing writer that diverts stderr into the active terminal surface.
+pub struct TuiLogWriter;
+
+struct CapturedLogOutput;
+
+impl Write for CapturedLogOutput {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut capture = log_capture()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if buf.len() >= LOG_CAPTURE_CAP {
+            capture.bytes.clear();
+            capture
+                .bytes
+                .extend_from_slice(&buf[buf.len() - LOG_CAPTURE_CAP..]);
+        } else {
+            let overflow = capture
+                .bytes
+                .len()
+                .saturating_add(buf.len())
+                .saturating_sub(LOG_CAPTURE_CAP);
+            if overflow > 0 {
+                capture.bytes.drain(..overflow);
+            }
+            capture.bytes.extend_from_slice(buf);
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for TuiLogWriter {
+    type Writer = Box<dyn Write + 'a>;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        let captured = log_capture()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .depth
+            > 0;
+        if captured {
+            Box::new(CapturedLogOutput)
+        } else {
+            Box::new(io::stderr())
+        }
+    }
+}
 
 /// Click + wheel tracking (?1000) with SGR encoding (?1006) — the only modes
 /// the sidebar consumes (`sidebar_pane::app::input::encode_mouse`). Crossterm's
@@ -85,7 +212,7 @@ pub fn truecolor() -> bool {
 }
 
 /// Write a buffered terminal frame with raw-mode-safe, self-clearing lines.
-pub fn write_crlf(w: &mut impl Write, bytes: &[u8]) -> io::Result<()> {
+fn write_crlf(w: &mut impl Write, bytes: &[u8]) -> io::Result<()> {
     let mut start = 0;
     for (index, byte) in bytes.iter().enumerate() {
         if *byte != b'\n' {
@@ -161,7 +288,11 @@ fn tput_capability(
 
 impl TerminalModeGuard {
     pub fn enable(mouse: MouseCapture, screen: Screen) -> io::Result<Self> {
-        terminal::enable_raw_mode()?;
+        begin_log_capture();
+        if let Err(err) = terminal::enable_raw_mode() {
+            end_log_capture_flush();
+            return Err(err);
+        }
         if screen == Screen::Alternate
             && let Err(err) = execute!(
                 io::stdout(),
@@ -204,6 +335,8 @@ impl TerminalModeGuard {
         // The process exits immediately after this handoff, so keeping the
         // panic hook installed and skipping the terminal restore are both
         // intentional.
+        // ponytail: the capture buffer dies with this process; transfer it if
+        // reexec handoffs ever need to preserve diagnostics.
         std::mem::forget(self);
     }
 
@@ -273,6 +406,7 @@ pub(crate) fn restore_terminal(mouse: MouseCapture, screen: Screen) {
         );
     }
     let _ = terminal::disable_raw_mode();
+    end_log_capture_flush();
 }
 
 /// Complete a terminal handoff whose guard preserved the active screen and
@@ -284,10 +418,12 @@ pub fn finish_handoff(mouse: MouseCapture, screen: Screen) {
 #[cfg(test)]
 mod tests {
     use super::{
-        DISABLE_CLICK_WHEEL_CAPTURE, ENABLE_CLICK_WHEEL_CAPTURE, TruecolorSignals, replace_frame,
-        write_crlf,
+        DISABLE_CLICK_WHEEL_CAPTURE, ENABLE_CLICK_WHEEL_CAPTURE, LOG_CAPTURE_CAP, TruecolorSignals,
+        TuiLogWriter, begin_log_capture, captured_log_lines, end_log_capture, replace_frame,
+        strip_ansi, write_crlf,
     };
     use std::io::Write;
+    use tracing_subscriber::fmt::MakeWriter;
 
     #[derive(Default)]
     struct RecordingWriter {
@@ -369,5 +505,33 @@ mod tests {
     fn mouse_capture_requests_only_click_wheel_and_sgr_modes() {
         assert_eq!(ENABLE_CLICK_WHEEL_CAPTURE, "\x1b[?1000h\x1b[?1006h");
         assert_eq!(DISABLE_CLICK_WHEEL_CAPTURE, "\x1b[?1006l\x1b[?1000l");
+    }
+
+    #[test]
+    fn tracing_writer_captures_and_cleans_full_screen_logs() {
+        let writer = TuiLogWriter;
+        begin_log_capture();
+        let mut output = writer.make_writer();
+        output
+            .write_all(b"\x1b[31mwarning\x1b[0m\nnext\n")
+            .expect("capture log");
+        assert_eq!(captured_log_lines(), ["warning", "next"]);
+        assert_eq!(
+            end_log_capture().expect("drain capture"),
+            b"\x1b[31mwarning\x1b[0m\nnext\n"
+        );
+        assert!(captured_log_lines().is_empty());
+        assert_eq!(strip_ansi("a\x1b[1;31mb\x1b[0mc"), "abc");
+
+        begin_log_capture();
+        let oversized = vec![b'x'; LOG_CAPTURE_CAP + 1];
+        writer
+            .make_writer()
+            .write_all(&oversized)
+            .expect("capture oversized log");
+        assert_eq!(
+            end_log_capture().expect("drain bounded capture").len(),
+            LOG_CAPTURE_CAP
+        );
     }
 }

--- a/crates/rimz/src/workspace.rs
+++ b/crates/rimz/src/workspace.rs
@@ -349,6 +349,19 @@ impl WorkspaceResolver {
         )
     }
 
+    /// Resolve the workspace identity recorded by durable state. Persisted
+    /// roots can outlive their directory, so a vanished path is normalized
+    /// lexically instead of being treated as a new room precondition.
+    pub fn persisted_workspace_id(root: impl AsRef<Path>) -> Result<WorkspaceId> {
+        let root = root.as_ref();
+        if root.exists() {
+            return Self::resolve(root, None).map(|workspace| workspace.workspace_id);
+        }
+        Ok(WorkspaceId::from_project_root(&normalized_root(
+            root.to_path_buf(),
+        )?))
+    }
+
     /// Resolve on behalf of a participant in a live room: the session's
     /// verified env pin ([`ENV_WORKSPACE_ID`]/[`ENV_PROJECT_ROOT`]) beats the
     /// static ladder; an explicit `root_override` beats both.
@@ -419,6 +432,12 @@ impl WorkspaceResolver {
                 let class = classify_root(&root)?;
                 let cwd_project_root = (class == RootClass::Repo).then(|| root.clone());
                 (root.clone(), cwd_project_root, root, class)
+            } else if mode == ResolveMode::Create && !start.exists() {
+                return Err(WorkspaceErr::Resolve {
+                    path: start_in.to_path_buf(),
+                    reason: "the path does not exist; check the path or create the directory first"
+                        .to_owned(),
+                });
             } else if let Some(pinned) = match mode {
                 ResolveMode::Create => None,
                 ResolveMode::Participate => {

--- a/crates/rimz/src/workspace/tests.rs
+++ b/crates/rimz/src/workspace/tests.rs
@@ -394,6 +394,36 @@ fn create_mode_ignores_the_pin() {
 }
 
 #[test]
+fn create_mode_refuses_a_missing_starting_path() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let missing = dir.path().join("missing");
+
+    let err =
+        WorkspaceResolver::resolve_with(ResolveMode::Create, &missing, None, &no_env, NO_SCAN)
+            .expect_err("missing path must fail");
+
+    assert_eq!(
+        err.to_string(),
+        format!(
+            "could not resolve workspace from {}: the path does not exist; check the path or create the directory first",
+            missing.display()
+        )
+    );
+}
+
+#[test]
+fn participate_mode_keeps_missing_path_fallback() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let missing = dir.path().join("missing");
+
+    let resolved =
+        WorkspaceResolver::resolve_with(ResolveMode::Participate, &missing, None, &no_env, NO_SCAN)
+            .expect("participant resolution must not fail");
+
+    assert_eq!(resolved.project_root, missing);
+}
+
+#[test]
 fn root_override_beats_the_pin() {
     let (dir, pinned_root, marker_dir) = pin_fixture();
     let pinned_root = pinned_root.canonicalize().expect("canonical room");
@@ -483,6 +513,20 @@ fn bare_directory_resolves_as_a_directory_workspace() {
     );
     assert_eq!(resolved.project_root, resolved.worktree_root);
     assert_eq!(resolved.cwd_project_root, None);
+}
+
+#[test]
+fn persisted_workspace_id_absolutizes_a_vanished_relative_root() {
+    let relative = Path::new("target/rimz-vanished-persisted-root");
+    assert!(!relative.exists(), "fixture root must stay nonexistent");
+    let absolute = crate::worktree::normalize_path_lexical(
+        &std::env::current_dir().expect("current dir").join(relative),
+    );
+
+    assert_eq!(
+        WorkspaceResolver::persisted_workspace_id(relative).expect("resolve persisted identity"),
+        WorkspaceId::from_project_root(&absolute)
+    );
 }
 
 #[test]

--- a/crates/rimz/tests/fixtures/ssh-trace/main.rs
+++ b/crates/rimz/tests/fixtures/ssh-trace/main.rs
@@ -20,6 +20,7 @@
 //! publishes the control socket marker before parking.
 //! `$RIMZ_TEST_SSH_MASTER_EXIT_PLAN` and `$RIMZ_TEST_SSH_MASTER_EXIT_MS`
 //! script established ControlMaster exits.
+//! `$RIMZ_TEST_SSH_PATH_PREFLIGHT_PLAN` scripts remote `test -d` probes.
 
 use std::env;
 use std::fs::OpenOptions;
@@ -50,6 +51,10 @@ fn main() {
             run_web_control_forward();
         }
         return;
+    }
+
+    if is_path_preflight(&argv) {
+        exit_from_plan("RIMZ_TEST_SSH_PATH_PREFLIGHT_PLAN");
     }
 
     if argv
@@ -390,6 +395,10 @@ fn is_control_check(argv: &[String]) -> bool {
 fn is_forward_control(argv: &[String]) -> bool {
     argv.windows(2)
         .any(|args| args[0] == "-O" && matches!(args[1].as_str(), "forward" | "cancel"))
+}
+
+fn is_path_preflight(argv: &[String]) -> bool {
+    argv.iter().any(|arg| arg.starts_with("test -d "))
 }
 
 fn exit_control_check(argv: &[String]) -> ! {

--- a/crates/rimz/tests/integration/remote_attach.rs
+++ b/crates/rimz/tests/integration/remote_attach.rs
@@ -72,6 +72,24 @@ fn remote_connect_command(env: &Env, log: &Path) -> Command {
     cmd
 }
 
+fn remote_path_connect_command(env: &Env, log: &Path) -> Command {
+    let mut cmd = env.rimz();
+    cmd.args([
+        "remote",
+        "connect",
+        "dev-box:workspace/query-engine",
+        "--attach",
+    ])
+    .env("RIMZ_SSH_BIN", ssh_shim())
+    .env("RIMZ_TEST_SSH_LOG", log)
+    .env("RIMZ_REMOTE_DIAL_MS", "0")
+    .env("RIMZ_REMOTE_PROBE_MS", "0")
+    .env("RIMZ_REMOTE_REACHABLE_RETRY_MS", "1")
+    .env("RIMZ_REMOTE_MIN_DISPLAY_MS", "0")
+    .env("TERM", "xterm-256color");
+    cmd
+}
+
 fn remote_connect_pty_command(env: &Env, log: &Path) -> CommandBuilder {
     let mut cmd = CommandBuilder::new(env.rimz_bin());
     env.pin_pty_command(&mut cmd);
@@ -275,6 +293,10 @@ fn is_config_query_invocation(argv: &[String]) -> bool {
     argv.iter().any(|arg| arg == "-G")
 }
 
+fn is_path_preflight_invocation(argv: &[String]) -> bool {
+    argv.iter().any(|arg| arg.starts_with("test -d "))
+}
+
 fn is_master_invocation(argv: &[String]) -> bool {
     argv.iter().any(|arg| arg == "-M")
 }
@@ -284,6 +306,7 @@ fn is_main_invocation(argv: &[String]) -> bool {
         && !is_control_check_invocation(argv)
         && !is_config_query_invocation(argv)
         && !is_master_invocation(argv)
+        && !is_path_preflight_invocation(argv)
 }
 
 fn main_invocation_count(log: &Path) -> usize {
@@ -730,6 +753,88 @@ fn one_shot_connect_mirrors_the_ssh_clients_suspend() {
     killpg(pid, Signal::SIGCONT).expect("foreground the attach process group");
     let status = child.wait().expect("wait resumed remote connect");
     assert!(status.success(), "resumed attach failed with {status}");
+}
+
+#[test]
+fn supervised_missing_remote_path_fails_before_attach() {
+    let env = Env::new();
+    let log = env.project_root.join("ssh-trace.log");
+    let preflight_plan = env.project_root.join("ssh-path-preflight.plan");
+    std::fs::write(&preflight_plan, "1\n").expect("write path preflight plan");
+
+    let out = remote_path_connect_command(&env, &log)
+        .env("RIMZ_TEST_SSH_PATH_PREFLIGHT_PLAN", &preflight_plan)
+        .bounded_output()
+        .expect("run missing-path remote connect");
+
+    assert!(!out.status.success(), "missing path must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("remote path does not exist on dev-box: workspace/query-engine"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("rimz remote list"), "{stderr}");
+    let invocations = shim_invocations(&log);
+    assert_eq!(
+        invocations
+            .iter()
+            .filter(|argv| is_path_preflight_invocation(argv))
+            .count(),
+        1,
+        "one path preflight: {invocations:?}"
+    );
+    assert_eq!(
+        main_invocation_count(&log),
+        0,
+        "the tty attach must not run: {invocations:?}"
+    );
+}
+
+#[test]
+fn supervised_existing_remote_path_preflights_before_attach() {
+    let env = Env::new();
+    let log = env.project_root.join("ssh-trace.log");
+
+    let out = remote_path_connect_command(&env, &log)
+        .bounded_output()
+        .expect("run existing-path remote connect");
+
+    assert!(
+        out.status.success(),
+        "existing path reaches attach\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let invocations = shim_invocations(&log);
+    let preflight_index = invocations
+        .iter()
+        .position(|argv| is_path_preflight_invocation(argv))
+        .expect("path preflight invocation");
+    let attach_index = invocations
+        .iter()
+        .position(|argv| is_main_invocation(argv))
+        .expect("main attach invocation");
+    assert!(
+        preflight_index < attach_index,
+        "preflight precedes attach: {invocations:?}"
+    );
+}
+
+#[test]
+fn supervised_session_target_skips_path_preflight() {
+    let env = Env::new();
+    let log = env.project_root.join("ssh-trace.log");
+
+    let out = remote_connect_command(&env, &log)
+        .bounded_output()
+        .expect("run session remote connect");
+
+    assert!(out.status.success(), "session attach succeeds");
+    assert!(
+        !shim_invocations(&log)
+            .iter()
+            .any(|argv| is_path_preflight_invocation(argv)),
+        "session targets have no filesystem preflight"
+    );
 }
 
 #[test]

--- a/docs/guide/remote.md
+++ b/docs/guide/remote.md
@@ -10,7 +10,7 @@ Point `rimz remote connect` at a target and RimZ builds the SSH command, connect
 rimz remote connect dev-box:~/code/query-engine   # [user@]host:<session-or-path>
 ```
 
-The target is `[user@]host:<session-or-path>`. After the colon, a path opens (or creates) that project's room, and a bare session name reaches one by name. Under the hood this is close to typing `ssh -t dev-box rimz attach query-engine` yourself: a normal SSH session that runs the host's own `rimz`, so your SSH config, keys, agent, ports, and jump hosts all apply exactly as for any `ssh` you run.
+The target is `[user@]host:<session-or-path>`. After the colon, an existing path opens (or creates) that project's room, and a bare session name reaches one by name. A missing path fails immediately with the path and alias fix before RimZ starts the visible attach; use `rimz remote list` to check a saved target. Under the hood this is close to typing `ssh -t dev-box rimz attach query-engine` yourself: a normal SSH session that runs the host's own `rimz`, so your SSH config, keys, agent, ports, and jump hosts all apply exactly as for any `ssh` you run.
 
 RimZ compares the local and remote versions before it enters the room. A patch difference warns and proceeds; a minor difference refuses until you upgrade the older side, with `--force-version` available as a one-shot bypass; and a major difference refuses without a bypass. An older remote RimZ keeps its prior warn-only behavior because the compatibility gate runs on the host.
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -89,6 +89,10 @@ The `MACHINE CONFIG` section names any `config.toml`, `theme.toml`, `agents.toml
 
 ## The room won't start
 
+### RimZ says the workspace path does not exist
+
+`rimz start -- /path/to/project` only creates a room for a directory that already exists. Correct a typo in the path or create the directory first, then run the command again. Remote path targets follow the same rule before attach; run `rimz remote list` to inspect a saved alias and correct its target.
+
 ### RimZ reports an existing room instead of opening one
 
 A RimZ room is its own Zellij or tmux session, so it cannot nest inside a session you are already attached to. Run bare `rimz` (or `rimz start`) from inside one, and instead of nesting it names the room and tells you how to reach it:

--- a/docs/internals/remote.md
+++ b/docs/internals/remote.md
@@ -71,8 +71,9 @@ Every remote invocation ships one shell word to the remote login shell. The atta
 
 1. Repair `PATH`, because a non-login shell often lacks `~/.cargo/bin`, `~/.local/bin`, `/opt/homebrew/bin`, and `/usr/local/bin`.
 2. `command -v rimz` or exit `127` after printing the install fix. The supervisor special-cases that sentinel and prints `rimz remote setup <original-input>` instead of its reconnect-policy tail.
-3. Export the environment the remote room reads.
-4. `exec` into `rimz`, so no shell survives between SSH and the room.
+3. For a path target, `test -d` or exit `67` after naming the missing path. This guard stays in the snippet so one-shot connections, interactive fallback, and older remote RimZ versions refuse before room birth.
+4. Export the environment the remote room reads.
+5. `exec` into `rimz`, so no shell survives between SSH and the room.
 
 The probe stream is the exception: it repairs `PATH` and execs `rimz remote link-stats ingest` without the missing-binary guard, because a probe that cannot start is best-effort and must not print into the user's session.
 
@@ -136,7 +137,10 @@ supervise_remote
      │                       reachability workers pace the attempts
      │                       ssh -M -N -o BatchMode=yes, then -O check
      │
-     ├── Connected ───────►  start the probe stream, then ssh -t on the same socket
+     ├── Connected ───────►  path target? test -d over the same socket
+     │                            │
+     │                            ▼
+     │                       start the probe stream, then ssh -t on the same socket
      │                            │
      │                            ▼
      │                       Verdict::CleanExit → return to the caller
@@ -147,7 +151,7 @@ supervise_remote
                              (prompts are usable; a failure there is fatal)
 ```
 
-**Proving the transport first** is why the master exists. RimZ launches `ssh -M -N -o BatchMode=yes` with piped stderr onto a PID-scoped control socket, then polls `ssh -S <socket> -O check`. A successful check proves transport and authentication before anything paints, so the panel never shows an all-healthy frame it cannot back. The visible `ssh -t` then reuses that socket.
+**Proving the transport first** is why the master exists. RimZ launches `ssh -M -N -o BatchMode=yes` with piped stderr onto a PID-scoped control socket, then polls `ssh -S <socket> -O check`. A successful check proves transport and authentication before anything paints, so the panel never shows an all-healthy frame it cannot back. On the initial connection, a path target then runs `test -d` over that same socket before handoff. Exit `1` is the one conclusive missing-path result; transport and unexpected exits stay unknown and defer to the normal attach instead of being misdiagnosed. The visible `ssh -t` then reuses the socket.
 
 `MasterState` holds three variants and each tick yields one outcome:
 
@@ -178,7 +182,7 @@ An attach over a confirmed master pipes and drains SSH stderr instead of letting
 | --- | --- | --- |
 | `0` | any | `CleanExit` — return to the caller |
 | `255` with OpenSSH's remote `SIGINT` diagnostic | any | Explicit Ctrl-C — return to the caller without retrying |
-| remote RimZ precondition sentinel (`65`, `66`, `127`) | any | `Fatal` — surface the specific version or install fix |
+| remote RimZ precondition sentinel (`65`, `66`, `67`, `127`) | any | `Fatal` — surface the specific version, path, or install fix |
 | `255` | established SSH | `Retry` — enter background recovery |
 | nonzero | established SSH, ControlMaster ended | `Retry` — the attach status is not trusted over SSH liveness |
 | nonzero | ControlMaster alive, foreground attach lived past gatetime | `Reattach` — replace only the multiplexer client over the existing SSH connection |
@@ -187,7 +191,7 @@ An attach over a confirmed master pipes and drains SSH stderr instead of letting
 
 SSH counts as established once its link probe receives the first ack, once its initial master is confirmed, or once the foreground attach lives past the gatetime (30 seconds by default). The gatetime is also independent evidence that the multiplexer attach ran rather than failing at launch. This split matters because tmux and Zellij may return a nonzero client status when a reload deliberately disconnects an established client: a live ControlMaster makes that a fast reattach, not a false link-loss notification. `ReconnectState` folds transport establishment and consecutive failures across sessions; `settle_zombie_kill` records an intentional kill without classifying its signal exit as fatal.
 
-**Terminal hygiene** wraps every session. `TtyGuard` snapshots local termios at connect, repairs a leftover raw tty at entry, and restores the snapshot after each SSH session. Before every replacement attach, it puts the local tty in raw mode and drains it until quiet. This absorbs DA1, DA2, and XTVERSION replies addressed to the dead SSH generation: a duplicate reply is what tmux passes through to the focused pane as keystrokes after the replacement client has already accepted the stale copy. Ctrl-C ends the drain promptly instead of extending the quiet window. Exit paths and the initial attach never drain, preserving type-ahead for the shell that regains the terminal and input typed while `rimz remote connect` starts. An unclean end also writes the emulator reset string, because `ssh -t` mirrors local tty modes onto the remote pty and a `SIGKILL`ed transport cannot restore terminal-emulator state itself.
+**Terminal hygiene** wraps every session. `TtyGuard` snapshots local termios at connect, repairs a leftover raw tty at entry, and restores the snapshot after each SSH session. Before every replacement attach, it puts the local tty in raw mode and drains it until quiet. This absorbs DA1, DA2, and XTVERSION replies addressed to the dead SSH generation: a duplicate reply is what tmux passes through to the focused pane as keystrokes after the replacement client has already accepted the stale copy. Ctrl-C ends the drain promptly instead of extending the quiet window. Exit paths and the initial attach never drain, preserving type-ahead for the shell that regains the terminal and input typed while `rimz remote connect` starts. An unclean end also writes the emulator reset string, because `ssh -t` mirrors local tty modes onto the remote pty and a `SIGKILL`ed transport cannot restore terminal-emulator state itself. While any full-screen guard owns the terminal, the tracing writer buffers warnings instead of writing through the frame; the panel can render their cleaned tail, and terminal restore replays the original bytes to stderr.
 
 ## Reconnect pacing and reachability
 
@@ -230,7 +234,7 @@ The panel separates four pipeline stages. Network checkpoints hold their last se
 
 `StageStatus::Suspect` is the one non-obvious status. A server that still answers TCP after at least two failed SSH attempts reads yellow with `answers TCP · SSH failing`, rather than a green row beside a failing connection. A TUN route reads `via TUN <interface> · TCP check skipped`, becoming `via TUN <interface> · SSH failing` under the same condition.
 
-Presentation details worth preserving: the panel centers one block with left-aligned rows and fixed label columns; initial-stage wording says `Connecting` while recovery says `Connection lost`; exactly one row animates, the Internet row while waiting for the network, the SSH session row while establishing the master, and the Multiplexer row after confirmation; the active phase, countdown, and final OpenSSH stderr line fold into that row while the dim header carries the attempt, elapsed time, and `Ctrl-C stops`. Once shown, the panel stays for at least `1.5s`, so a fast reconnect uses the remaining hold window for the attaching animation instead of flashing. A connection that lands inside the grace never shows a panel, marker, or handoff frame.
+Presentation details worth preserving: the panel centers one block with left-aligned rows and fixed label columns; initial-stage wording says `Connecting` while recovery says `Connection lost`; exactly one row animates, the Internet row while waiting for the network, the SSH session row while establishing the master, and the Multiplexer row after confirmation; the active phase, countdown, and final OpenSSH stderr line fold into that row while the dim header carries the attempt, elapsed time, and `Ctrl-C stops`. Once shown, the panel stays for at least `1.5s`, so a fast reconnect uses the remaining hold window for the attaching animation instead of flashing. A connection that lands inside the grace never shows a panel, marker, or handoff frame. A fatal pre-attach failure replaces an active panel with the error, its fix, and up to five captured warning lines, then holds that frame until any key is pressed. Restore returns to the main screen before the CLI reports the error again, preserving it in scrollback.
 
 Ctrl-C is polled as a terminal event in raw mode: it kills a pending master, restores the terminal, and stops the supervisor cleanly. Once SSH owns the terminal, OpenSSH reports a remote prompt interrupted by Ctrl-C as status 255 plus `Killed by signal 2.`; the supervisor recognizes that diagnostic before transport classification and stops instead of reconnecting.
 

--- a/refactor-target.toml
+++ b/refactor-target.toml
@@ -660,7 +660,9 @@ surface-budget = 48
 [[module]]
 path = "crates/rimz/src/tui.rs"
 allowed-imports = []
-surface-budget = 15
+# Reload handoffs need a named terminal-preservation API; hiding the lifecycle
+# behind call-site `mem::forget` makes the log-capture ownership invisible.
+surface-budget = 16
 
 [[module]]
 path = "crates/rimz/src/uninstall.rs"

--- a/refactor-target.toml
+++ b/refactor-target.toml
@@ -390,7 +390,10 @@ allowed-imports = [
     "store",
     "update",
 ]
-surface-budget = 172
+# Remote failure presentation needs typed access to the path sentinel, target
+# path, and retained recovery error; keeping these private forced string
+# dispatch and dummy-frame construction across the library/binary boundary.
+surface-budget = 175
 
 [[module]]
 path = "crates/rimz/src/remote_control.rs"


### PR DESCRIPTION
## Context

A `rimz remote connect` against an alias whose target path no longer exists on the server connected, attached, and birthed a broken room. Two failures sat behind that:

Nothing validated the remote path. Remote `rimz start` accepted it because `WorkspaceResolver::resolve_with` never checked existence in `Create` mode: the chdir-`NotFound` from `git_output` mapped to `Ok(None)`, the marker walk found nothing, the bare-directory tier accepted the path, and `normalized_root` fell back to lexical absolutize. Room birth then ran with a bogus cwd, and the user saw only downstream symptoms — an "ignoring workspace pin with a vanished root" warning and later "no live RimZ room". Local `rimz start` had the same bug.

The `connecting…` panel also lost its errors. Retry detail rendered only inside the alternate screen, which `LeaveAlternateScreen` discards, so on Ctrl-C the error vanished and only a terse "reconnect stopped" survived. Meanwhile the tracing fmt layer wrote straight to stderr with no terminal coordination, scribbling raw WARN lines over the live frame.

## Design choices

**Two fail-fast layers, chosen for different reach.** A `test -d` preflight runs over the already-established ControlMaster inside `wait_for_master`'s `Connected` arm, before handoff — the socket is live, so it costs about one round trip, and the panel is still up to render the failure. It is gated to the initial connect. A version-independent `test -d … || exit 67` guard in the launch snippet covers what the preflight cannot reach: `--no-reconnect`, the interactive fallback, older remote RimZ versions, and a path that vanishes mid-session.

**Preflight classification is deliberately conservative.** Only exit `1` means missing. Transport failures and unexpected exits proceed to the attach, which can report the real error, so a network wobble is never misdiagnosed as a missing path.

**The root cause is fixed once, in the resolver.** `resolve_with` refuses a nonexistent `Create`-mode root rather than each caller checking. The guard sits below the `root_override` branch so it only fires when the starting path actually determines the root, and the four call sites that resolve a *persisted* task root — which legitimately outlives its directory — share one `WorkspaceResolver::persisted_workspace_id` boundary that resolves a live root and absolutizes a vanished one, so loop-task maintenance keeps working after a project is deleted.

**Log capture is real, not suppression.** A `MakeWriter` in `rimz::tui` buffers tracing output while any `TerminalModeGuard` owns the terminal and replays the original bytes to stderr on restore. Warnings stay visible and formatted instead of being silenced or painted over, and every full-screen surface benefits, not just the connect panel.

**On failure the panel holds.** A missing path repaints the panel as a red error frame carrying the fix and the five most recent captured warnings, waits for a keypress, restores the terminal, and lets the normal CLI report write the error to scrollback.

## Implementation

The resolver refuses missing `Create`-mode roots; `delivery_target_alive`, `FireContext::resolve`, `newest_active_run_for_entry`, and `loop stop` route through `WorkspaceResolver::persisted_workspace_id`, which resolves a live root and absolutizes a vanished one, so the delivery reaper still reaps, a `Deliver` task still self-removes via `TargetGone`, and an active run is still stoppable. `stop_supervised_run` split out `cancel_supervised_run` so a vanished root cancels the run without the pane close that needs a workspace.

On the remote side, `SshAttachPlan::path_preflight` compiles the probe for path targets only, `remote_path_guard` adds the snippet sentinel through the shared `remote_exec_snippet` — which also serves web prep, so web gets the guard too — and exit `67` joins the fatal sentinels. `fatal_session_message` dispatches on that code and rebuilds the message from the typed target path, so captured stderr never truncates the path or repeats the fix line; `run_web_prep` gained the same sentinel, which previously fell through to a bare exit-status message.

`TuiLogWriter` routes tracing into a 64 KiB capped buffer while a guard is active. The session picker settles its handoff before re-entering the alt screen, keeping capture balanced and putting buffered warnings into scrollback. Interrupt paths now name the host and the last SSH error instead of a bare "stopped".

Two deviations from the plan. The snippet guard applies through the shared helper rather than attach-only, because `remote_exec_snippet` also serves web prep. And `crates/rimz/src/remote` and `tui.rs` both sat exactly at their `refactor-target.toml` surface budgets: the first implementation traded away named API to fit, which produced string-matching on remote stderr, dummy-frame construction, and a bare `mem::forget` in place of a documented lifecycle method. Review rejected that trade. The budgets are raised by the items actually needed (`remote` 172→175, `tui.rs` 15→16), with the rationale recorded beside each entry.

Covered by unit tests for the resolver guard, preflight argv and quoting, snippet contents, exit classification, sentinel message rebuilding, failure-frame rows, and bounded capture; by three vanished-root regressions in their owning modules; and by end-to-end tests driving a mock SSH shim that assert the tty attach never runs when the probe reports a missing path, that an existing path preflights before attaching, and that session targets skip the probe entirely.

## Advisories

- A sibling family still hashes the persisted task root raw: `run_lock_path`, `fire.rs`'s ownership check, `loop run`, `loop run-report`, and task arming call `WorkspaceId::from_project_root` on `entry.resolved_root()` instead of the new boundary. This predates the change and is identical for an absolute normalized root; only a hand-edited relative or dotted persisted root splits the two conventions. Routing that family through `persisted_workspace_id` too would retire the class.
- On the interactive-fallback attach, stderr is inherited, so the snippet's own echo reaches the terminal and the rebuilt message prints after it. Both now say the same thing; before, the second line was a generic status. Still duplicated on that path.
- No PTY-driven test asserts the blocking keypress and alternate-screen teardown itself. Frame content, capture routing, and the process decisions are covered; the hold lifecycle rests on unit tests plus a manual smoke.
- The live remote smoke could not be completed: SSH to the host timed out before reaching the path probe. The local refusal was verified directly, and the mock-SSH suite covers the remote preflight and no-attach guarantee.
- The outage panel keeps its hard-coded crossterm colors. Migrating it onto the shared theme accessors is a follow-up, unrelated to the failure lifecycle.
- `preserve_for_reexec` may drop a nonempty capture buffer at exec time; the upgrade path is noted in code.

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>forge</code> team · 3 agents · 1h33m active · $38.81 · 9 messages (1 from you)</summary>

- **planner** — Claude `claude-fable-5@high`
  - effort: 14m active · $8.92 incl. subagents
  - calls: 1 ask · 32 tool calls
  - messages: 1 from you · 2 from teammates · 3 to teammates
  - tokens: 176 input, 87.8k output, 375.8k cache write, 6.9m cache read
  - subagents: 2 × explore ($2.00)
- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 58m active · $19.94
  - calls: 166 tool calls · 1 compaction
  - messages: 4 from teammates · 3 to teammates
  - tokens: 585.9k input, 80.1k output, 40m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 19m active · $9.94 incl. subagents
  - calls: 89 tool calls
  - messages: 2 from teammates · 2 to teammates
  - tokens: 186 input, 98.2k output, 264.8k cache write, 10.2m cache read
  - subagents: 1 × general-purpose ($1.38)

</details>

