### PR TITLE
feat(teams): print launch receipts and accept team#worktree addressing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ rimz agents attribution --md         # credit the lane's agents in a PR footnote
 rimz agents restart @coder           # bounce in place and resume the session
 rimz agents resume '#docs'           # restore every closed place in one lane
 rimz teams                           # configured teams and their live instances
-rimz teams show forge                # resolved roles, validation, and live members
+rimz teams show forge#feat-x         # resolved roles, validation, and one live cohort
 rimz teams forge -w feat-x           # launch one configured cohort in a worktree
 rimz teams resume forge              # reopen a configured team cohort
 rimz teams focus|restart|stop forge  # drive one live team cohort

--- a/crates/rimz/src/cli/agents_cmd/launch.rs
+++ b/crates/rimz/src/cli/agents_cmd/launch.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use super::*;
 use crate::cli::ctx::Ctx;
-use crate::cli::{machine_config, report_unknown_config_keys, require_agents_fragments};
+use crate::cli::{machine_config, render, report_unknown_config_keys, require_agents_fragments};
 
 use super::placement::{PlacementErrors, PlacementRequest};
 
@@ -317,7 +317,7 @@ pub(super) fn launch_layout(
         PlacementRequest {
             placement,
             mux,
-            cwd,
+            cwd: cwd.clone(),
             title,
             panes,
             sidebar,
@@ -333,7 +333,22 @@ pub(super) fn launch_layout(
                 same_pane: "running the agent in the current pane",
             },
         },
-    )
+    )?;
+    if !in_place {
+        let leader = team_name
+            .as_deref()
+            .and_then(|name| teams.0.get(name))
+            .and_then(|team| team.leader.as_deref());
+        write_launch_receipt(
+            &mut render::out(),
+            team_name.as_deref(),
+            room_channel.as_deref(),
+            &cwd,
+            launch_batch.identities(),
+            leader,
+        )?;
+    }
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -464,8 +479,20 @@ fn launch_resume_layout(
             fallback_channel: channel.as_deref(),
         },
     )?;
+    let leader = team_name
+        .as_deref()
+        .and_then(|name| teams.0.get(name))
+        .and_then(|team| team.leader.as_deref());
     if in_place {
-        report_cohort_resume(&plan);
+        let mut out = render::out();
+        report_cohort_resume(&mut out, &plan)?;
+        write_launch_hints(
+            &mut out,
+            team_name.as_deref(),
+            channel.as_deref(),
+            launch_batch.identities(),
+            leader,
+        )?;
     }
     super::placement::execute(
         backend,
@@ -488,7 +515,15 @@ fn launch_resume_layout(
         },
     )?;
     if !in_place {
-        report_cohort_resume(&plan);
+        let mut out = render::out();
+        report_cohort_resume(&mut out, &plan)?;
+        write_launch_hints(
+            &mut out,
+            team_name.as_deref(),
+            channel.as_deref(),
+            launch_batch.identities(),
+            leader,
+        )?;
     }
     Ok(())
 }
@@ -607,26 +642,97 @@ fn cohort_resume_subject(spec: &str, scope: Option<&str>) -> String {
     }
 }
 
