### PR TITLE
fix(mux): fail fast before attaching a live but unresponsive Zellij session

### DIFF
--- a/crates/rimz/src/cli/doctor/model.rs
+++ b/crates/rimz/src/cli/doctor/model.rs
@@ -390,6 +390,7 @@ pub(super) struct ZellijSocket {
 pub(super) enum SessionHealth {
     Ok,
     Stuck { fix: String },
+    Unresponsive { fix: String },
 }
 
 /// Live sidebar sessions that share this workspace. More than one risks a

--- a/crates/rimz/src/cli/doctor/render.rs
+++ b/crates/rimz/src/cli/doctor/render.rs
@@ -566,6 +566,11 @@ fn session_health_cell(tally: &mut Tally, health: &Probe<SessionHealth>) -> Cell
             Health::Alarm,
             format!("stuck (resurrected/suspended panes) — {fix}"),
         ),
+        Probe::Ready(SessionHealth::Unresponsive { fix }) => verdict(
+            tally,
+            Health::Alarm,
+            format!("live but not responding — {fix}"),
+        ),
     }
 }
 

--- a/crates/rimz/src/cli/doctor/runtime.rs
+++ b/crates/rimz/src/cli/doctor/runtime.rs
@@ -404,14 +404,18 @@ fn collect_session_health(
     session_name: &str,
 ) -> model::Probe<model::SessionHealth> {
     match backend.probe_session_health(session_name) {
-        // `probe_session_health` never returns `Reborn` (it does not mutate), so
-        // the live verdict is just clean-or-stuck.
+        // `probe_session_health` never returns `Reborn` (it does not mutate).
         Ok(SessionHealth::Healthy | SessionHealth::Reborn) => {
             model::Probe::Ready(model::SessionHealth::Ok)
         }
         Ok(SessionHealth::Stuck) => model::Probe::Ready(model::SessionHealth::Stuck {
             fix: "run `rimz reset` to rebuild".to_owned(),
         }),
+        Ok(SessionHealth::Unresponsive) => {
+            model::Probe::Ready(model::SessionHealth::Unresponsive {
+                fix: "run `rimz reset` to rebuild".to_owned(),
+            })
+        }
         Err(err) => model::Probe::Unavailable {
             error: err.to_string(),
         },

--- a/crates/rimz/src/cli/room/mod.rs
+++ b/crates/rimz/src/cli/room/mod.rs
@@ -525,7 +525,6 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
             context.claim_owner()?;
             birth_managed_room(
                 &mut context,
-                was_live,
                 preflight_health,
                 entry.no_resume(),
                 entry.resume_prompt_mode(),
@@ -545,7 +544,6 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
             context.claim_owner()?;
             birth_managed_room(
                 &mut context,
-                was_live,
                 preflight_health,
                 entry.no_resume(),
                 entry.resume_prompt_mode(),
@@ -560,7 +558,6 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
                 RoomContext::from_record(record, machine_config.clone(), mux, RoomSizing::Birth)?;
             birth_managed_room(
                 &mut context,
-                was_live,
                 preflight_health,
                 entry.no_resume(),
                 entry.resume_prompt_mode(),
@@ -584,7 +581,6 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
                 )?;
                 birth_managed_room(
                     &mut context,
-                    was_live,
                     preflight_health,
                     entry.no_resume(),
                     entry.resume_prompt_mode(),
@@ -637,7 +633,6 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
 
 fn birth_managed_room(
     context: &mut RoomContext,
-    was_live: bool,
     preflight_health: Option<rimz::mux::SessionHealth>,
     no_resume: bool,
     resume_prompt: ResumePromptMode,
@@ -645,7 +640,7 @@ fn birth_managed_room(
     background_view: Option<rimz::remote_control::ReadinessSnapshot>,
     cwd: std::path::PathBuf,
 ) -> Result<()> {
-    let rebirth = if was_live {
+    let rebirth = if preflight_health.is_some() {
         NormalRebirth::Live
     } else {
         match context.inspect_rebirth(no_resume) {

--- a/crates/rimz/src/cli/room/mod.rs
+++ b/crates/rimz/src/cli/room/mod.rs
@@ -16,9 +16,7 @@ use rimz::room::session::{
     MissingSessionReport, ensure_single_backend_room, pick_mux_for_session, retire_renamed_session,
     session_probe_retry_timeout, session_probe_timeout, workspace_record_for_session,
 };
-use rimz::room::{
-    AttendedRecovery, NormalRebirth, RoomBirth, RoomContext, RoomSizing, SessionOwnership,
-};
+use rimz::room::{AttendedRecovery, NormalRebirth, RoomBirth, RoomContext, RoomSizing};
 use rimz::{RuntimePaths, store::workspace_record::WorkspaceRecord};
 
 use crate::cli::hooks::ensure_detected_agent_hooks;
@@ -147,15 +145,6 @@ impl RoomEntry<'_> {
                 .ok()
                 .and_then(|record| record.as_ref())
                 .map(|record| &record.workspace_id),
-        }
-    }
-
-    fn session_ownership(&self) -> SessionOwnership {
-        match self {
-            Self::AttachSession { record, .. } if !matches!(record, Ok(Some(_))) => {
-                SessionOwnership::External
-            }
-            _ => SessionOwnership::Managed,
         }
     }
 }
@@ -474,7 +463,7 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
     // tmux would create the session and erase the distinction. A live room never
     // re-seeds prior agents, and its health verdict is reused by the attach gate.
     let preflight_health =
-        RoomContext::preflight_live_session(mux, entry.session_name(), entry.session_ownership())?;
+        RoomContext::preflight_live_session(mux, entry.session_name(), entry.workspace_id())?;
     let was_live = preflight_health.is_some();
     report_version_mismatch_notices(entry.workspace_id(), mux, entry.session_name(), was_live)?;
 

--- a/crates/rimz/src/cli/room/mod.rs
+++ b/crates/rimz/src/cli/room/mod.rs
@@ -16,7 +16,9 @@ use rimz::room::session::{
     MissingSessionReport, ensure_single_backend_room, pick_mux_for_session, retire_renamed_session,
     session_probe_retry_timeout, session_probe_timeout, workspace_record_for_session,
 };
-use rimz::room::{AttendedRecovery, NormalRebirth, RoomBirth, RoomContext, RoomSizing};
+use rimz::room::{
+    AttendedRecovery, NormalRebirth, RoomBirth, RoomContext, RoomSizing, SessionOwnership,
+};
 use rimz::{RuntimePaths, store::workspace_record::WorkspaceRecord};
 
 use crate::cli::hooks::ensure_detected_agent_hooks;
@@ -145,6 +147,15 @@ impl RoomEntry<'_> {
                 .ok()
                 .and_then(|record| record.as_ref())
                 .map(|record| &record.workspace_id),
+        }
+    }
+
+    fn session_ownership(&self) -> SessionOwnership {
+        match self {
+            Self::AttachSession { record, .. } if !matches!(record, Ok(Some(_))) => {
+                SessionOwnership::External
+            }
+            _ => SessionOwnership::Managed,
         }
     }
 }
@@ -462,7 +473,8 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
     // Capture whether this is a plain reattach *before* `ensure_session`, which on
     // tmux would create the session and erase the distinction. A live room never
     // re-seeds prior agents, and its health verdict is reused by the attach gate.
-    let preflight_health = RoomContext::preflight_live_session(mux, entry.session_name())?;
+    let preflight_health =
+        RoomContext::preflight_live_session(mux, entry.session_name(), entry.session_ownership())?;
     let was_live = preflight_health.is_some();
     report_version_mismatch_notices(entry.workspace_id(), mux, entry.session_name(), was_live)?;
 

--- a/crates/rimz/src/cli/room/mod.rs
+++ b/crates/rimz/src/cli/room/mod.rs
@@ -460,9 +460,10 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
 
     let backend = rimz::mux::backend_for(mux);
     // Capture whether this is a plain reattach *before* `ensure_session`, which on
-    // tmux would create the session and erase the distinction. A healthy live room
-    // re-seeds nothing; only a birth (absent or stuck) resumes prior agents.
-    let was_live = RoomContext::session_is_healthy_live(mux, entry.session_name());
+    // tmux would create the session and erase the distinction. A live room never
+    // re-seeds prior agents, and its health verdict is reused by the attach gate.
+    let preflight_health = RoomContext::preflight_live_session(mux, entry.session_name())?;
+    let was_live = preflight_health.is_some();
     report_version_mismatch_notices(entry.workspace_id(), mux, entry.session_name(), was_live)?;
 
     let hook_intro_rendered = if matches!(entry, RoomEntry::Start { .. }) && !was_live {
@@ -525,6 +526,7 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
             birth_managed_room(
                 &mut context,
                 was_live,
+                preflight_health,
                 entry.no_resume(),
                 entry.resume_prompt_mode(),
                 entry.refresh_ms(),
@@ -544,6 +546,7 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
             birth_managed_room(
                 &mut context,
                 was_live,
+                preflight_health,
                 entry.no_resume(),
                 entry.resume_prompt_mode(),
                 entry.refresh_ms(),
@@ -558,6 +561,7 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
             birth_managed_room(
                 &mut context,
                 was_live,
+                preflight_health,
                 entry.no_resume(),
                 entry.resume_prompt_mode(),
                 entry.refresh_ms(),
@@ -581,6 +585,7 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
                 birth_managed_room(
                     &mut context,
                     was_live,
+                    preflight_health,
                     entry.no_resume(),
                     entry.resume_prompt_mode(),
                     entry.refresh_ms(),
@@ -633,6 +638,7 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
 fn birth_managed_room(
     context: &mut RoomContext,
     was_live: bool,
+    preflight_health: Option<rimz::mux::SessionHealth>,
     no_resume: bool,
     resume_prompt: ResumePromptMode,
     refresh_ms: Option<u16>,
@@ -666,6 +672,7 @@ fn birth_managed_room(
         context.birth(RoomBirth::Normal {
             cwd,
             rebirth,
+            preflight_health,
             background_view,
             refresh_ms,
             recovery: if std::io::stdin().is_terminal() {

--- a/crates/rimz/src/cli/room/mod.rs
+++ b/crates/rimz/src/cli/room/mod.rs
@@ -134,17 +134,18 @@ impl RoomEntry<'_> {
         }
     }
 
-    fn workspace_id(&self) -> Option<&WorkspaceId> {
+    /// Keep a failed record lookup distinct from a known missing record because
+    /// only the latter proves a named session is foreign.
+    fn workspace_record_id(&self) -> std::result::Result<Option<&WorkspaceId>, ()> {
         match self {
             Self::Start { workspace, .. }
             | Self::StartDetached { workspace, .. }
-            | Self::AttachCwd { workspace, .. } => Some(&workspace.workspace_id),
-            Self::WebSession { record, .. } => Some(&record.workspace_id),
-            Self::AttachSession { record, .. } => record
-                .as_ref()
-                .ok()
-                .and_then(|record| record.as_ref())
-                .map(|record| &record.workspace_id),
+            | Self::AttachCwd { workspace, .. } => Ok(Some(&workspace.workspace_id)),
+            Self::WebSession { record, .. } => Ok(Some(&record.workspace_id)),
+            Self::AttachSession { record, .. } => match record {
+                Ok(record) => Ok(record.as_ref().map(|record| &record.workspace_id)),
+                Err(_) => Err(()),
+            },
         }
     }
 }
@@ -462,10 +463,16 @@ fn prepare_room(entry: RoomEntry<'_>, globals: &GlobalFlags) -> Result<ReadyRoom
     // Capture whether this is a plain reattach *before* `ensure_session`, which on
     // tmux would create the session and erase the distinction. A live room never
     // re-seeds prior agents, and its health verdict is reused by the attach gate.
+    let workspace_record_id = entry.workspace_record_id();
     let preflight_health =
-        RoomContext::preflight_live_session(mux, entry.session_name(), entry.workspace_id())?;
+        RoomContext::preflight_live_session(mux, entry.session_name(), workspace_record_id)?;
     let was_live = preflight_health.is_some();
-    report_version_mismatch_notices(entry.workspace_id(), mux, entry.session_name(), was_live)?;
+    report_version_mismatch_notices(
+        workspace_record_id.ok().flatten(),
+        mux,
+        entry.session_name(),
+        was_live,
+    )?;
 
     let hook_intro_rendered = if matches!(entry, RoomEntry::Start { .. }) && !was_live {
         ensure_detected_agent_hooks(start_attended())?

--- a/crates/rimz/src/mux/mod.rs
+++ b/crates/rimz/src/mux/mod.rs
@@ -759,8 +759,8 @@ pub enum BackgroundViewLaunch {
 }
 
 /// Health verdict for a backend session. [`MuxBackend::probe_session_health`]
-/// returns `Healthy` or `Stuck` (read-only); [`MuxBackend::ensure_clean_session`]
-/// adds `Reborn` when it rebirthed a safely-rebuildable room into a clean one.
+/// returns a read-only verdict; [`MuxBackend::ensure_clean_session`] adds
+/// `Reborn` when it rebirthed a safely-rebuildable room into a clean one.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SessionHealth {
     /// Clean and running — or absent, with nothing to heal.
@@ -770,6 +770,10 @@ pub enum SessionHealth {
     /// Stuck and needs an explicit reset: a rebirth could not clear an
     /// absent/exited room.
     Stuck,
+    /// Live according to the session roster, but failed a bounded native
+    /// control-plane probe. Callers must not attach or destructively recover
+    /// this room without explicit user consent.
+    Unresponsive,
 }
 
 /// Read-only liveness of one named session on a backend.
@@ -891,11 +895,12 @@ pub trait MuxBackend: Send + Sync {
     /// Only `rimz start` passes a `daemon`; other launches pass `None` and birth
     /// the working view alone.
     fn open_sidebar(&self, opts: &SidebarPaneOptions, daemon: Option<&DaemonView>) -> Result<()>;
-    /// Read-only health verdict for `name`'s room. Zellij trusts
-    /// `list-sessions` liveness: a live session is [`SessionHealth::Healthy`],
-    /// an exited session is [`SessionHealth::Stuck`], and an absent session is
-    /// healthy because birth can create it. tmux has no resurrection, so the
-    /// default is always [`SessionHealth::Healthy`]. `rimz doctor` reports this;
+    /// Read-only health verdict for `name`'s room. Zellij requires a live
+    /// session to answer a bounded native control-plane probe; an exited
+    /// session is [`SessionHealth::Stuck`], and an absent session is healthy
+    /// because birth can create it. tmux has no resurrection or per-session
+    /// actor that can wedge independently of its session roster, so the default
+    /// is always [`SessionHealth::Healthy`]. `rimz doctor` reports this;
     /// [`Self::ensure_clean_session`] acts on it. Never mutates the session.
     fn probe_session_health(&self, name: &str) -> Result<SessionHealth> {
         let _ = name;
@@ -911,11 +916,13 @@ pub trait MuxBackend: Send + Sync {
             .unwrap_or(false)
     }
     /// Guarantee the next [`Self::attach_command`] lands on a live, running
-    /// room. Probe `opts.session_name`; a live room is left untouched
-    /// ([`SessionHealth::Healthy`]); an absent or exited one is (re)birthed from
-    /// the layout ([`SessionHealth::Reborn`]); a room that a rebirth still
-    /// cannot make live returns [`SessionHealth::Stuck`] so the caller can
-    /// reset it on an attached terminal or direct the user to `rimz reset`.
+    /// room. Probe `opts.session_name`; a live, responsive room is left
+    /// untouched ([`SessionHealth::Healthy`]); a live room that does not answer
+    /// the bounded control-plane probe returns [`SessionHealth::Unresponsive`]
+    /// and must be preserved; an absent or exited one is (re)birthed from the
+    /// layout ([`SessionHealth::Reborn`]); a room that a rebirth still cannot
+    /// make live returns [`SessionHealth::Stuck`] so the caller can reset it on
+    /// an attached terminal or direct the user to `rimz reset`.
     /// This is the authoritative pre-attach gate that the best-effort sidebar
     /// launch cannot bypass. A socket path overflow returns an error and reset
     /// is not offered. tmux has no resurrection, so the default is a no-op

--- a/crates/rimz/src/mux/zellij.rs
+++ b/crates/rimz/src/mux/zellij.rs
@@ -46,10 +46,13 @@ pub const MIN_ZELLIJ_VERSION: (u32, u32, u32) = (0, 44, 0);
 /// without moving any attached client.
 const MIN_NO_FOCUS_ZELLIJ_VERSION: (u32, u32, u32) = (0, 45, 0);
 
-/// Per-attempt bound for the pre-attach health probe.
+/// Total budget for the pre-attach responsiveness verdict.
 const HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(8);
 
-/// Runtime pre-attach health-probe bound. Tests may set
+/// Pause between failed native responsiveness probes.
+const HEALTH_PROBE_RETRY_DELAY: Duration = Duration::from_millis(250);
+
+/// Runtime pre-attach responsiveness budget. Tests may set
 /// `RIMZ_TEST_ZELLIJ_HEALTH_PROBE_MS` to shorten fake-shim wait paths.
 fn health_probe_timeout() -> Duration {
     let Some(value) =
@@ -285,11 +288,28 @@ pub struct ZellijBackend {
     /// mutation while exercising topology dump pipes.
     #[cfg(test)]
     presence_plugin_path: Option<PathBuf>,
+    /// Test-only responsiveness budget override.
+    #[cfg(test)]
+    health_probe_timeout: Option<Duration>,
 }
 
 impl ZellijBackend {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    fn health_probe_timeout(&self) -> Duration {
+        #[cfg(test)]
+        if let Some(timeout) = self.health_probe_timeout {
+            return timeout;
+        }
+        health_probe_timeout()
+    }
+
+    #[cfg(test)]
+    fn with_health_probe_timeout_for_test(mut self, timeout: Duration) -> Self {
+        self.health_probe_timeout = Some(timeout);
+        self
     }
 
     /// Pin every Zellij command this backend runs to `dir` as the full XDG,

--- a/crates/rimz/src/mux/zellij/backend.rs
+++ b/crates/rimz/src/mux/zellij/backend.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use super::super::mount_proof::{prove_sidebar_mount, sidebar_build_identity};
-use super::ZellijBackend;
 use super::layout::{TempLayoutFile, render_background_view_layout, render_tab_layout};
 use super::pane_topology::{PaneTopologyCache, PaneTopologyPane, ZellijPaneId};
 use super::parse::{
@@ -17,6 +16,7 @@ use super::raw_pane::{
     tab_fullscreen_active, tab_view_cols,
 };
 use super::sidebar::DockOutcome;
+use super::{ZellijBackend, health_probe_timeout};
 use crate::ids::{MuxName, PaneId, WorkspaceId};
 use crate::mux::{
     BRACKET_PASTE_CLOSE, BRACKET_PASTE_OPEN, BackgroundViewLaunch, BackgroundViewOptions,
@@ -226,6 +226,25 @@ impl ZellijBackend {
             program: "zellij".to_owned(),
             reason: format!("parsing `list-panes --all --json`: {err}"),
         })
+    }
+
+    fn live_session_health(&self, name: &str) -> SessionHealth {
+        let probe = || self.raw_listed_panes(name, health_probe_timeout());
+        if probe().is_ok() {
+            return SessionHealth::Healthy;
+        }
+        match probe() {
+            Ok(_) => SessionHealth::Healthy,
+            Err(err) => {
+                tracing::warn!(
+                    session = %name,
+                    tags.operation = "zellij.session_health",
+                    error = &err as &dyn std::error::Error,
+                    "live zellij room did not answer the native health probe",
+                );
+                SessionHealth::Unresponsive
+            }
+        }
     }
 
     pub(super) fn authoritative_pane_listing(
@@ -922,8 +941,7 @@ impl MuxBackend for ZellijBackend {
             SessionLiveness::Absent => SessionHealth::Healthy,
             // `attach --create` would resurrect a serialized, suspended layout.
             SessionLiveness::Exited => SessionHealth::Stuck,
-            // `list-sessions` liveness is the attach gate truth; attach live rooms as-is.
-            SessionLiveness::Live => SessionHealth::Healthy,
+            SessionLiveness::Live => self.live_session_health(name),
         })
     }
 
@@ -933,11 +951,11 @@ impl MuxBackend for ZellijBackend {
         daemon: Option<&DaemonView>,
     ) -> Result<SessionHealth> {
         let state = self.session_state(&opts.session_name);
-        // A live room is trusted from `list-sessions` alone: attach as-is, never
-        // inspect panes. A stale topology cache is not evidence the room is
-        // stuck.
+        // A stale topology cache is not evidence that a live room is stuck, but
+        // a direct native listing must answer before attach. Its payload is not
+        // used as topology truth here.
         if matches!(state, SessionLiveness::Live) {
-            return Ok(SessionHealth::Healthy);
+            return Ok(self.live_session_health(&opts.session_name));
         }
         // Absent → first birth; Exited → delete and rebirth from the layout so
         // the room comes up clean and RUNNING (with serialization off, a rebirth

--- a/crates/rimz/src/mux/zellij/backend.rs
+++ b/crates/rimz/src/mux/zellij/backend.rs
@@ -16,7 +16,7 @@ use super::raw_pane::{
     tab_fullscreen_active, tab_view_cols,
 };
 use super::sidebar::DockOutcome;
-use super::{ZellijBackend, health_probe_timeout};
+use super::{HEALTH_PROBE_RETRY_DELAY, ZellijBackend};
 use crate::ids::{MuxName, PaneId, WorkspaceId};
 use crate::mux::{
     BRACKET_PASTE_CLOSE, BRACKET_PASTE_OPEN, BackgroundViewLaunch, BackgroundViewOptions,
@@ -229,22 +229,40 @@ impl ZellijBackend {
     }
 
     fn live_session_health(&self, name: &str) -> SessionHealth {
-        let probe = || self.raw_listed_panes(name, health_probe_timeout());
-        if probe().is_ok() {
-            return SessionHealth::Healthy;
-        }
-        match probe() {
-            Ok(_) => SessionHealth::Healthy,
-            Err(err) => {
-                tracing::warn!(
-                    session = %name,
-                    tags.operation = "zellij.session_health",
-                    error = &err as &dyn std::error::Error,
-                    "live zellij room did not answer the native health probe",
-                );
-                SessionHealth::Unresponsive
+        self.live_session_health_within(name, self.health_probe_timeout())
+    }
+
+    fn live_session_health_within(&self, name: &str, budget: Duration) -> SessionHealth {
+        let deadline = Instant::now() + budget;
+        let mut remaining = budget;
+        let last_error = loop {
+            match self.raw_listed_panes(name, remaining) {
+                Ok(_) => return SessionHealth::Healthy,
+                Err(err) => {
+                    let Some(wait_budget) = deadline
+                        .checked_duration_since(Instant::now())
+                        .filter(|remaining| !remaining.is_zero())
+                    else {
+                        break err;
+                    };
+                    std::thread::sleep(HEALTH_PROBE_RETRY_DELAY.min(wait_budget));
+                    let Some(next_budget) = deadline
+                        .checked_duration_since(Instant::now())
+                        .filter(|remaining| !remaining.is_zero())
+                    else {
+                        break err;
+                    };
+                    remaining = next_budget;
+                }
             }
-        }
+        };
+        tracing::warn!(
+            session = %name,
+            tags.operation = "zellij.session_health",
+            error = &last_error as &dyn std::error::Error,
+            "live zellij room did not answer the native health probe",
+        );
+        SessionHealth::Unresponsive
     }
 
     pub(super) fn authoritative_pane_listing(

--- a/crates/rimz/src/mux/zellij/tests.rs
+++ b/crates/rimz/src/mux/zellij/tests.rs
@@ -144,7 +144,7 @@ fn readonly_attach_relies_on_the_broadcast_ttyd_input_boundary() {
 #[test]
 fn live_session_that_fails_native_probe_is_unresponsive() {
     let room = TestRoom::new();
-    let (temp, shim) = zellij_shim(
+    let (_temp, shim) = zellij_shim(
         r#"#!/bin/sh
 dir=$(dirname "$0"); printf '%s\n' "$*" >> "$dir/zellij.log"
 if [ "$1" = "list-sessions" ]; then printf 'rimz-test [Created 1s ago]\n'; exit 0; fi
@@ -157,19 +157,16 @@ exit 0
 
     let health = room
         .backend(&shim)
+        .with_health_probe_timeout_for_test(Duration::from_millis(50))
         .ensure_clean_session(&room.sidebar_options(120), None)
         .expect("classify live session");
 
     assert_eq!(health, SessionHealth::Unresponsive);
-    assert_eq!(
-        command_count(&shim_log(&temp), "action list-panes --all --json"),
-        2,
-    );
 }
 
 #[cfg(unix)]
 #[test]
-fn live_session_native_probe_retries_a_transient_failure() {
+fn live_session_native_probe_accepts_success_before_deadline() {
     let room = TestRoom::new();
     let (temp, shim) = zellij_shim(
         r#"#!/bin/sh
@@ -187,6 +184,7 @@ exit 0
 
     let health = room
         .backend(&shim)
+        .with_health_probe_timeout_for_test(Duration::from_millis(500))
         .ensure_clean_session(&room.sidebar_options(120), None)
         .expect("classify live session");
 

--- a/crates/rimz/src/mux/zellij/tests.rs
+++ b/crates/rimz/src/mux/zellij/tests.rs
@@ -16,8 +16,8 @@ use crate::mux::zellij::pane_topology::{PaneTopologyCache, PaneTopologyPane, Top
 #[cfg(unix)]
 use crate::mux::{
     LayoutColumn, LayoutPanes, MuxBackend, PaneCmd, PaneListOptions, PaneReadConsistency,
-    ReconcilePaneRole, SidebarLiveness, SidebarPaneOptions, SidebarWidth, SplitDirection,
-    SplitPaneOptions, SplitPlacement, SplitTarget, TabOptions, WidthSyncOptions,
+    ReconcilePaneRole, SessionHealth, SidebarLiveness, SidebarPaneOptions, SidebarWidth,
+    SplitDirection, SplitPaneOptions, SplitPlacement, SplitTarget, TabOptions, WidthSyncOptions,
 };
 #[cfg(unix)]
 use crate::sidebar::cache::write_pane_topology_cache;
@@ -138,6 +138,63 @@ fn readonly_attach_relies_on_the_broadcast_ttyd_input_boundary() {
     let spec = ZellijBackend::new().attach_readonly_command("rimz-test");
 
     assert_eq!(spec.args, ["attach", "rimz-test"]);
+}
+
+#[cfg(unix)]
+#[test]
+fn live_session_that_fails_native_probe_is_unresponsive() {
+    let room = TestRoom::new();
+    let (temp, shim) = zellij_shim(
+        r#"#!/bin/sh
+dir=$(dirname "$0"); printf '%s\n' "$*" >> "$dir/zellij.log"
+if [ "$1" = "list-sessions" ]; then printf 'rimz-test [Created 1s ago]\n'; exit 0; fi
+case " $* " in
+  *" action list-panes --all --json "*) exit 1 ;;
+esac
+exit 0
+"#,
+    );
+
+    let health = room
+        .backend(&shim)
+        .ensure_clean_session(&room.sidebar_options(120), None)
+        .expect("classify live session");
+
+    assert_eq!(health, SessionHealth::Unresponsive);
+    assert_eq!(
+        command_count(&shim_log(&temp), "action list-panes --all --json"),
+        2,
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn live_session_native_probe_retries_a_transient_failure() {
+    let room = TestRoom::new();
+    let (temp, shim) = zellij_shim(
+        r#"#!/bin/sh
+dir=$(dirname "$0"); log="$dir/zellij.log"; marker="$dir/probe-failed"
+printf '%s\n' "$*" >> "$log"
+if [ "$1" = "list-sessions" ]; then printf 'rimz-test [Created 1s ago]\n'; exit 0; fi
+case " $* " in
+  *" action list-panes --all --json "*)
+    if [ ! -e "$marker" ]; then : > "$marker"; exit 1; fi
+    printf '[]\n'; exit 0 ;;
+esac
+exit 0
+"#,
+    );
+
+    let health = room
+        .backend(&shim)
+        .ensure_clean_session(&room.sidebar_options(120), None)
+        .expect("classify live session");
+
+    assert_eq!(health, SessionHealth::Healthy);
+    assert_eq!(
+        command_count(&shim_log(&temp), "action list-panes --all --json"),
+        2,
+    );
 }
 
 #[cfg(unix)]

--- a/crates/rimz/src/room/birth.rs
+++ b/crates/rimz/src/room/birth.rs
@@ -39,6 +39,8 @@ pub enum RoomBirth {
     Normal {
         cwd: PathBuf,
         rebirth: NormalRebirth,
+        /// Health already proved for a session that was live before birth.
+        preflight_health: Option<SessionHealth>,
         /// `None` requests no configured background-view launch.
         background_view: Option<ReadinessSnapshot>,
         refresh_ms: Option<u16>,
@@ -75,6 +77,32 @@ pub struct BirthOutcome {
 impl RoomContext {
     /// Execute shared room birth ordering for a normal or supervised caller.
     pub fn birth(&mut self, birth: RoomBirth) -> Result<BirthOutcome> {
+        let (cwd, refresh_ms, rebirth, preflight_health, background_view, recovery, supervised) =
+            match birth {
+                RoomBirth::Normal {
+                    cwd,
+                    rebirth,
+                    preflight_health,
+                    background_view,
+                    refresh_ms,
+                    recovery,
+                } => (
+                    cwd,
+                    refresh_ms,
+                    Some(rebirth),
+                    preflight_health,
+                    background_view,
+                    recovery,
+                    false,
+                ),
+                RoomBirth::Supervised { cwd, recovery } => {
+                    (cwd, None, None, None, None, recovery, true)
+                }
+            };
+        if matches!(preflight_health, Some(SessionHealth::Unresponsive)) {
+            return Err(super::unresponsive_error(&self.workspace.session_name));
+        }
+
         let pre_existed = match self.backend.list_sessions() {
             Ok(sessions) => sessions
                 .iter()
@@ -106,23 +134,6 @@ impl RoomContext {
             }
         }
 
-        let (cwd, refresh_ms, rebirth, background_view, recovery, supervised) = match birth {
-            RoomBirth::Normal {
-                cwd,
-                rebirth,
-                background_view,
-                refresh_ms,
-                recovery,
-            } => (
-                cwd,
-                refresh_ms,
-                Some(rebirth),
-                background_view,
-                recovery,
-                false,
-            ),
-            RoomBirth::Supervised { cwd, recovery } => (cwd, None, None, None, recovery, true),
-        };
         self.backend.ensure_session(&self.session_options(&cwd))?;
         if supervised && pre_existed {
             self.detected_size = None;
@@ -178,7 +189,7 @@ impl RoomContext {
             self.launch_background_view(options);
         }
 
-        let reset = self.ensure_healthy(&sidebar, daemon, recovery)?;
+        let reset = self.ensure_healthy(&sidebar, daemon, recovery, preflight_health)?;
         self.load_presence();
         Ok(BirthOutcome { resume, reset })
     }
@@ -223,15 +234,17 @@ impl RoomContext {
         sidebar: &SidebarPaneOptions,
         daemon: Option<&DaemonView>,
         recovery: AttendedRecovery,
+        preflight_health: Option<SessionHealth>,
     ) -> Result<Option<RoomResetReport>> {
-        match self.clean_session(sidebar, daemon)? {
+        let health = match preflight_health {
+            Some(health) => health,
+            None => self.clean_session(sidebar, daemon)?,
+        };
+        match health {
             SessionHealth::Healthy | SessionHealth::Reborn => return Ok(None),
-            SessionHealth::Unresponsive => anyhow::bail!(
-                "The '{}' Zellij room is live but not responding to Zellij control commands.\n\
-                 Attaching could open a black screen, so RimZ left the room untouched.\n\
-                 Run `rimz doctor` to inspect it or `rimz reset` to rebuild it (destructive; prompts first).",
-                self.workspace.session_name,
-            ),
+            SessionHealth::Unresponsive => {
+                return Err(super::unresponsive_error(&self.workspace.session_name));
+            }
             SessionHealth::Stuck => {}
         }
         if recovery == AttendedRecovery::RequireExplicitReset {

--- a/crates/rimz/src/room/birth.rs
+++ b/crates/rimz/src/room/birth.rs
@@ -224,8 +224,15 @@ impl RoomContext {
         daemon: Option<&DaemonView>,
         recovery: AttendedRecovery,
     ) -> Result<Option<RoomResetReport>> {
-        if self.clean_session(sidebar, daemon)? != SessionHealth::Stuck {
-            return Ok(None);
+        match self.clean_session(sidebar, daemon)? {
+            SessionHealth::Healthy | SessionHealth::Reborn => return Ok(None),
+            SessionHealth::Unresponsive => anyhow::bail!(
+                "The '{}' Zellij room is live but not responding to Zellij control commands.\n\
+                 Attaching could open a black screen, so RimZ left the room untouched.\n\
+                 Run `rimz doctor` to inspect it or `rimz reset` to rebuild it (destructive; prompts first).",
+                self.workspace.session_name,
+            ),
+            SessionHealth::Stuck => {}
         }
         if recovery == AttendedRecovery::RequireExplicitReset {
             anyhow::bail!(
@@ -238,7 +245,7 @@ impl RoomContext {
         let reset = self.reset(false)?;
         match self.clean_session(sidebar, daemon) {
             Ok(SessionHealth::Healthy | SessionHealth::Reborn) => Ok(Some(reset)),
-            Ok(SessionHealth::Stuck) => Err(ResetRecoveryError {
+            Ok(SessionHealth::Stuck | SessionHealth::Unresponsive) => Err(ResetRecoveryError {
                 report: reset,
                 message: "the room is still stuck after a reset; inspect with `rimz doctor`"
                     .to_owned(),

--- a/crates/rimz/src/room/birth.rs
+++ b/crates/rimz/src/room/birth.rs
@@ -99,10 +99,6 @@ impl RoomContext {
                     (cwd, None, None, None, None, recovery, true)
                 }
             };
-        if matches!(preflight_health, Some(SessionHealth::Unresponsive)) {
-            return Err(super::unresponsive_error(&self.workspace.session_name));
-        }
-
         let pre_existed = match self.backend.list_sessions() {
             Ok(sessions) => sessions
                 .iter()
@@ -243,7 +239,10 @@ impl RoomContext {
         match health {
             SessionHealth::Healthy | SessionHealth::Reborn => return Ok(None),
             SessionHealth::Unresponsive => {
-                return Err(super::unresponsive_error(&self.workspace.session_name));
+                return Err(super::unresponsive_error(
+                    &self.workspace.session_name,
+                    super::SessionOwnership::Managed,
+                ));
             }
             SessionHealth::Stuck => {}
         }

--- a/crates/rimz/src/room/mod.rs
+++ b/crates/rimz/src/room/mod.rs
@@ -43,13 +43,6 @@ pub enum LiveRoomErr {
 
 pub type LiveRoomResult<T> = std::result::Result<T, LiveRoomErr>;
 
-/// Whether the selected session belongs to a RimZ workspace record.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum SessionOwnership {
-    Managed,
-    External,
-}
-
 /// Select the configured multiplexer and require this workspace's room to be live.
 pub fn require_live_mux(
     explicit: Option<MuxName>,
@@ -253,7 +246,7 @@ impl RoomContext {
     pub fn preflight_live_session(
         mux: MuxName,
         session_name: &str,
-        ownership: SessionOwnership,
+        workspace_id: Option<&WorkspaceId>,
     ) -> Result<Option<SessionHealth>> {
         let backend = crate::mux::backend_for(mux);
         if !backend
@@ -264,6 +257,11 @@ impl RoomContext {
             return Ok(None);
         }
         let health = backend.probe_session_health(session_name)?;
+        let ownership = if workspace_id.is_some() {
+            SessionOwnership::Managed
+        } else {
+            SessionOwnership::External
+        };
         classify_preflight_health(session_name, ownership, health)
     }
 
@@ -433,6 +431,12 @@ impl RoomContext {
             sidebar: self.sidebar_options(&self.workspace.worktree_root, Vec::new(), refresh_ms),
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SessionOwnership {
+    Managed,
+    External,
 }
 
 fn classify_preflight_health(

--- a/crates/rimz/src/room/mod.rs
+++ b/crates/rimz/src/room/mod.rs
@@ -240,21 +240,26 @@ impl RoomContext {
     }
 
     /// Probe a selected backend before first-run config can construct final context.
-    pub fn session_is_healthy_live(mux: MuxName, session_name: &str) -> bool {
+    /// Refuses an unresponsive live session immediately; other live verdicts
+    /// are returned for reuse by the birth gate, while absent and exited
+    /// sessions return `None`.
+    pub fn preflight_live_session(
+        mux: MuxName,
+        session_name: &str,
+    ) -> Result<Option<SessionHealth>> {
         let backend = crate::mux::backend_for(mux);
-        Self::probe_healthy_live(backend.as_ref(), session_name)
-    }
-
-    fn probe_healthy_live(backend: &dyn MuxBackend, session_name: &str) -> bool {
-        let exists = backend
-            .list_sessions()
-            .map(|sessions| sessions.iter().any(|name| name == session_name))
-            .unwrap_or(false);
-        exists
-            && matches!(
-                backend.probe_session_health(session_name),
-                Ok(SessionHealth::Healthy)
-            )
+        if !backend
+            .list_sessions()?
+            .iter()
+            .any(|candidate| candidate == session_name)
+        {
+            return Ok(None);
+        }
+        let health = backend.probe_session_health(session_name)?;
+        if health == SessionHealth::Unresponsive {
+            return Err(unresponsive_error(session_name));
+        }
+        Ok(Some(health))
     }
 
     /// Inspect previous incarnation state without mutating it.
@@ -423,6 +428,14 @@ impl RoomContext {
             sidebar: self.sidebar_options(&self.workspace.worktree_root, Vec::new(), refresh_ms),
         }
     }
+}
+
+fn unresponsive_error(session_name: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "The '{session_name}' Zellij room is live but not responding to Zellij control commands.\n\
+         Attaching could open a black screen, so RimZ left the room untouched.\n\
+         Run `rimz doctor` to inspect it or `rimz reset` to rebuild it (destructive; prompts first).",
+    )
 }
 
 fn recorded_room_bin(workspace_id: &WorkspaceId) -> PathBuf {

--- a/crates/rimz/src/room/mod.rs
+++ b/crates/rimz/src/room/mod.rs
@@ -242,11 +242,12 @@ impl RoomContext {
     /// Probe a selected backend before first-run config can construct final context.
     /// Refuses an unresponsive live session immediately; other live verdicts
     /// are returned for reuse by the birth gate, while absent and exited
-    /// sessions return `None`.
+    /// sessions return `None`. The nested workspace-record result preserves
+    /// managed, foreign, and unknown ownership for safe recovery guidance.
     pub fn preflight_live_session(
         mux: MuxName,
         session_name: &str,
-        workspace_id: Option<&WorkspaceId>,
+        workspace_record_id: std::result::Result<Option<&WorkspaceId>, ()>,
     ) -> Result<Option<SessionHealth>> {
         let backend = crate::mux::backend_for(mux);
         if !backend
@@ -257,10 +258,10 @@ impl RoomContext {
             return Ok(None);
         }
         let health = backend.probe_session_health(session_name)?;
-        let ownership = if workspace_id.is_some() {
-            SessionOwnership::Managed
-        } else {
-            SessionOwnership::External
+        let ownership = match workspace_record_id {
+            Ok(Some(_)) => SessionOwnership::Managed,
+            Ok(None) => SessionOwnership::External,
+            Err(()) => SessionOwnership::Unknown,
         };
         classify_preflight_health(session_name, ownership, health)
     }
@@ -437,6 +438,7 @@ impl RoomContext {
 enum SessionOwnership {
     Managed,
     External,
+    Unknown,
 }
 
 fn classify_preflight_health(
@@ -458,6 +460,12 @@ fn unresponsive_error(session_name: &str, ownership: SessionOwnership) -> anyhow
             let session_name = shell_quote(session_name);
             format!(
                 "This session is not RimZ-managed. Run `zellij delete-session --force {session_name}` to destroy it without a confirmation prompt, or `zellij attach {session_name}` to bypass RimZ if you insist."
+            )
+        }
+        SessionOwnership::Unknown => {
+            let session_name = shell_quote(session_name);
+            format!(
+                "RimZ could not determine whether this session is managed. Run `rimz doctor` to inspect it, or `zellij attach {session_name}` to bypass RimZ if you choose to attach directly."
             )
         }
     };
@@ -608,5 +616,12 @@ mod tests {
         assert!(external.contains("without a confirmation prompt"));
         assert!(!external.contains("rimz reset"));
         assert!(!external.contains("prompts first"));
+
+        let unknown = unresponsive_error("rimz-demo", SessionOwnership::Unknown).to_string();
+        assert!(unknown.contains("could not determine whether this session is managed"));
+        assert!(unknown.contains("`rimz doctor`"));
+        assert!(unknown.contains("`zellij attach 'rimz-demo'`"));
+        assert!(!unknown.contains("delete-session"));
+        assert!(!unknown.contains("rimz reset"));
     }
 }

--- a/crates/rimz/src/room/mod.rs
+++ b/crates/rimz/src/room/mod.rs
@@ -43,6 +43,13 @@ pub enum LiveRoomErr {
 
 pub type LiveRoomResult<T> = std::result::Result<T, LiveRoomErr>;
 
+/// Whether the selected session belongs to a RimZ workspace record.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SessionOwnership {
+    Managed,
+    External,
+}
+
 /// Select the configured multiplexer and require this workspace's room to be live.
 pub fn require_live_mux(
     explicit: Option<MuxName>,
@@ -246,6 +253,7 @@ impl RoomContext {
     pub fn preflight_live_session(
         mux: MuxName,
         session_name: &str,
+        ownership: SessionOwnership,
     ) -> Result<Option<SessionHealth>> {
         let backend = crate::mux::backend_for(mux);
         if !backend
@@ -256,10 +264,7 @@ impl RoomContext {
             return Ok(None);
         }
         let health = backend.probe_session_health(session_name)?;
-        if health == SessionHealth::Unresponsive {
-            return Err(unresponsive_error(session_name));
-        }
-        Ok(Some(health))
+        classify_preflight_health(session_name, ownership, health)
     }
 
     /// Inspect previous incarnation state without mutating it.
@@ -430,12 +435,37 @@ impl RoomContext {
     }
 }
 
-fn unresponsive_error(session_name: &str) -> anyhow::Error {
+fn classify_preflight_health(
+    session_name: &str,
+    ownership: SessionOwnership,
+    health: SessionHealth,
+) -> Result<Option<SessionHealth>> {
+    match health {
+        SessionHealth::Healthy => Ok(Some(health)),
+        SessionHealth::Unresponsive => Err(unresponsive_error(session_name, ownership)),
+        SessionHealth::Reborn | SessionHealth::Stuck => Ok(None),
+    }
+}
+
+fn unresponsive_error(session_name: &str, ownership: SessionOwnership) -> anyhow::Error {
+    let recovery = match ownership {
+        SessionOwnership::Managed => "Run `rimz doctor` to inspect it or `rimz reset` to rebuild it (destructive; prompts first).".to_owned(),
+        SessionOwnership::External => {
+            let session_name = shell_quote(session_name);
+            format!(
+                "This session is not RimZ-managed. Run `zellij delete-session --force {session_name}` to destroy it without a confirmation prompt, or `zellij attach {session_name}` to bypass RimZ if you insist."
+            )
+        }
+    };
     anyhow::anyhow!(
         "The '{session_name}' Zellij room is live but not responding to Zellij control commands.\n\
          Attaching could open a black screen, so RimZ left the room untouched.\n\
-         Run `rimz doctor` to inspect it or `rimz reset` to rebuild it (destructive; prompts first).",
+         {recovery}",
     )
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn recorded_room_bin(workspace_id: &WorkspaceId) -> PathBuf {
@@ -530,5 +560,49 @@ mod tests {
         assert_eq!(unavailable.to_string(), expected);
         assert!(std::error::Error::source(&unavailable).is_none());
         assert_eq!(mux.to_string(), MuxErr::NoMuxFound.to_string());
+    }
+
+    #[test]
+    fn preflight_reuses_only_a_healthy_live_verdict() {
+        assert_eq!(
+            classify_preflight_health(
+                "rimz-demo",
+                SessionOwnership::Managed,
+                SessionHealth::Healthy,
+            )
+            .expect("healthy verdict"),
+            Some(SessionHealth::Healthy)
+        );
+        for health in [SessionHealth::Reborn, SessionHealth::Stuck] {
+            assert_eq!(
+                classify_preflight_health("rimz-demo", SessionOwnership::Managed, health)
+                    .expect("non-live verdict"),
+                None
+            );
+        }
+        assert!(
+            classify_preflight_health(
+                "rimz-demo",
+                SessionOwnership::Managed,
+                SessionHealth::Unresponsive,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn unresponsive_recovery_matches_session_ownership() {
+        let managed = unresponsive_error("rimz-demo", SessionOwnership::Managed).to_string();
+        assert!(managed.contains("`rimz reset`"));
+        assert!(managed.contains("prompts first"));
+
+        let external =
+            unresponsive_error("someone else's session", SessionOwnership::External).to_string();
+        assert!(external.contains("not RimZ-managed"));
+        assert!(external.contains("`zellij delete-session --force 'someone else'\\''s session'`"));
+        assert!(external.contains("`zellij attach 'someone else'\\''s session'`"));
+        assert!(external.contains("without a confirmation prompt"));
+        assert!(!external.contains("rimz reset"));
+        assert!(!external.contains("prompts first"));
     }
 }

--- a/crates/rimz/tests/integration/run.rs
+++ b/crates/rimz/tests/integration/run.rs
@@ -1162,6 +1162,7 @@ fn spawn_verifying_print(
         .env("RIMZ_TEST_PANE_LIST", pane_fixture)
         .env("RIMZ_ZELLIJ_BIN", zellij_trace_shim())
         .env("RIMZ_TEST_ZELLIJ_LOG", trace_log)
+        .env("RIMZ_TEST_ZELLIJ_LIST_PANES", "[]")
         .env("ZELLIJ_PANE_ID", "1")
         .env(
             "RIMZ_TEST_ZELLIJ_LIST_SESSIONS",

--- a/crates/rimz/tests/integration/zellij_health.rs
+++ b/crates/rimz/tests/integration/zellij_health.rs
@@ -116,6 +116,59 @@ fn unresponsive_foreign_zellij_session_names_native_recovery_and_bypass() {
 }
 
 #[test]
+fn unresponsive_zellij_session_with_unknown_ownership_avoids_destroy_guidance() {
+    let env = Env::new();
+    let workspace = WorkspaceResolver::resolve(&env.project_root, None).expect("resolve");
+    env.store()
+        .record_room_bin(
+            &workspace,
+            std::env::current_exe().expect("current test binary"),
+            "test".to_owned(),
+        )
+        .expect("record managed room");
+
+    let workspaces = env.state_root().join("rimz/workspaces");
+    let hidden_workspaces = env.state_root().join("rimz/workspaces-hidden");
+    fs::rename(&workspaces, &hidden_workspaces).expect("hide workspace records");
+    fs::write(&workspaces, b"not a directory").expect("block workspace record lookup");
+
+    let shim = FakeZellij::new();
+    let output = env
+        .rimz()
+        .args([
+            "--mux",
+            "zellij",
+            "attach",
+            workspace.session_name.as_str(),
+            "--print",
+        ])
+        .env("PATH", shim.bin_dir.path())
+        .env("RIMZ_ZELLIJ_BIN", &shim.bin)
+        .env("RIMZ_TEST_ZELLIJ_LOG", &shim.log)
+        .env("RIMZ_TEST_SESSION_NAME", &workspace.session_name)
+        .env("RIMZ_TEST_ZELLIJ_HEALTH_PROBE_MS", "100")
+        .bounded_output_within(ROOM_WORKFLOW_TIMEOUT)
+        .expect("run rimz attach");
+
+    fs::remove_file(&workspaces).expect("remove lookup blocker");
+    fs::rename(&hidden_workspaces, &workspaces).expect("restore workspace records");
+
+    assert!(!output.status.success(), "unresponsive attach must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("could not determine whether this session is managed"),
+        "stderr: {stderr}",
+    );
+    assert!(stderr.contains("rimz doctor"), "stderr: {stderr}");
+    assert!(
+        stderr.contains(&format!("zellij attach '{}'", workspace.session_name)),
+        "stderr: {stderr}",
+    );
+    assert!(!stderr.contains("delete-session"), "stderr: {stderr}");
+    assert!(!stderr.contains("rimz reset"), "stderr: {stderr}");
+}
+
+#[test]
 fn attach_retries_transient_zellij_session_listing_before_default_mux_fallback() {
     let env = Env::new();
     let workspace = WorkspaceResolver::resolve(&env.project_root, None).expect("resolve");

--- a/crates/rimz/tests/integration/zellij_health.rs
+++ b/crates/rimz/tests/integration/zellij_health.rs
@@ -74,6 +74,48 @@ fn assert_unresponsive_live_room_is_preserved(list_panes_sleep: Option<&str>) {
 }
 
 #[test]
+fn unresponsive_foreign_zellij_session_names_native_recovery_and_bypass() {
+    let env = Env::new();
+    let shim = FakeZellij::new();
+    let session = "someone-elses-session";
+
+    let output = env
+        .rimz()
+        .args(["--mux", "zellij", "attach", session, "--print"])
+        .env("PATH", shim.bin_dir.path())
+        .env("RIMZ_ZELLIJ_BIN", &shim.bin)
+        .env("RIMZ_TEST_ZELLIJ_LOG", &shim.log)
+        .env("RIMZ_TEST_SESSION_NAME", session)
+        .env("RIMZ_TEST_ZELLIJ_HEALTH_PROBE_MS", "100")
+        .bounded_output_within(ROOM_WORKFLOW_TIMEOUT)
+        .expect("run rimz attach");
+
+    assert!(!output.status.success(), "unresponsive attach must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not RimZ-managed"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("zellij delete-session --force 'someone-elses-session'"),
+        "stderr: {stderr}",
+    );
+    assert!(
+        stderr.contains("zellij attach 'someone-elses-session'") && stderr.contains("bypass RimZ"),
+        "stderr: {stderr}",
+    );
+    assert!(!stderr.contains("rimz reset"), "stderr: {stderr}");
+    assert!(!stderr.contains("prompts first"), "stderr: {stderr}");
+
+    let lines = read_trace_lines(&shim.log, Duration::from_millis(200));
+    assert!(
+        !lines.iter().any(|line| line.starts_with("attach")),
+        "the bypass is advice, not a command RimZ ran: {lines:?}",
+    );
+    assert!(
+        !lines.iter().any(|line| line.contains("delete-session")),
+        "RimZ must not destroy a foreign session: {lines:?}",
+    );
+}
+
+#[test]
 fn attach_retries_transient_zellij_session_listing_before_default_mux_fallback() {
     let env = Env::new();
     let workspace = WorkspaceResolver::resolve(&env.project_root, None).expect("resolve");

--- a/crates/rimz/tests/integration/zellij_health.rs
+++ b/crates/rimz/tests/integration/zellij_health.rs
@@ -11,36 +11,61 @@ use tempfile::TempDir;
 use crate::common::{CommandTimeoutExt, Env, ROOM_WORKFLOW_TIMEOUT};
 
 #[test]
-fn uninspectable_live_zellij_room_attaches_as_is() {
+fn unresponsive_live_zellij_room_fails_fast_and_is_preserved() {
+    assert_unresponsive_live_room_is_preserved(None);
+}
+
+#[test]
+fn timed_out_live_zellij_room_fails_fast_and_is_preserved() {
+    assert_unresponsive_live_room_is_preserved(Some("60"));
+}
+
+fn assert_unresponsive_live_room_is_preserved(list_panes_sleep: Option<&str>) {
     let env = Env::new();
     let workspace = WorkspaceResolver::resolve(&env.project_root, None).expect("resolve");
     let shim = FakeZellij::new();
 
-    let output = env
-        .rimz()
-        .args(["--mux", "zellij", "start", "--no-attach"])
+    let mut command = env.rimz();
+    command
+        .args(["--mux", "zellij", "start"])
         .env("PATH", shim.bin_dir.path())
         .env("RIMZ_ZELLIJ_BIN", &shim.bin)
         .env("RIMZ_TEST_ZELLIJ_LOG", &shim.log)
         .env("RIMZ_TEST_SESSION_NAME", &workspace.session_name)
-        .env("RIMZ_TEST_ZELLIJ_HEALTH_PROBE_MS", "250")
-        // The uninspectable room legitimately holds `start` for the full
-        // pre-attach topology ceiling before attaching as-is, so keep the outer
-        // test bound roomy while shortening the fake-shim probe.
+        .env("RIMZ_TEST_ZELLIJ_HEALTH_PROBE_MS", "100");
+    if let Some(sleep) = list_panes_sleep {
+        command.env("RIMZ_TEST_ZELLIJ_LIST_PANES_SLEEP", sleep);
+    }
+    let output = command
         .bounded_output_within(ROOM_WORKFLOW_TIMEOUT)
         .expect("run rimz start");
 
-    assert!(output.status.success(), "live room should attach as-is");
+    assert!(
+        !output.status.success(),
+        "an unresponsive live room must fail before attach",
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        !stderr.contains("No terminal is available to confirm"),
-        "live room should not reach reset, got: {stderr}"
+        stderr.contains(&workspace.session_name) && stderr.contains("rimz reset"),
+        "error should name the room and recovery command, got: {stderr}",
     );
 
     let lines = read_trace_lines(&shim.log, Duration::from_millis(200));
+    let probe_attempts = lines
+        .iter()
+        .filter(|line| line.contains("action\tlist-panes"))
+        .count();
+    assert!(
+        probe_attempts >= 2,
+        "the native pane probe should retry once: {lines:?}",
+    );
+    assert!(
+        !lines.iter().any(|line| line.starts_with("attach")),
+        "the attach child must not run: {lines:?}",
+    );
     assert!(
         !lines.iter().any(|line| line.contains("delete-session")),
-        "an uninspectable live room must be preserved: {lines:?}"
+        "an unresponsive live room must be preserved: {lines:?}",
     );
 }
 
@@ -108,6 +133,7 @@ fn named_attach_preserves_recorded_room_owner() {
         .env("RIMZ_ZELLIJ_BIN", &shim.bin)
         .env("RIMZ_TEST_ZELLIJ_LOG", &shim.log)
         .env("RIMZ_TEST_SESSION_NAME", &workspace.session_name)
+        .env("RIMZ_TEST_ZELLIJ_LIST_PANES", "[]")
         .bounded_output()
         .expect("run rimz attach");
 
@@ -261,6 +287,13 @@ if [ "$1" = "list-sessions" ]; then
 fi
 
 if [ "$1" = "--session" ] && [ "$3" = "action" ] && [ "$4" = "list-panes" ]; then
+  if [ -n "$RIMZ_TEST_ZELLIJ_LIST_PANES_SLEEP" ]; then
+    exec /bin/sleep "$RIMZ_TEST_ZELLIJ_LIST_PANES_SLEEP"
+  fi
+  if [ -n "$RIMZ_TEST_ZELLIJ_LIST_PANES" ]; then
+    printf '%s\n' "$RIMZ_TEST_ZELLIJ_LIST_PANES"
+    exit 0
+  fi
   printf 'simulated wedged list-panes\n' >&2
   exit 5
 fi

--- a/crates/rimz/tests/integration/zellij_health.rs
+++ b/crates/rimz/tests/integration/zellij_health.rs
@@ -51,21 +51,25 @@ fn assert_unresponsive_live_room_is_preserved(list_panes_sleep: Option<&str>) {
     );
 
     let lines = read_trace_lines(&shim.log, Duration::from_millis(200));
-    let probe_attempts = lines
-        .iter()
-        .filter(|line| line.contains("action\tlist-panes"))
-        .count();
-    assert!(
-        probe_attempts >= 2,
-        "the native pane probe should retry once: {lines:?}",
-    );
     assert!(
         !lines.iter().any(|line| line.starts_with("attach")),
         "the attach child must not run: {lines:?}",
     );
     assert!(
+        !lines.iter().any(|line| line.contains("action\tlist-tabs")),
+        "best-effort room launches must not run before the health refusal: {lines:?}",
+    );
+    assert!(
         !lines.iter().any(|line| line.contains("delete-session")),
         "an unresponsive live room must be preserved: {lines:?}",
+    );
+    assert!(
+        env.read_events().iter().all(|event| !matches!(
+            event.kind(),
+            rimz::store::event::EventKind::SessionDeath(_)
+                | rimz::store::event::EventKind::SessionRebirth
+        )),
+        "a live room must not be recorded as dead or reborn",
     );
 }
 
@@ -83,6 +87,7 @@ fn attach_retries_transient_zellij_session_listing_before_default_mux_fallback()
         .env("RIMZ_ZELLIJ_BIN", &shim.bin)
         .env("RIMZ_TEST_ZELLIJ_LOG", &shim.log)
         .env("RIMZ_TEST_SESSION_NAME", &workspace.session_name)
+        .env("RIMZ_TEST_ZELLIJ_LIST_PANES", "[]")
         .env("RIMZ_TEST_ZELLIJ_LIST_SESSIONS_FAIL_ONCE", &fail_once)
         .bounded_output()
         .expect("run rimz attach");

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -104,6 +104,16 @@ This directory's room is `rimz-rimz-f89e49`. Detach to (re)launch it, or run `ri
 
 Open a fresh terminal window that is not attached to Zellij or tmux, then run `rimz` there.
 
+### Zellij is live but not responding
+
+Zellij can still list a room after that room has stopped answering pane queries. Attaching then opens an alternate screen that cannot draw, so RimZ refuses before attach and leaves every pane untouched. Run `rimz doctor` to confirm the `live but not responding` session-health verdict. If it does not recover, rebuild the room explicitly:
+
+```sh
+rimz reset
+```
+
+Reset is destructive and asks for confirmation before replacing the wedged room; see [Rebuild a wedged room with `rimz reset`](#rebuild-a-wedged-room-with-rimz-reset) for the exact lifecycle and non-interactive flags.
+
 ### Zellij or tmux is missing or too old
 
 RimZ needs Zellij 0.44+ or tmux 3.5+ on the machine, pixel-perfect pets add tmux 3.6+, and Zellij's kitty-graphics capability requires 0.45+. The `MULTIPLEXER` section reports the detected backend and its version against the floor (`zellij floor: ✓ OK (>= 0.44.0 required)`, or `TOO OLD`). Install or upgrade the multiplexer if the row flags it. When both are installed and doctor resolved the one you did not want, pick a backend explicitly with `--zellij`, `--tmux`, or `--mux <name>`.

--- a/docs/internals/multiplexers.md
+++ b/docs/internals/multiplexers.md
@@ -333,11 +333,11 @@ Birth branches on the session's liveness, as reported by `zellij list-sessions`:
 
 | Liveness | Branch |
 | --- | --- |
-| Live | Before attach, a bounded direct `list-panes` probe must prove the session's control plane responds. A responsive session already carries its sidebar and owns every resize and split since. A trusted sidebar heartbeat makes `open_sidebar` a no-op; a stale heartbeat rebuilds only an inspected live room, and an uninspectable one is left untouched. |
+| Live | Before attach, a bounded direct `list-panes` probe must prove the session's control plane responds. A responsive session already carries its sidebar and owns every resize and split since. Separately, sidebar launch trusts a fresh heartbeat; after a stale heartbeat it rebuilds only a room whose presence topology can be inspected and otherwise leaves the sidebar untouched. |
 | `Exited` (`EXITED - attach to resurrect`) | Clean rebirth: delete, then create from the layout. With serialization off this state stops being minted, but the branch stays as defence for sessions serialized before the flag landed. |
 | Absent | First birth: create from the layout. |
 
-A session can remain in Zellij's live roster while its per-session Screen actor no longer answers control commands. RimZ classifies that state separately from a safely rebuildable exited session: it refuses to attach before entering the alternate screen, preserves the room and its panes, and directs the user to inspect with `rimz doctor` or explicitly rebuild with `rimz reset`. tmux needs no equivalent per-session probe because its session roster and pane queries share one server event loop.
+A session can remain in Zellij's live roster while its per-session Screen actor no longer answers control commands. RimZ retries native pane queries within one eight-second total budget and classifies the session separately from a safely rebuildable exited session when none succeeds: it refuses to attach before entering the alternate screen, preserves the room and its panes, and directs the user to inspect with `rimz doctor` or explicitly rebuild with `rimz reset`. tmux needs no equivalent per-session probe because its session roster and pane queries share one server event loop.
 
 ### Room options and the CLI XOR problem
 

--- a/docs/internals/multiplexers.md
+++ b/docs/internals/multiplexers.md
@@ -333,9 +333,11 @@ Birth branches on the session's liveness, as reported by `zellij list-sessions`:
 
 | Liveness | Branch |
 | --- | --- |
-| Live | The session already carries its sidebar and owns every resize and split since. A trusted sidebar heartbeat makes `open_sidebar` a no-op; a stale heartbeat rebuilds only an inspected live room, and an uninspectable one is left untouched. |
+| Live | Before attach, a bounded direct `list-panes` probe must prove the session's control plane responds. A responsive session already carries its sidebar and owns every resize and split since. A trusted sidebar heartbeat makes `open_sidebar` a no-op; a stale heartbeat rebuilds only an inspected live room, and an uninspectable one is left untouched. |
 | `Exited` (`EXITED - attach to resurrect`) | Clean rebirth: delete, then create from the layout. With serialization off this state stops being minted, but the branch stays as defence for sessions serialized before the flag landed. |
 | Absent | First birth: create from the layout. |
+
+A session can remain in Zellij's live roster while its per-session Screen actor no longer answers control commands. RimZ classifies that state separately from a safely rebuildable exited session: it refuses to attach before entering the alternate screen, preserves the room and its panes, and directs the user to inspect with `rimz doctor` or explicitly rebuild with `rimz reset`. tmux needs no equivalent per-session probe because its session roster and pane queries share one server event loop.
 
 ### Room options and the CLI XOR problem
 

--- a/docs/internals/multiplexers.md
+++ b/docs/internals/multiplexers.md
@@ -280,11 +280,12 @@ The one-second settled-resize pass arms only when the measured pane sits outside
 
 ### The pre-attach health gate
 
-`open_sidebar` is best-effort and can be skipped or fail, so it cannot be the only thing standing between the user and a resurrecting attach. The room birth transition runs `ensure_clean_session` as the authoritative gate, immediately before presence load and attach preparation.
+`open_sidebar` is best-effort and can be skipped or fail, so it cannot be the only thing standing between the user and a resurrecting attach. A normal managed entry probes a live session before setup side effects and threads that verdict through birth; when no reusable live verdict exists, birth runs `ensure_clean_session` to create or cleanly rebirth the session. Supervised birth enters through `ensure_clean_session` directly. Both paths must return an attachable verdict before presence load and attach preparation.
 
 | Session state | Gate action | Verdict |
 | --- | --- | --- |
-| Live | Attach as-is, without inspecting panes | `Healthy` |
+| Live and responsive | Preserve the room after a bounded direct pane probe | `Healthy` |
+| Live but unresponsive | Preserve the room and refuse attach | `Unresponsive` |
 | Absent | Birth from the layout | `Reborn` |
 | Exited (Zellij resurrection record) | Delete, then birth from the layout | `Reborn` |
 | Still not live after a rebirth | Nothing further | `Stuck` |


### PR DESCRIPTION
## Context

Zellij can list a session as live while that session stops answering control commands. Its per-session Screen actor busy-loops, and native `list-panes` and `list-tabs` calls fail. RimZ trusted `list-sessions` liveness alone as its pre-attach gate. It then ran `zellij attach`, which opened the alternate screen and drew no frame. The user saw only a black screen, and the alternate screen hid the warning.

`rimz doctor` reported `session health: ✓ ok` for the same room, so the one diagnostic tool agreed with the bad gate. This change makes RimZ refuse the attach before the alternate screen opens, and keep the room. The upstream cause in Zellij is already fixed and is out of scope.

## Design choices

- **Fail fast, keep the room.** A live but unresponsive session is never reset automatically. An automatic reset kills live agent panes, so RimZ exits non-zero and names the recovery command instead.
- **Direct probe, not the cached topology.** The gate runs `zellij action list-panes --all --json` against the session. Only a direct answer proves that the actor which must draw the attach is alive. A stale presence cache proves nothing, so it stays out of the gate.
- **One deadline, not a retry count.** RimZ retries the probe until the first success or until one eight-second total budget expires. A fixed retry count refuses a healthy but busy room that misses Zellij's internal one-second budget twice. A total deadline states the real rule: a session that cannot answer one query in eight seconds is unresponsive.
- **One verdict for each launch.** A preflight computes the verdict once, before any setup side effect. Birth reuses that verdict, so a launch pays for one probe.
- **Recovery guidance follows session ownership.** The gate protects the attach act itself, so it also covers a session that RimZ does not manage. The message must then name a command that applies to that session.
- **Zellij only.** tmux keeps the no-op default. Its session list and its pane queries share one server event loop, so tmux has no equivalent per-session wedge.

## Implementation

`SessionHealth::Unresponsive` is a new verdict. It means live in the session roster, but silent on the control plane. `Stuck` keeps its old meaning: dead or rebirth-failed, where a reset loses no live work.

`RoomContext::preflight_live_session` classifies the session before RimZ installs hooks, prompts for project trust, inspects rebirth state, or starts the sidebar. An unresponsive session returns an error there. Birth consumes the same verdict, and the birth gate re-probes only when the preflight has none, as with a supervised birth or a newly created room.

The recovery line has three forms. A managed room names `rimz reset`, which prompts first. A session with no RimZ record names `zellij delete-session --force <name>`, and states that this command does not prompt. A record lookup that fails leaves ownership unknown, so RimZ names `rimz doctor` and offers no destroy command. All three forms name `zellij attach <name>` as the explicit bypass, and quote the session name for the shell.

`rimz doctor` renders the state as `live but not responding` with its own fix text.

Documentation follows the code: `docs/internals/multiplexers.md` describes both gate entry paths and the new verdict table, and `docs/guide/troubleshooting.md` adds a section a user can search for.

Deterministic coverage uses the fake-Zellij shim. The tests prove that the command exits non-zero, that no attach child runs, that no `delete-session` runs, and that RimZ writes no session death or session rebirth record for a room it keeps.

### Deviations from the plan

- The plan first required one retry. Review showed that this rule refuses a healthy but busy room, so the rule became the single total deadline described above.
- The plan did not cover a session that RimZ does not manage. The gate reaches such a session, so the recovery message became ownership-aware.
- `rimz doctor` uses its own typed model variant. Reuse of the `stuck` presentation would name a live room as resurrected or suspended, which is false.

## Advisories

- The new shell quoting helper is a third copy of the same function; `mux/focus_key.rs` and `remote/mod.rs` hold the other two. Consolidation needs edits in two unrelated modules, so it is deferred.
- The gate is conservative. It refuses a room that cannot answer one query inside the budget, so a heavily overloaded room can be refused. Every pane stays in place when that happens.
- A failing host can hold the attach for the full eight seconds before the error appears.
- There is no live-backend test. A real Zellij Screen thread cannot be wedged on demand, so the shim tier proves the RimZ decision path but not the upstream failure.

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>forge</code> team · 3 agents · 1h42m active · $34.95 · 19 messages (1 from you)</summary>

- **planner** — Claude `claude-fable-5@high`
  - effort: 14m active · $8.03 incl. subagents
  - calls: 1 ask · 32 tool calls
  - messages: 1 from you · 3 from teammates · 7 to teammates
  - tokens: 206 input, 43.1k output, 281.4k cache write, 6.3m cache read
  - subagents: 2 × explore ($1.20)
- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 1h07m active · $17.30
  - calls: 169 tool calls · 1 compaction
  - messages: 9 from teammates · 6 to teammates
  - tokens: 821.1k input, 78k output, 31.1m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 20m active · $9.62
  - calls: 86 tool calls
  - messages: 6 from teammates · 8 to teammates
  - tokens: 184 input, 84.3k output, 191.7k cache write, 11.2m cache read

</details>