-fn report_cohort_resume(plan: &rimz::harness::plan::CohortResumePlan) {
+fn write_launch_receipt(
+    w: &mut impl Write,
+    team: Option<&str>,
+    channel: Option<&str>,
+    cwd: &Path,
+    identities: &[AgentLaunchIdentity],
+    leader: Option<&str>,
+) -> Result<()> {
+    let subject = match (team, identities) {
+        (Some(team), _) => team.to_owned(),
+        (None, [identity]) => format!("@{}", identity.name),
+        (None, identities) => format!("{} agents", identities.len()),
+    };
+    let lane = channel.map_or_else(String::new, |channel| format!(" in #{channel}"));
+    let cwd = rimz::worktree::normalize_path_lexical(cwd);
+    let cwd = render::home_relative(&cwd.display().to_string());
+    writeln!(w, "launched {subject}{lane} ({cwd})")?;
+
+    let handle_width = identities
+        .iter()
+        .map(|identity| launch_identity_handle(identity).len() + 1)
+        .max()
+        .unwrap_or(0);
+    let kind_width = identities
+        .iter()
+        .map(|identity| identity.kind.as_str().len())
+        .max()
+        .unwrap_or(0);
+    for identity in identities {
+        let handle = format!("@{:<handle_width$}", launch_identity_handle(identity));
+        let kind = format!("{:<kind_width$}", identity.kind.as_str());
+        writeln!(
+            w,
+            "  {}  {kind}  {}",
+            render::paint(render::palette::identity(identity.kind.as_str()), &handle),
+            render::paint(render::palette::muted(), "starting")
+        )?;
+    }
+    write_launch_hints(w, team, channel, identities, leader)
+}
+
+fn launch_identity_handle(identity: &AgentLaunchIdentity) -> &str {
+    identity
+        .launch
+        .role
+        .as_deref()
+        .or_else(|| identity.name_explicit.then_some(identity.name.as_str()))
+        .unwrap_or(&identity.name)
+}
+
+fn write_launch_hints(
+    w: &mut impl Write,
+    team: Option<&str>,
+    channel: Option<&str>,
+    identities: &[AgentLaunchIdentity],
+    leader: Option<&str>,
+) -> Result<()> {
+    if let (Some(team), Some(channel)) = (team, channel) {
+        writeln!(w, "Check: rimz teams show {team}#{channel}")?;
+    }
+    if let Some(handle) = leader.or_else(|| identities.first().map(launch_identity_handle)) {
+        let lane = channel.map_or_else(String::new, |channel| format!("#{channel}"));
+        writeln!(w, "Reach: rimz message @{handle}{lane} '<text>'")?;
+    }
+    Ok(())
+}
+
+fn report_cohort_resume(
+    w: &mut impl Write,
+    plan: &rimz::harness::plan::CohortResumePlan,
+) -> Result<()> {
     let mut fresh = plan.fresh.iter();
     for seed in &plan.seeds {
         match seed {
             rimz::harness::plan::CohortSeed::Resume(agent) => {
                 let name = agent.name.as_deref().unwrap_or("unnamed");
-                let _ = writeln!(
-                    std::io::stderr(),
+                writeln!(
+                    w,
                     "resumed {}:{} ({})",
                     agent.kind.as_str(),
                     name,
                     agent.agent_id
-                );
+                )?;
             }
             rimz::harness::plan::CohortSeed::Fresh => {
                 let label = fresh.next().map_or("agent", String::as_str);
-                let _ = writeln!(std::io::stderr(), "started fresh {label}");
+                writeln!(w, "started fresh {label}")?;
             }
         }
     }
+    Ok(())
 }
 
 pub(super) fn interactive_permission_mode_from_flags(
@@ -751,6 +857,56 @@ pub(super) fn validate_resolved_launch_inputs(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn team_launch_receipt_names_startup_and_next_actions() {
+        let mut identities = [
+            launch_identity("claude", "planner"),
+            launch_identity("codex", "coder"),
+        ];
+        identities[0].launch.role = Some("planner".to_owned());
+        identities[1].launch.role = Some("coder".to_owned());
+        let mut output = Vec::new();
+
+        write_launch_receipt(
+            &mut output,
+            Some("forge"),
+            Some("feat-x"),
+            Path::new("/repo-worktrees/feat-x"),
+            &identities,
+            Some("planner"),
+        )
+        .unwrap();
+
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("launched forge in #feat-x (/repo-worktrees/feat-x)"));
+        assert!(output.contains("@planner"));
+        assert!(output.contains("claude"));
+        assert!(output.contains("starting"));
+        assert!(output.contains("Check: rimz teams show forge#feat-x"));
+        assert!(output.contains("Reach: rimz message @planner#feat-x '<text>'"));
+    }
+
+    #[test]
+    fn plain_launch_receipt_uses_the_first_member_without_a_team_check() {
+        let identities = [launch_identity("codex", "worker")];
+        let mut output = Vec::new();
+
+        write_launch_receipt(
+            &mut output,
+            None,
+            None,
+            Path::new("/repo"),
+            &identities,
+            None,
+        )
+        .unwrap();
+
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("launched @worker (/repo)"));
+        assert!(!output.contains("Check:"));
+        assert!(output.contains("Reach: rimz message @worker '<text>'"));
+    }
 
     #[test]
     fn resume_in_the_lane_directory_stays_in_the_origin_pane() {
@@ -907,5 +1063,17 @@ mod tests {
 
     fn test_agent(id: &str) -> AgentState {
         rimz::testkit::agent_state("codex", id, jiff::Timestamp::UNIX_EPOCH)
+    }
+
+    fn launch_identity(kind: &str, name: &str) -> AgentLaunchIdentity {
+        AgentLaunchIdentity {
+            kind: AgentKind::new_unchecked(kind),
+            agent_id: AgentSessionId::from(format!("launch-{name}")),
+            name: name.to_owned(),
+            name_explicit: false,
+            launch: rimz::agents::LaunchParams::default(),
+            run_id: None,
+            prompt: None,
+        }
     }
 }

--- a/crates/rimz/src/cli/agents_cmd/launch.rs
+++ b/crates/rimz/src/cli/agents_cmd/launch.rs
@@ -484,10 +484,9 @@ fn launch_resume_layout(
         .and_then(|name| teams.0.get(name))
         .and_then(|team| team.leader.as_deref());
     if in_place {
-        let mut out = render::out();
-        report_cohort_resume(&mut out, &plan)?;
-        write_launch_hints(
-            &mut out,
+        write_resume_receipt(
+            &mut render::out(),
+            &plan,
             team_name.as_deref(),
             channel.as_deref(),
             launch_batch.identities(),
@@ -515,10 +514,9 @@ fn launch_resume_layout(
         },
     )?;
     if !in_place {
-        let mut out = render::out();
-        report_cohort_resume(&mut out, &plan)?;
-        write_launch_hints(
-            &mut out,
+        write_resume_receipt(
+            &mut render::out(),
+            &plan,
             team_name.as_deref(),
             channel.as_deref(),
             launch_batch.identities(),
@@ -680,33 +678,69 @@ fn write_launch_receipt(
             render::paint(render::palette::muted(), "starting")
         )?;
     }
-    write_launch_hints(w, team, channel, identities, leader)
+    write_launch_hints(
+        w,
+        team,
+        channel,
+        identities.first().map(launch_identity_handle),
+        leader,
+    )
 }
 
 fn launch_identity_handle(identity: &AgentLaunchIdentity) -> &str {
-    identity
-        .launch
-        .role
-        .as_deref()
-        .or_else(|| identity.name_explicit.then_some(identity.name.as_str()))
-        .unwrap_or(&identity.name)
+    identity.launch.role.as_deref().unwrap_or(&identity.name)
+}
+
+fn resume_hint_handle<'a>(
+    plan: &'a rimz::harness::plan::CohortResumePlan,
+    fresh_identities: &'a [AgentLaunchIdentity],
+) -> Option<&'a str> {
+    match plan.seeds.first()? {
+        rimz::harness::plan::CohortSeed::Resume(agent) => agent
+            .role
+            .as_deref()
+            .or(agent.name.as_deref())
+            .or(agent.profile.as_deref())
+            .or(Some(agent.kind.as_str())),
+        rimz::harness::plan::CohortSeed::Fresh => {
+            fresh_identities.first().map(launch_identity_handle)
+        }
+    }
 }
 
 fn write_launch_hints(
     w: &mut impl Write,
     team: Option<&str>,
     channel: Option<&str>,
-    identities: &[AgentLaunchIdentity],
+    fallback_handle: Option<&str>,
     leader: Option<&str>,
 ) -> Result<()> {
     if let (Some(team), Some(channel)) = (team, channel) {
         writeln!(w, "Check: rimz teams show {team}#{channel}")?;
     }
-    if let Some(handle) = leader.or_else(|| identities.first().map(launch_identity_handle)) {
+    if let Some(handle) = leader.or(fallback_handle) {
         let lane = channel.map_or_else(String::new, |channel| format!("#{channel}"));
         writeln!(w, "Reach: rimz message @{handle}{lane} '<text>'")?;
     }
     Ok(())
+}
+
+fn write_resume_receipt(
+    w: &mut impl Write,
+    plan: &rimz::harness::plan::CohortResumePlan,
+    team: Option<&str>,
+    channel: Option<&str>,
+    fresh_identities: &[AgentLaunchIdentity],
+    leader: Option<&str>,
+) -> Result<()> {
+    report_cohort_resume(w, plan)?;
+    write_launch_hints(
+        w,
+        team,
+        channel,
+        resume_hint_handle(plan, fresh_identities),
+        leader,
+    )
 }
 
 fn report_cohort_resume(
@@ -906,6 +940,26 @@ mod tests {
         assert!(output.contains("launched @worker (/repo)"));
         assert!(!output.contains("Check:"));
         assert!(output.contains("Reach: rimz message @worker '<text>'"));
+    }
+
+    #[test]
+    fn resume_hint_uses_the_first_resumed_member_without_fresh_identities() {
+        let mut agent = test_agent("sess-planner");
+        agent.name = Some("stable-haven".to_owned());
+        agent.role = Some("planner".to_owned());
+        let plan = rimz::harness::plan::CohortResumePlan {
+            seeds: vec![rimz::harness::plan::CohortSeed::Resume(Box::new(agent))],
+            cwd: Some(PathBuf::from("/repo")),
+            channel: Some("feat-x".to_owned()),
+            fresh: Vec::new(),
+            launch_group: None,
+        };
+
+        assert_eq!(resume_hint_handle(&plan, &[]), Some("planner"));
+        let mut output = Vec::new();
+        write_resume_receipt(&mut output, &plan, None, Some("feat-x"), &[], None).unwrap();
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("Reach: rimz message @planner#feat-x '<text>'"));
     }
 
     #[test]

--- a/crates/rimz/src/cli/snapshots/rimz__cli__surface_tests__cli_surface.snap
+++ b/crates/rimz/src/cli/snapshots/rimz__cli__surface_tests__cli_surface.snap
@@ -2315,6 +2315,7 @@ rimz teams show (aliases: inspect)
     --mux <MUX>  [action=set takes=1..=1 global]
     --root <ROOT>  [action=set takes=1..=1 global]
     --tmux  [action=set-true takes=0..=0 global]
+    -w, --worktree <NAME>  [action=set takes=1..=1]
     --zellij  [action=set-true takes=0..=0 global]
 
 rimz teams stop

--- a/crates/rimz/src/cli/teams/cohort.rs
+++ b/crates/rimz/src/cli/teams/cohort.rs
@@ -19,15 +19,7 @@ fn select<'a>(
         .collect::<Vec<_>>();
     let mut cohorts = team_cohorts
         .iter()
-        .filter(|cohort| {
-            worktree.is_none_or(|worktree| {
-                cohort.channel == worktree
-                    || cohort
-                        .members
-                        .iter()
-                        .any(|agent| rimz::harness::target::agent_in_worktree(agent, worktree))
-            })
-        })
+        .filter(|cohort| worktree.is_none_or(|worktree| matches_worktree(cohort, worktree)))
         .cloned()
         .collect::<Vec<_>>();
     if cohorts.is_empty() {
@@ -66,6 +58,14 @@ fn select<'a>(
         );
     }
     bail!("team `{team}` has live cohorts in {lanes}; select one with `-w <worktree>`")
+}
+
+pub(super) fn matches_worktree(cohort: &TeamCohort<'_>, worktree: &str) -> bool {
+    cohort.channel == worktree
+        || cohort
+            .members
+            .iter()
+            .any(|agent| rimz::harness::target::agent_in_worktree(agent, worktree))
 }
 
 pub(super) fn stop(team: &str, worktree: Option<&str>, globals: &GlobalFlags) -> Result<()> {

--- a/crates/rimz/src/cli/teams/list.rs
+++ b/crates/rimz/src/cli/teams/list.rs
@@ -66,14 +66,17 @@ pub(super) struct LiveMember {
 }
 
 pub(super) fn run(json: bool, globals: &GlobalFlags) -> Result<()> {
-    let reports = load_catalog(globals)?;
+    let reports = load_catalog(globals, None)?;
     if json {
         return render::json_pretty(&reports);
     }
     write_catalog(&mut render::out(), &reports)
 }
 
-pub(super) fn load_catalog(globals: &GlobalFlags) -> Result<Vec<TeamReport>> {
+pub(super) fn load_catalog(
+    globals: &GlobalFlags,
+    worktree: Option<&str>,
+) -> Result<Vec<TeamReport>> {
     let ctx = Ctx::open(globals)?;
     let machine = rimz::config::MachineConfig::load().context("loading machine config")?;
     report_unknown_config_keys(&machine)?;
@@ -96,6 +99,7 @@ pub(super) fn load_catalog(globals: &GlobalFlags) -> Result<Vec<TeamReport>> {
         &snapshot.agents,
         &audit.agents,
         &prices,
+        worktree,
         |name| team_source(&ctx.workspace.project_root, name),
     ))
 }
@@ -121,9 +125,10 @@ fn build_catalog(
     agents: &[AgentState],
     audit_agents: &[AgentState],
     prices: &rimz::agents::PriceBook,
+    worktree: Option<&str>,
     source: impl Fn(&str) -> Option<String>,
 ) -> Vec<TeamReport> {
-    let live = live_instances(agents, audit_agents, prices);
+    let live = live_instances(agents, audit_agents, prices, worktree);
     let mut reports = teams
         .0
         .iter()
@@ -304,8 +309,14 @@ fn live_instances(
     agents: &[AgentState],
     audit_agents: &[AgentState],
     prices: &rimz::agents::PriceBook,
+    worktree: Option<&str>,
 ) -> BTreeMap<String, Vec<LiveInstance>> {
-    let cohorts = rimz::harness::target::team_cohorts(agents);
+    let cohorts = rimz::harness::target::team_cohorts(agents)
+        .into_iter()
+        .filter(|cohort| {
+            worktree.is_none_or(|worktree| super::cohort::matches_worktree(cohort, worktree))
+        })
+        .collect::<Vec<_>>();
     let live_ids = cohorts
         .iter()
         .flat_map(|cohort| cohort.members.iter().map(|agent| agent.agent_id.clone()))
@@ -535,6 +546,7 @@ mod tests {
             &[agent],
             &[],
             &rimz::agents::PriceBook::default(),
+            None,
             |_| Some("/tmp/team.toml".to_owned()),
         );
 
@@ -581,6 +593,7 @@ mod tests {
             &[agent.clone()],
             &[agent],
             &rimz::agents::PriceBook::default(),
+            None,
             |_| None,
         );
 
@@ -598,6 +611,7 @@ mod tests {
             &[],
             &[],
             &rimz::agents::PriceBook::default(),
+            None,
             |_| None,
         );
 
@@ -641,6 +655,7 @@ mod tests {
             &[],
             &[],
             &rimz::agents::PriceBook::default(),
+            None,
             |_| None,
         );
         let mut rendered = Vec::new();
@@ -676,5 +691,34 @@ mod tests {
                 .unwrap()
                 .contains("No installed teams")
         );
+    }
+
+    #[test]
+    fn catalog_filter_matches_an_exact_lane_or_member_worktree() {
+        let teams = TeamsConfig(BTreeMap::from([("forge".to_owned(), team())]));
+        let mut agent = AgentState::stub("claude", "sess-planner", AgentStatus::Running);
+        agent.team = Some("forge".to_owned());
+        agent.role = Some("planner".to_owned());
+        agent.channel = None;
+        agent.worktree_path = Some("/repo-worktrees/feat-x".to_owned());
+        let build = |filter| {
+            build_catalog(
+                &teams,
+                &ProfilesConfig::default(),
+                &CommandsConfig::default(),
+                std::slice::from_ref(&agent),
+                &[],
+                &rimz::agents::PriceBook::default(),
+                filter,
+                |_| None,
+            )
+        };
+
+        assert_eq!(build(Some("feat-x"))[0].instances[0].channel, "feat-x");
+        assert_eq!(
+            build(Some("/repo-worktrees/feat-x"))[0].instances[0].channel,
+            "feat-x"
+        );
+        assert!(build(Some("other"))[0].instances.is_empty());
     }
 }

--- a/crates/rimz/src/cli/teams/list.rs
+++ b/crates/rimz/src/cli/teams/list.rs
@@ -96,10 +96,12 @@ pub(super) fn load_catalog(
         &effective.teams,
         &effective.profiles,
         &machine.agents.commands,
-        &snapshot.agents,
-        &audit.agents,
-        &prices,
-        worktree,
+        LiveCatalog {
+            agents: &snapshot.agents,
+            audit_agents: &audit.agents,
+            prices: &prices,
+            worktree,
+        },
         |name| team_source(&ctx.workspace.project_root, name),
     ))
 }
@@ -122,13 +124,15 @@ fn build_catalog(
     teams: &TeamsConfig,
     profiles: &ProfilesConfig,
     commands: &CommandsConfig,
-    agents: &[AgentState],
-    audit_agents: &[AgentState],
-    prices: &rimz::agents::PriceBook,
-    worktree: Option<&str>,
+    live_catalog: LiveCatalog<'_>,
     source: impl Fn(&str) -> Option<String>,
 ) -> Vec<TeamReport> {
-    let live = live_instances(agents, audit_agents, prices, worktree);
+    let live = live_instances(
+        live_catalog.agents,
+        live_catalog.audit_agents,
+        live_catalog.prices,
+        live_catalog.worktree,
+    );
     let mut reports = teams
         .0
         .iter()
@@ -161,6 +165,13 @@ fn build_catalog(
     }
     reports.sort_by(|left, right| left.name.cmp(&right.name));
     reports
+}
+
+struct LiveCatalog<'a> {
+    agents: &'a [AgentState],
+    audit_agents: &'a [AgentState],
+    prices: &'a rimz::agents::PriceBook,
+    worktree: Option<&'a str>,
 }
 
 fn definition_report(
@@ -543,10 +554,12 @@ mod tests {
             &teams,
             &ProfilesConfig::default(),
             &CommandsConfig::default(),
-            &[agent],
-            &[],
-            &rimz::agents::PriceBook::default(),
-            None,
+            LiveCatalog {
+                agents: &[agent],
+                audit_agents: &[],
+                prices: &rimz::agents::PriceBook::default(),
+                worktree: None,
+            },
             |_| Some("/tmp/team.toml".to_owned()),
         );
 
@@ -590,10 +603,12 @@ mod tests {
             &TeamsConfig(BTreeMap::from([("forge".to_owned(), team())])),
             &ProfilesConfig::default(),
             &CommandsConfig::default(),
-            &[agent.clone()],
-            &[agent],
-            &rimz::agents::PriceBook::default(),
-            None,
+            LiveCatalog {
+                agents: &[agent.clone()],
+                audit_agents: &[agent],
+                prices: &rimz::agents::PriceBook::default(),
+                worktree: None,
+            },
             |_| None,
         );
 
@@ -608,10 +623,12 @@ mod tests {
             &TeamsConfig(BTreeMap::from([("broken".to_owned(), broken)])),
             &ProfilesConfig::default(),
             &CommandsConfig::default(),
-            &[],
-            &[],
-            &rimz::agents::PriceBook::default(),
-            None,
+            LiveCatalog {
+                agents: &[],
+                audit_agents: &[],
+                prices: &rimz::agents::PriceBook::default(),
+                worktree: None,
+            },
             |_| None,
         );
 
@@ -652,10 +669,12 @@ mod tests {
             &TeamsConfig(BTreeMap::from([("forge".to_owned(), team())])),
             &ProfilesConfig::default(),
             &CommandsConfig::default(),
-            &[],
-            &[],
-            &rimz::agents::PriceBook::default(),
-            None,
+            LiveCatalog {
+                agents: &[],
+                audit_agents: &[],
+                prices: &rimz::agents::PriceBook::default(),
+                worktree: None,
+            },
             |_| None,
         );
         let mut rendered = Vec::new();
@@ -706,10 +725,12 @@ mod tests {
                 &teams,
                 &ProfilesConfig::default(),
                 &CommandsConfig::default(),
-                std::slice::from_ref(&agent),
-                &[],
-                &rimz::agents::PriceBook::default(),
-                filter,
+                LiveCatalog {
+                    agents: std::slice::from_ref(&agent),
+                    audit_agents: &[],
+                    prices: &rimz::agents::PriceBook::default(),
+                    worktree: filter,
+                },
                 |_| None,
             )
         };

--- a/crates/rimz/src/cli/teams/mod.rs
+++ b/crates/rimz/src/cli/teams/mod.rs
@@ -41,6 +41,14 @@ enum TeamsSubcmd {
             add = clap_complete::ArgValueCandidates::new(crate::cli::complete::team_names)
         )]
         name: String,
+        /// Scope live instances to one worktree or lane.
+        #[arg(
+            long,
+            short = 'w',
+            value_name = "NAME",
+            add = clap_complete::ArgValueCandidates::new(crate::cli::complete::worktrees)
+        )]
+        worktree: Option<String>,
         /// Emit the report as JSON.
         #[arg(long)]
         json: bool,
@@ -138,18 +146,26 @@ pub fn run(args: TeamsArgs, globals: &GlobalFlags) -> Result<()> {
                 list::run(args.json, globals)
             }
         },
-        Some(TeamsSubcmd::Show { name, json }) => show::run(&name, json, globals),
+        Some(TeamsSubcmd::Show {
+            name,
+            worktree,
+            json,
+        }) => {
+            let (name, worktree) = team_lane(name, worktree)?;
+            show::run(&name, worktree.as_deref(), json, globals)
+        }
         Some(TeamsSubcmd::List { json }) => list::run(json, globals),
         Some(TeamsSubcmd::Launch(args)) => {
             launch_team(args.name, args.prompt, args.launch, globals)
         }
         Some(TeamsSubcmd::Resume(args)) => {
-            ensure_defined(&args.name, globals)?;
+            let (name, worktree) = team_lane(args.name, args.worktree)?;
+            ensure_defined(&name, globals)?;
             agents_cmd::run(
                 agents_cmd::AgentsArgs::from_launch(agents_cmd::AgentLaunchArgs {
-                    spec: Some(args.name),
+                    spec: Some(name),
                     cohort: agents_cmd::CohortLaunchArgs {
-                        worktree: args.worktree,
+                        worktree,
                         resume: true,
                         bg: args.bg,
                         ..Default::default()
@@ -160,20 +176,20 @@ pub fn run(args: TeamsArgs, globals: &GlobalFlags) -> Result<()> {
             )
         }
         Some(TeamsSubcmd::Stop(args)) => {
-            ensure_defined(&args.name, globals)?;
-            cohort::stop(&args.name, args.worktree.as_deref(), globals)
+            let (name, worktree) = team_lane(args.name, args.worktree)?;
+            ensure_defined(&name, globals)?;
+            cohort::stop(&name, worktree.as_deref(), globals)
         }
         Some(TeamsSubcmd::Focus(args)) => {
-            let teams = ensure_defined(&args.name, globals)?;
-            let leader = teams
-                .0
-                .get(&args.name)
-                .and_then(|team| team.leader.as_deref());
-            cohort::focus(&args.name, args.worktree.as_deref(), leader, globals)
+            let (name, worktree) = team_lane(args.name, args.worktree)?;
+            let teams = ensure_defined(&name, globals)?;
+            let leader = teams.0.get(&name).and_then(|team| team.leader.as_deref());
+            cohort::focus(&name, worktree.as_deref(), leader, globals)
         }
         Some(TeamsSubcmd::Restart(args)) => {
-            ensure_defined(&args.name, globals)?;
-            cohort::restart(&args.name, args.worktree.as_deref(), globals)
+            let (name, worktree) = team_lane(args.name, args.worktree)?;
+            ensure_defined(&name, globals)?;
+            cohort::restart(&name, worktree.as_deref(), globals)
         }
         Some(TeamsSubcmd::Install(args)) => install::run(args),
     }
@@ -182,9 +198,14 @@ pub fn run(args: TeamsArgs, globals: &GlobalFlags) -> Result<()> {
 fn launch_team(
     name: String,
     prompt: Option<String>,
-    launch: agents_cmd::CohortLaunchArgs,
+    mut launch: agents_cmd::CohortLaunchArgs,
     globals: &GlobalFlags,
 ) -> Result<()> {
+    let (name, worktree) = team_lane(name, launch.worktree)?;
+    if worktree.is_some() && launch.channel.is_some() {
+        bail!("--channel cannot be used with team#worktree addressing");
+    }
+    launch.worktree = worktree;
     ensure_defined(&name, globals)?;
     agents_cmd::run(
         agents_cmd::AgentsArgs::from_launch(agents_cmd::AgentLaunchArgs {
@@ -195,6 +216,19 @@ fn launch_team(
         }),
         globals,
     )
+}
+
+fn team_lane(name: String, worktree: Option<String>) -> Result<(String, Option<String>)> {
+    let Some((team, lane)) = name.split_once('#') else {
+        return Ok((name, worktree));
+    };
+    if lane.is_empty() {
+        bail!("expected a worktree or lane after `#` in `{name}`");
+    }
+    if worktree.is_some() {
+        bail!("worktree given twice; use either `team#worktree` or `-w/--worktree`");
+    }
+    Ok((team.to_owned(), Some(lane.to_owned())))
 }
 
 fn reject_launch_flags_without_name(
@@ -318,5 +352,51 @@ mod tests {
             reject_launch_flags_without_name(&args.prompt, &args.launch).expect_err("missing team");
 
         assert!(error.to_string().contains("require a team name"));
+    }
+
+    #[test]
+    fn fused_team_lane_feeds_the_canonical_worktree_argument() {
+        let show = parse_teams(&["rimz", "show", "forge#feat-x"]);
+        let stop = parse_teams(&["rimz", "stop", "forge#feat-x"]);
+        let resume = parse_teams(&["rimz", "resume", "forge#feat-x"]);
+        let bare = parse_teams(&["rimz", "forge#feat-x", "ship"]);
+
+        let Some(TeamsSubcmd::Show { name, worktree, .. }) = show.command else {
+            panic!("show verb");
+        };
+        assert_eq!(
+            team_lane(name, worktree).unwrap(),
+            ("forge".to_owned(), Some("feat-x".to_owned()))
+        );
+        let Some(TeamsSubcmd::Stop(args)) = stop.command else {
+            panic!("stop verb");
+        };
+        assert_eq!(
+            team_lane(args.name, args.worktree).unwrap().1.as_deref(),
+            Some("feat-x")
+        );
+        let Some(TeamsSubcmd::Resume(args)) = resume.command else {
+            panic!("resume verb");
+        };
+        assert_eq!(
+            team_lane(args.name, args.worktree).unwrap().1.as_deref(),
+            Some("feat-x")
+        );
+        assert_eq!(
+            team_lane(bare.name.unwrap(), bare.launch.worktree)
+                .unwrap()
+                .1
+                .as_deref(),
+            Some("feat-x")
+        );
+    }
+
+    #[test]
+    fn fused_team_lane_rejects_missing_and_duplicate_lanes() {
+        let missing = team_lane("forge#".to_owned(), None).unwrap_err();
+        assert!(missing.to_string().contains("after `#`"));
+
+        let duplicate = team_lane("forge#feat-x".to_owned(), Some("other".to_owned())).unwrap_err();
+        assert!(duplicate.to_string().contains("given twice"));
     }
 }

--- a/crates/rimz/src/cli/teams/show.rs
+++ b/crates/rimz/src/cli/teams/show.rs
@@ -6,8 +6,8 @@ use super::super::{GlobalFlags, render};
 use super::list::{LiveMember, RoleReport, TeamReport};
 
 pub(super) fn run(name: &str, lane: Option<&str>, json: bool, globals: &GlobalFlags) -> Result<()> {
-    let reports = super::list::load_catalog(globals)?;
-    let Some(mut report) = reports
+    let reports = super::list::load_catalog(globals, lane)?;
+    let Some(report) = reports
         .iter()
         .find(|report| report.name == name && report.defined)
         .cloned()
@@ -27,9 +27,6 @@ pub(super) fn run(name: &str, lane: Option<&str>, json: bool, globals: &GlobalFl
             valid.join(", ")
         );
     };
-    if let Some(lane) = lane {
-        report.instances.retain(|instance| instance.channel == lane);
-    }
     if json {
         return render::json_pretty(&report);
     }

--- a/crates/rimz/src/cli/teams/show.rs
+++ b/crates/rimz/src/cli/teams/show.rs
@@ -5,11 +5,12 @@ use anyhow::{Result, bail};
 use super::super::{GlobalFlags, render};
 use super::list::{LiveMember, RoleReport, TeamReport};
 
-pub(super) fn run(name: &str, json: bool, globals: &GlobalFlags) -> Result<()> {
+pub(super) fn run(name: &str, lane: Option<&str>, json: bool, globals: &GlobalFlags) -> Result<()> {
     let reports = super::list::load_catalog(globals)?;
-    let Some(report) = reports
+    let Some(mut report) = reports
         .iter()
         .find(|report| report.name == name && report.defined)
+        .cloned()
     else {
         let valid = reports
             .iter()
@@ -26,13 +27,16 @@ pub(super) fn run(name: &str, json: bool, globals: &GlobalFlags) -> Result<()> {
             valid.join(", ")
         );
     };
-    if json {
-        return render::json_pretty(report);
+    if let Some(lane) = lane {
+        report.instances.retain(|instance| instance.channel == lane);
     }
-    write_report(&mut render::out(), report)
+    if json {
+        return render::json_pretty(&report);
+    }
+    write_report(&mut render::out(), &report, lane)
 }
 
-fn write_report(w: &mut impl Write, report: &TeamReport) -> Result<()> {
+fn write_report(w: &mut impl Write, report: &TeamReport, lane: Option<&str>) -> Result<()> {
     writeln!(
         w,
         "{}",
@@ -78,7 +82,17 @@ fn write_report(w: &mut impl Write, report: &TeamReport) -> Result<()> {
     }
     roles.render(w)?;
 
-    if !report.instances.is_empty() {
+    if report.instances.is_empty() && lane.is_some() {
+        writeln!(w)?;
+        writeln!(
+            w,
+            "{}",
+            render::paint(
+                render::palette::muted(),
+                &format!("no live instance in #{}", lane.unwrap_or_default())
+            )
+        )?;
+    } else if !report.instances.is_empty() {
         writeln!(w)?;
         writeln!(
             w,
@@ -188,7 +202,7 @@ mod tests {
             }],
         };
         let mut output = Vec::new();
-        write_report(&mut output, &report).unwrap();
+        write_report(&mut output, &report, None).unwrap();
         let output = String::from_utf8(output).unwrap();
 
         assert!(output.contains("planner,coder+reviewer"));
@@ -197,5 +211,26 @@ mod tests {
         assert!(output.contains("$0.25"));
         assert!(output.contains("rimz teams launch forge -w <worktree>"));
         assert!(output.contains("rimz teams resume forge"));
+    }
+
+    #[test]
+    fn human_show_answers_when_a_selected_lane_is_not_live() {
+        let report = TeamReport {
+            name: "forge".to_owned(),
+            defined: true,
+            source: None,
+            layout: Some("planner".to_owned()),
+            leader: Some("planner".to_owned()),
+            roles: Vec::new(),
+            valid: true,
+            error: None,
+            instances: Vec::new(),
+        };
+        let mut output = Vec::new();
+
+        write_report(&mut output, &report, Some("ended-lane")).unwrap();
+
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("no live instance in #ended-lane"));
     }
 }

--- a/docs/guide/teams.md
+++ b/docs/guide/teams.md
@@ -71,7 +71,7 @@ The team catalogue merges configured definitions with the cohorts alive in this 
 
 ```sh
 rimz teams                              # every definition and live instance
-rimz teams show forge                   # roles, models, validation, and live members
+rimz teams show forge#feat-query        # roles, models, validation, and one live cohort
 rimz teams forge -w feat-query          # launch or reconcile one cohort
 rimz teams resume forge                 # reopen its newest closed cohort
 rimz teams focus forge                  # jump to the role that needs attention
@@ -81,7 +81,8 @@ rimz teams stop forge                   # close the whole live cohort
 
 Add `--json` to `rimz teams` or `show` for the structured report.
 The bare team name and the longer `launch` form use the same reconciliation engine as `rimz agents <team>`, while `resume`, `focus`, `restart`, and `stop` keep the cohort lifecycle together.
-When the same team is live in several lanes, run the lifecycle command inside the lane you mean or select it with `-w NAME`.
+Fresh launches print the handles RimZ minted as `starting`, followed by copy-ready commands to check the cohort and reach its leader; live status arrives asynchronously and stays authoritative in `teams show`.
+When the same team is live in several lanes, run the lifecycle command inside the lane you mean or select it with `team#worktree` or `-w NAME`.
 The `COST` in `rimz teams show`, the team's attribution footer, and its collapsed finished sidebar receipt all use the same lifetime fold across every resumed session of each role, so their dollars and token totals agree. Expanding that finished receipt puts each role's lifetime cost on its card, and those cards add back to the receipt; live cards remain scoped to the current provider session.
 Use [`rimz agents attribution --md`](../reference/cli/agents.md#attribution) when the team's pull request is ready; it credits every contributing role from durable lane history, including members that exited before the PR opened.
 The full flag surface lives in the [teams CLI reference](../reference/cli/teams.md).

--- a/docs/guide/teams.md
+++ b/docs/guide/teams.md
@@ -81,7 +81,7 @@ rimz teams stop forge                   # close the whole live cohort
 
 Add `--json` to `rimz teams` or `show` for the structured report.
 The bare team name and the longer `launch` form use the same reconciliation engine as `rimz agents <team>`, while `resume`, `focus`, `restart`, and `stop` keep the cohort lifecycle together.
-Fresh launches print the handles RimZ minted as `starting`, followed by copy-ready commands to check the cohort and reach its leader; live status arrives asynchronously and stays authoritative in `teams show`.
+Fresh launches that open a new pane or tab print the handles RimZ minted as `starting`, followed by copy-ready commands to check the cohort and reach its leader; live status arrives asynchronously and stays authoritative in `teams show`.
 When the same team is live in several lanes, run the lifecycle command inside the lane you mean or select it with `team#worktree` or `-w NAME`.
 The `COST` in `rimz teams show`, the team's attribution footer, and its collapsed finished sidebar receipt all use the same lifetime fold across every resumed session of each role, so their dollars and token totals agree. Expanding that finished receipt puts each role's lifetime cost on its card, and those cards add back to the receipt; live cards remain scoped to the current provider session.
 Use [`rimz agents attribution --md`](../reference/cli/agents.md#attribution) when the team's pull request is ready; it credits every contributing role from durable lane history, including members that exited before the PR opened.

--- a/docs/reference/cli/agents.md
+++ b/docs/reference/cli/agents.md
@@ -96,6 +96,7 @@ rimz agents claude --worktree "Take another approach."
 ```
 
 The bare spec and `launch` verb are equivalent: use whichever reads better in a command chain.
+Fresh launches that open a new pane or tab print the minted handles as `starting` and a copy-ready `Reach` command; in-place launches replace the command pane directly and print no receipt.
 
 When a RimZ-launched agent runs this command, each new agent is an independent top-level peer with its own sidebar row. `[agents] max-chain-length` bounds successive agent-to-agent launches (three by default); an over-limit command refuses before it creates launch state. Agents that want a parented, one-prompt child with the safe flags implied use the agent-only [`rimz subagents`](./subagents.md) doorway instead. Only that doorway creates a subagent relationship, and a subagent cannot launch agents or subagents.
 

--- a/docs/reference/cli/teams.md
+++ b/docs/reference/cli/teams.md
@@ -29,12 +29,15 @@ Unknown fields print a warning, are ignored, and can be removed with `rimz setup
 
 ```sh
 rimz teams show forge
+rimz teams show forge#feat-rate-limits
+rimz teams show forge -w feat-rate-limits
 rimz teams inspect forge
 rimz teams show forge --json
 ```
 
 `show` and its `inspect` alias name the best-effort definition source, layout, leader, and validation result, then list each resolved role's profile or kind, model, effort, mode, and prompt files.
 Live instances include the lane, member handle and status, context fill, and tracked session cost.
+Use `team#worktree` or `-w NAME` to narrow the live section to one lane; an ended or not-yet-live lane reports that no instance is live and still exits successfully.
 The report ends with copy-ready launch and resume forms.
 
 ## Launch a team
@@ -42,6 +45,7 @@ The report ends with copy-ready launch and resume forms.
 ```sh
 rimz teams forge
 rimz teams launch forge
+rimz teams launch forge#feat-rate-limits "add rate limiting"
 rimz teams forge -w feat-rate-limits "add rate limiting"
 rimz teams forge --channel triage
 rimz teams forge --from-pr 91 --bg
@@ -50,6 +54,8 @@ rimz teams forge --from-pr 91 --bg
 The bare-name form and `launch` verb accept a configured team name and send an optional trailing prompt to its configured leader.
 It uses the same launch and relaunch-reconciliation path as `rimz agents <team>`, including worktree creation, channel placement, pull-request checkout, and existing-cohort focus or recovery.
 When an agent launches a team, its members are top-level peers rather than children of the caller.
+After opening the panes, a fresh launch prints the minted member handles as `starting` and copy-ready `Check` and `Reach` commands.
+Members report their live status asynchronously, so `rimz teams show team#worktree` remains the source of truth rather than the receipt.
 
 `rimz teams` sets where a cohort runs, whether it resumes, and what each member may spend.
 `rimz agents` sets what an agent is — model, effort, prompts, permission posture, name, pane placement, supervised runs.
@@ -74,20 +80,22 @@ Put stable role-specific choices in the team definition.
 
 ```sh
 rimz teams resume forge
+rimz teams resume forge#feat-rate-limits
 rimz teams resume forge -w feat-rate-limits
 rimz teams resume forge -w --bg
 ```
 
 `resume` reopens the newest matching closed cohort with the same identity, directory, and lane from durable state.
 Current role profiles supply the launch configuration.
-`-w NAME` limits selection to one worktree, while bare `-w` uses the current worktree.
+`team#worktree` and `-w NAME` limit selection to one worktree, while bare `-w` uses the current worktree.
+Use either the fused form or `-w`, not both.
 `--bg` leaves focus where it is.
 
 ## Drive a live team
 
 ```sh
 rimz teams focus forge
-rimz teams stop forge
+rimz teams stop forge#feat-rate-limits
 rimz teams restart forge
 rimz teams stop forge -w feat-rate-limits
 ```
@@ -97,7 +105,7 @@ rimz teams stop forge -w feat-rate-limits
 `restart` relaunches every live member in declared role order, resuming its provider session where supported.
 
 When one team has live cohorts in several lanes, RimZ prefers the cohort in the current lane.
-From outside those lanes, select one with `-w NAME`.
+From outside those lanes, select one with `team#worktree` or `-w NAME`; use either form, not both.
 
 ## Install a team bundle
 

--- a/docs/reference/cli/teams.md
+++ b/docs/reference/cli/teams.md
@@ -37,7 +37,7 @@ rimz teams show forge --json
 
 `show` and its `inspect` alias name the best-effort definition source, layout, leader, and validation result, then list each resolved role's profile or kind, model, effort, mode, and prompt files.
 Live instances include the lane, member handle and status, context fill, and tracked session cost.
-Use `team#worktree` or `-w NAME` to narrow the live section to one lane; an ended or not-yet-live lane reports that no instance is live and still exits successfully.
+Use `team#worktree` or `-w NAME` to narrow the live section by exact lane or member worktree; an ended or not-yet-live lane reports that no instance is live and still exits successfully.
 The report ends with copy-ready launch and resume forms.
 
 ## Launch a team


### PR DESCRIPTION
## Context

`rimz teams launch` printed nothing on success. An agent that launched a team got `(No output)`. It could not tell which members started.

The agent then ran the check command that the `rimz-teams` and `rimz-handoff` skills document: `rimz teams show <team>#<worktree>`. That command never parsed. `teams show` compared its positional argument directly against the configured team names, and answered `unknown team`.

This change fixes both halves. A fresh launch prints a receipt. The cohort verbs accept the fused `team#worktree` address that the skills already document.

## Design choices

- **`team#worktree` is address sugar, not a new grammar.** The positional splits on the first `#`. The lane then feeds the existing `-w/--worktree` plumbing. `-w` stays canonical. Both forms together are an error. The sugar applies to `show`, `focus`, `stop`, `restart`, `resume`, and `launch`. The agent mention grammar (`harness::target::parse_target`) does not change, because teams commands never use it.
- **The receipt covers every fresh launch through the shared path.** Team launches get the team header and a `Check` hint. Plain `rimz agents` launches get the member lines and a `Reach` hint.
- **Launch stays fire-and-forget.** RimZ mints the identities before any member reports in. The receipt therefore shows each member as `starting`, and points at `teams show` for live status. No wait and no multiplexer polling were added.
- **In-place launches print no receipt.** The agent takes over the command pane, which erases the output.
- **One fused address gives the same result on all cohort verbs.** `show` uses the same `cohort::matches_worktree` predicate as `stop`, `focus`, and `restart`. The predicate matches an exact lane, or a member that sits in that worktree.

## Implementation

**Receipt** — `cli/agents_cmd/launch.rs`. After `placement::execute` succeeds, `write_launch_receipt` writes the header, one line for each minted identity, and the copy-ready `Check:` and `Reach:` commands. All output goes through `render::out()`.

```
launched forge in #feat-x (~/…/rimz-worktrees/feat-x)
  @planner   claude  starting
  @coder     codex   starting
  @reviewer  claude  starting
Check: rimz teams show forge#feat-x
Reach: rimz message @planner#feat-x '<text>'
```

The resume path reported its members on stderr before. That report moves to stdout and gets the same hints, through `write_resume_receipt`.

**Addressing** — `cli/teams/mod.rs`. One private `team_lane` helper splits the positional argument. It folds the lane into the canonical worktree argument before `ensure_defined`. `show` gets `-w/--worktree`, to match the other cohort verbs. A fused lane with `--channel` is refused. Clap enforces that conflict on the flag pair, but it cannot see inside a positional argument.

**Lane narrowing** — `cli/teams/list.rs` and `show.rs`. The filter goes through `load_catalog`, `build_catalog`, and `live_instances`. At that point the cohorts are still `TeamCohort` values, so the members' worktree paths are available. `teams list` passes `None`. Human output and `--json` output narrow together. An ended lane, or a lane that is not live yet, reports `no live instance in #lane` and exits with status 0. A status check on a finished team is an answer, not a usage error.

### Deviations from the plan

- **Receipt handles come from `launch.role`, not `identity.name`.** The plan specified `AgentLaunchIdentity.name`. A sandbox launch showed that these values are allocated pet names, such as `@stable-haven`. The team roles that users know live in `identity.launch.role`. The receipt prefers the role, and otherwise uses the allocated name. Both are always addressable.
- **The `show` filter moved up into `list::live_instances`.** The plan first put it on `report.instances`. `LiveInstance` and `LiveMember` hold no worktree path, so the shared predicate cannot run there. Section 3 of the plan was corrected after review.
- **`LiveCatalog` groups the live-catalog inputs.** The lane filter would have made `build_catalog` take eight arguments. The four values already travelled together.
- **One more documentation sentence** in `docs/reference/cli/agents.md`. The shared launch path also changes plain `rimz agents` output.

## Advisories

- **A missed lane does not name the live lanes.** `rimz teams show forge#typo` answers `no live instance in #typo`. It does not list the lanes where the team is live, but `cohort::select` does. To list them now needs a second unfiltered catalog pass, because the filter moved upstream. That price was refused. The team definition and the `Launch:` and `Resume:` hints still show.
- **A relaunch of a live cohort still prints no `Check:` hint.** That path returns early from launch reconciliation, writes a note on stderr, and never reaches the receipt. It is outside the agreed scope of fresh launches. Agents use this flow often, so it is a good follow-up.
- **Zellij was not tested separately.** The receipt renders after the backend-neutral placement call, so it should not depend on the backend. Manual tests used the tmux sandbox.
- **Review record.** The review raised three blocking findings, and all three are fixed: a dead branch in handle derivation, a `Reach:` hint that disappeared when all cohort members resumed, and `show` lane matching that differed from the other cohort verbs.

## Verification

`cargo xtask gate` passed: fmt, invariants, conform, docs-links, lint, and 5821 tests.

In the tmux sandbox, `rimz teams launch forge#receipt-smoke --bg` printed the three role handles as `starting`, with `Check` and `Reach` commands that work. `rimz teams show forge#nope` showed the definition and the no-live-instance line, and exited with status 0.

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>forge</code> team · 3 agents · 59m active · $26.16 · 9 messages (1 from you)</summary>

- **planner** — Claude `claude-fable-5@high`
  - effort: 9m active · $4.68 incl. subagents
  - calls: 1 ask · 25 tool calls
  - messages: 1 from you · 1 from teammates · 4 to teammates
  - tokens: 128 input, 25.7k output, 215.9k cache write, 3.2m cache read
  - subagents: 2 × explore ($0.74)
- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 32m active · $13.17
  - calls: 89 tool calls
  - messages: 4 from teammates · 4 to teammates
  - tokens: 344.3k input, 45.4k output, 27.2m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 18m active · $8.31
  - calls: 72 tool calls
  - messages: 3 from teammates · 4 to teammates
  - tokens: 150 input, 58.9k output, 302.9k cache write, 7.6m cache read

</details>