### PR TITLE
teams CLI: drop the misleading PROMPT column and polish launch/show output

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ rimz agents codex --from-pr 42                 # worktree checked out from a pul
 ```sh
 rimz agents claude:planner,codex:coder -w feat-once   # one-off roles without agents.toml
 rimz teams install forge                              # release-matched shipped team
-rimz teams launch forge -w feat-complex               # planner, coder, reviewer on one feature
+rimz teams forge -w feat-complex                      # planner, coder, reviewer on one feature
 ```
 
 ### Steer the fleet

--- a/crates/rimz/src/cli/agents_cmd/launch.rs
+++ b/crates/rimz/src/cli/agents_cmd/launch.rs
@@ -669,15 +669,22 @@ fn write_launch_receipt(
         .max()
         .unwrap_or(0);
     for identity in identities {
+        let identity_handle = launch_identity_handle(identity);
         let handle = format!("@{:<handle_width$}", launch_identity_handle(identity));
         let kind = format!("{:<kind_width$}", identity.kind.as_str());
+        let leader_marker = if leader == Some(identity_handle) {
+            render::paint(render::palette::muted(), "  · leader")
+        } else {
+            String::new()
+        };
         writeln!(
             w,
-            "  {}  {kind}  {}",
+            "  {}  {kind}  {}{leader_marker}",
             render::paint(render::palette::identity(identity.kind.as_str()), &handle),
             render::paint(render::palette::muted(), "starting")
         )?;
     }
+    writeln!(w)?;
     write_launch_hints(
         w,
         team,
@@ -900,7 +907,7 @@ mod tests {
         ];
         identities[0].launch.role = Some("planner".to_owned());
         identities[1].launch.role = Some("coder".to_owned());
-        let mut output = Vec::new();
+        let mut output = anstream::StripStream::new(Vec::new());
 
         write_launch_receipt(
             &mut output,
@@ -912,13 +919,7 @@ mod tests {
         )
         .unwrap();
 
-        let output = String::from_utf8(output).unwrap();
-        assert!(output.contains("launched forge in #feat-x (/repo-worktrees/feat-x)"));
-        assert!(output.contains("@planner"));
-        assert!(output.contains("claude"));
-        assert!(output.contains("starting"));
-        assert!(output.contains("Check: rimz teams show forge#feat-x"));
-        assert!(output.contains("Reach: rimz message @planner#feat-x '<text>'"));
+        insta::assert_snapshot!(String::from_utf8(output.into_inner()).unwrap());
     }
 
     #[test]

--- a/crates/rimz/src/cli/agents_cmd/launch.rs
+++ b/crates/rimz/src/cli/agents_cmd/launch.rs
@@ -673,7 +673,7 @@ fn write_launch_receipt(
         let identity_handle = launch_identity_handle(identity);
         let handle = format!("@{:<handle_width$}", launch_identity_handle(identity));
         let kind = format!("{:<kind_width$}", identity.kind.as_str());
-        let leader_marker = if receipt_leader == Some(identity_handle) {
+        let leader_marker = if identities.len() > 1 && receipt_leader == Some(identity_handle) {
             render::paint(render::palette::muted(), "  · leader")
         } else {
             String::new()
@@ -942,7 +942,7 @@ mod tests {
         let output = String::from_utf8(output).unwrap();
         assert!(output.contains("launched @worker (/repo)"));
         assert!(!output.contains("Check:"));
-        assert!(output.contains("· leader"));
+        assert!(!output.contains("· leader"));
         assert!(output.contains("Reach: rimz message @worker '<text>'"));
     }
 

--- a/crates/rimz/src/cli/agents_cmd/launch.rs
+++ b/crates/rimz/src/cli/agents_cmd/launch.rs
@@ -668,11 +668,12 @@ fn write_launch_receipt(
         .map(|identity| identity.kind.as_str().len())
         .max()
         .unwrap_or(0);
+    let receipt_leader = leader.or_else(|| identities.first().map(launch_identity_handle));
     for identity in identities {
         let identity_handle = launch_identity_handle(identity);
         let handle = format!("@{:<handle_width$}", launch_identity_handle(identity));
         let kind = format!("{:<kind_width$}", identity.kind.as_str());
-        let leader_marker = if leader == Some(identity_handle) {
+        let leader_marker = if receipt_leader == Some(identity_handle) {
             render::paint(render::palette::muted(), "  · leader")
         } else {
             String::new()
@@ -741,6 +742,7 @@ fn write_resume_receipt(
     leader: Option<&str>,
 ) -> Result<()> {
     report_cohort_resume(w, plan)?;
+    writeln!(w)?;
     write_launch_hints(
         w,
         team,
@@ -940,7 +942,36 @@ mod tests {
         let output = String::from_utf8(output).unwrap();
         assert!(output.contains("launched @worker (/repo)"));
         assert!(!output.contains("Check:"));
+        assert!(output.contains("· leader"));
         assert!(output.contains("Reach: rimz message @worker '<text>'"));
+    }
+
+    #[test]
+    fn team_launch_receipt_marks_the_implicit_leader() {
+        let identities = [
+            launch_identity("claude", "planner"),
+            launch_identity("codex", "coder"),
+        ];
+        let mut output = anstream::StripStream::new(Vec::new());
+
+        write_launch_receipt(
+            &mut output,
+            Some("forge"),
+            Some("feat-x"),
+            Path::new("/repo-worktrees/feat-x"),
+            &identities,
+            None,
+        )
+        .unwrap();
+
+        let output = String::from_utf8(output.into_inner()).unwrap();
+        let planner = output
+            .lines()
+            .find(|line| line.contains("@planner"))
+            .unwrap();
+        let coder = output.lines().find(|line| line.contains("@coder")).unwrap();
+        assert!(planner.contains("· leader"));
+        assert!(!coder.contains("· leader"));
     }
 
     #[test]
@@ -960,6 +991,7 @@ mod tests {
         let mut output = Vec::new();
         write_resume_receipt(&mut output, &plan, None, Some("feat-x"), &[], None).unwrap();
         let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("\n\nReach:"));
         assert!(output.contains("Reach: rimz message @planner#feat-x '<text>'"));
     }
 

--- a/crates/rimz/src/cli/agents_cmd/snapshots/rimz__cli__agents_cmd__launch__tests__team_launch_receipt_names_startup_and_next_actions.snap
+++ b/crates/rimz/src/cli/agents_cmd/snapshots/rimz__cli__agents_cmd__launch__tests__team_launch_receipt_names_startup_and_next_actions.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rimz/src/cli/agents_cmd/launch.rs
+expression: "String::from_utf8(output.into_inner()).unwrap()"
+---
+launched forge in #feat-x (/repo-worktrees/feat-x)
+  @planner   claude  starting  · leader
+  @coder     codex   starting
+
+Check: rimz teams show forge#feat-x
+Reach: rimz message @planner#feat-x '<text>'

--- a/crates/rimz/src/cli/teams/install.rs
+++ b/crates/rimz/src/cli/teams/install.rs
@@ -87,7 +87,7 @@ pub(super) fn run(args: InstallArgs) -> Result<()> {
 
     let mut out = render::out();
     writeln!(out, "installed {name} at {}", dir.display())?;
-    writeln!(out, "launch with: rimz teams launch {name} -w <worktree>")?;
+    writeln!(out, "launch with: rimz teams {name} -w <worktree>")?;
     Ok(())
 }
 

--- a/crates/rimz/src/cli/teams/list.rs
+++ b/crates/rimz/src/cli/teams/list.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 
 use super::super::{Ctx, GlobalFlags, render, report_unknown_config_keys};
-use rimz::agents::AgentState;
+use rimz::agents::{AgentState, AgentStatus, TurnPhase};
 use rimz::config::{CommandsConfig, ProfilesConfig, Team, TeamsConfig};
 use rimz::harness::spec::{AgentCell, LayoutSpec};
 use rimz::workspace::WorkspaceResolver;
@@ -58,7 +58,9 @@ pub(super) struct LiveInstance {
 pub(super) struct LiveMember {
     pub handle: String,
     pub kind: String,
-    pub status: String,
+    pub status: AgentStatus,
+    #[serde(skip)]
+    pub phase: TurnPhase,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context_fill_pct: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -366,14 +368,22 @@ fn live_instances(
         let state = instance_state(&status_counts).to_owned();
         let members = members
             .iter()
-            .map(|agent| LiveMember {
-                handle: rimz::harness::target::agent_handle(agent, &members, false),
-                kind: agent.kind.to_string(),
-                status: agent.effective_status().as_str().to_owned(),
-                context_fill_pct: agent.context_fill_pct(),
-                cost_usd: effort_by_session
-                    .get(&agent.agent_id)
-                    .and_then(|effort| effort.cost_usd),
+            .map(|agent| {
+                let status = agent.effective_status();
+                LiveMember {
+                    handle: rimz::harness::target::agent_handle(agent, &members, false),
+                    kind: agent.kind.to_string(),
+                    status,
+                    phase: if status == AgentStatus::Running {
+                        agent.phase
+                    } else {
+                        TurnPhase::Idle
+                    },
+                    context_fill_pct: agent.context_fill_pct(),
+                    cost_usd: effort_by_session
+                        .get(&agent.agent_id)
+                        .and_then(|effort| effort.cost_usd),
+                }
             })
             .collect();
         by_team
@@ -534,7 +544,7 @@ mod tests {
                 effort: Some("high".to_owned()),
                 budget: None,
                 system_prompt_file: Some("planner.md".into()),
-                append_system_prompt_files: Vec::new(),
+                append_system_prompt_files: vec!["consensus.md".into()],
                 args: None,
             }],
             leader: Some("planner".to_owned()),
@@ -569,10 +579,15 @@ mod tests {
         assert_eq!(reports[0].instances[0].channel, "feat-x");
         assert_eq!(reports[0].instances[0].members.len(), 1);
         assert_eq!(reports[0].instances[0].state, "working");
+        let json = serde_json::to_value(&reports).unwrap();
+        assert_eq!(json[0]["roles"][0]["system_prompt_file"], "planner.md");
         assert_eq!(
-            serde_json::to_value(&reports).unwrap()[0]["instances"][0]["members"][0]["handle"],
-            "@planner"
+            json[0]["roles"][0]["append_system_prompt_files"],
+            serde_json::json!(["consensus.md"])
         );
+        assert_eq!(json[0]["instances"][0]["members"][0]["handle"], "@planner");
+        assert_eq!(json[0]["instances"][0]["members"][0]["status"], "running");
+        assert!(json[0]["instances"][0]["members"][0].get("phase").is_none());
     }
 
     #[test]

--- a/crates/rimz/src/cli/teams/show.rs
+++ b/crates/rimz/src/cli/teams/show.rs
@@ -124,13 +124,14 @@ fn write_report(w: &mut impl Write, report: &TeamReport, lane: Option<&str>) -> 
         live.render(w)?;
     }
 
-    writeln!(w)?;
     if report.instances.is_empty() {
+        writeln!(w)?;
         writeln!(w, "Launch: rimz teams {} -w <worktree>", report.name)?;
         writeln!(w, "Resume: rimz teams resume {}", report.name)?;
         return Ok(());
     }
     if let Some((handle, channel)) = live_target(report) {
+        writeln!(w)?;
         writeln!(
             w,
             "Reach: rimz message @{}#{} '<text>'",
@@ -272,6 +273,7 @@ mod tests {
             let output = rendered(&report, lane);
             assert!(!output.contains("Reach:"));
             assert!(!output.contains("Focus:"));
+            assert!(!output.ends_with("\n\n"));
         }
     }
 }

--- a/crates/rimz/src/cli/teams/show.rs
+++ b/crates/rimz/src/cli/teams/show.rs
@@ -130,20 +130,20 @@ fn write_report(w: &mut impl Write, report: &TeamReport, lane: Option<&str>) -> 
         writeln!(w, "Resume: rimz teams resume {}", report.name)?;
         return Ok(());
     }
-    if let Some((handle, channel)) = reach_target(report, lane) {
+    if let Some((handle, channel)) = live_target(report) {
         writeln!(
             w,
             "Reach: rimz message @{}#{} '<text>'",
             handle.trim_start_matches('@'),
             channel
         )?;
+        writeln!(w, "Focus: rimz teams focus {}#{}", report.name, channel)?;
     }
-    writeln!(w, "Focus: rimz teams focus {}", report.name)?;
     Ok(())
 }
 
-fn reach_target<'a>(report: &'a TeamReport, lane: Option<&str>) -> Option<(&'a str, &'a str)> {
-    if report.instances.len() != 1 && lane.is_none() {
+fn live_target(report: &TeamReport) -> Option<(&str, &str)> {
+    if report.instances.len() != 1 {
         return None;
     }
     let instance = report.instances.first()?;
@@ -266,10 +266,12 @@ mod tests {
     fn human_show_omits_ambiguous_reach_hint() {
         let mut second = live_instance();
         second.channel = "feat-y".to_owned();
+        let report = report(vec![live_instance(), second]);
 
-        let output = rendered(&report(vec![live_instance(), second]), None);
-
-        assert!(!output.contains("Reach:"));
-        assert!(output.contains("Focus: rimz teams focus forge"));
+        for lane in [None, Some("feat-x")] {
+            let output = rendered(&report, lane);
+            assert!(!output.contains("Reach:"));
+            assert!(!output.contains("Focus:"));
+        }
     }
 }

--- a/crates/rimz/src/cli/teams/show.rs
+++ b/crates/rimz/src/cli/teams/show.rs
@@ -42,7 +42,14 @@ fn write_report(w: &mut impl Write, report: &TeamReport, lane: Option<&str>) -> 
     let mut definition = render::KeyVals::new().indent(2);
     definition.push(
         "source",
-        render::cell(report.source.as_deref().unwrap_or("-")).dash(),
+        render::cell(
+            report
+                .source
+                .as_deref()
+                .map(render::home_relative)
+                .unwrap_or_else(|| "-".to_owned()),
+        )
+        .dash(),
     );
     definition.push(
         "layout",
@@ -69,15 +76,25 @@ fn write_report(w: &mut impl Write, report: &TeamReport, lane: Option<&str>) -> 
     definition.render(w)?;
     writeln!(w)?;
 
-    let mut roles = render::Table::new([
-        "ROLE", "PROFILE", "KIND", "MODEL", "EFFORT", "MODE", "PROMPT",
-    ])
-    .indent(2)
-    .max_width(render::terminal_columns(120));
+    let mut roles = render::Table::new(["ROLE", "PROFILE", "KIND", "MODEL", "EFFORT", "MODE"])
+        .indent(2)
+        .max_width(render::terminal_columns(120));
     for role in &report.roles {
         roles.row(role_cells(role));
     }
     roles.render(w)?;
+    if report.roles.iter().any(|role| {
+        role.system_prompt_file.is_some() || !role.append_system_prompt_files.is_empty()
+    }) {
+        writeln!(
+            w,
+            "  {}",
+            render::paint(
+                render::palette::muted(),
+                &format!("(prompt stack: rimz teams show {} --json)", report.name)
+            )
+        )?;
+    }
 
     if report.instances.is_empty() && lane.is_some() {
         writeln!(w)?;
@@ -108,23 +125,42 @@ fn write_report(w: &mut impl Write, report: &TeamReport, lane: Option<&str>) -> 
     }
 
     writeln!(w)?;
-    writeln!(w, "Launch: rimz teams launch {} -w <worktree>", report.name)?;
-    writeln!(w, "Resume: rimz teams resume {}", report.name)?;
+    if report.instances.is_empty() {
+        writeln!(w, "Launch: rimz teams {} -w <worktree>", report.name)?;
+        writeln!(w, "Resume: rimz teams resume {}", report.name)?;
+        return Ok(());
+    }
+    if let Some((handle, channel)) = reach_target(report, lane) {
+        writeln!(
+            w,
+            "Reach: rimz message @{}#{} '<text>'",
+            handle.trim_start_matches('@'),
+            channel
+        )?;
+    }
+    writeln!(w, "Focus: rimz teams focus {}", report.name)?;
     Ok(())
 }
 
-fn role_cells(role: &RoleReport) -> [render::Cell; 7] {
-    let prompt = role
-        .system_prompt_file
+fn reach_target<'a>(report: &'a TeamReport, lane: Option<&str>) -> Option<(&'a str, &'a str)> {
+    if report.instances.len() != 1 && lane.is_none() {
+        return None;
+    }
+    let instance = report.instances.first()?;
+    let member = report
+        .leader
         .as_deref()
-        .map(|path| path.display().to_string())
-        .into_iter()
-        .collect::<Vec<_>>();
-    let prompt = if prompt.is_empty() {
-        "-".to_owned()
-    } else {
-        prompt.join(" ")
-    };
+        .and_then(|leader| {
+            instance
+                .members
+                .iter()
+                .find(|member| member.handle.trim_start_matches('@') == leader)
+        })
+        .or_else(|| instance.members.first())?;
+    Some((&member.handle, &instance.channel))
+}
+
+fn role_cells(role: &RoleReport) -> [render::Cell; 6] {
     [
         render::cell(&role.role).fg(render::palette::accent()),
         render::cell(&role.profile),
@@ -132,7 +168,6 @@ fn role_cells(role: &RoleReport) -> [render::Cell; 7] {
         render::cell(role.model.as_deref().unwrap_or("-")).dash(),
         render::cell(role.effort.as_deref().unwrap_or("-")).dash(),
         render::cell(role.mode.as_deref().unwrap_or("-")).dash(),
-        render::cell(prompt).dash(),
     ]
 }
 
@@ -140,7 +175,7 @@ fn member_cells(channel: &str, member: &LiveMember) -> [render::Cell; 5] {
     [
         render::cell(format!("#{channel}")).fg(render::palette::meta()),
         render::cell(&member.handle).fg(render::palette::identity(&member.kind)),
-        render::cell(&member.status),
+        render::cell(member.status.as_str()).fg(render::status::agent(member.status, member.phase)),
         render::cell(
             member
                 .context_fill_pct
@@ -163,14 +198,14 @@ fn member_cells(channel: &str, member: &LiveMember) -> [render::Cell; 5] {
 mod tests {
     use super::*;
     use crate::cli::teams::list::{LiveInstance, RoleReport, TeamReport};
+    use rimz::agents::{AgentStatus, TurnPhase};
     use std::collections::BTreeMap;
 
-    #[test]
-    fn human_show_includes_definition_live_members_and_hints() {
-        let report = TeamReport {
+    fn report(instances: Vec<LiveInstance>) -> TeamReport {
+        TeamReport {
             name: "forge".to_owned(),
             defined: true,
-            source: Some("/home/me/.agents/teams/forge/team.toml".to_owned()),
+            source: Some("/tmp/.agents/teams/forge/team.toml".to_owned()),
             layout: Some("planner,coder+reviewer".to_owned()),
             leader: Some("planner".to_owned()),
             roles: vec![RoleReport {
@@ -181,53 +216,60 @@ mod tests {
                 effort: Some("high".to_owned()),
                 mode: Some("auto".to_owned()),
                 system_prompt_file: Some("planner.md".into()),
-                append_system_prompt_files: Vec::new(),
+                append_system_prompt_files: vec!["consensus.md".into()],
             }],
             valid: true,
             error: None,
-            instances: vec![LiveInstance {
-                channel: "feat-x".to_owned(),
-                state: "running".to_owned(),
-                status_counts: BTreeMap::from([("running".to_owned(), 1)]),
-                members: vec![LiveMember {
-                    handle: "planner".to_owned(),
-                    kind: "claude".to_owned(),
-                    status: "running".to_owned(),
-                    context_fill_pct: Some(42.0),
-                    cost_usd: Some(0.25),
-                }],
-            }],
-        };
-        let mut output = Vec::new();
-        write_report(&mut output, &report, None).unwrap();
-        let output = String::from_utf8(output).unwrap();
+            instances,
+        }
+    }
 
-        assert!(output.contains("planner,coder+reviewer"));
-        assert!(output.contains("#feat-x"));
-        assert!(output.contains("42%"));
-        assert!(output.contains("$0.25"));
-        assert!(output.contains("rimz teams launch forge -w <worktree>"));
-        assert!(output.contains("rimz teams resume forge"));
+    fn live_instance() -> LiveInstance {
+        LiveInstance {
+            channel: "feat-x".to_owned(),
+            state: "running".to_owned(),
+            status_counts: BTreeMap::from([("running".to_owned(), 1)]),
+            members: vec![LiveMember {
+                handle: "@planner".to_owned(),
+                kind: "claude".to_owned(),
+                status: AgentStatus::Running,
+                phase: TurnPhase::Reasoning,
+                context_fill_pct: Some(42.0),
+                cost_usd: Some(0.25),
+            }],
+        }
+    }
+
+    fn rendered(report: &TeamReport, lane: Option<&str>) -> String {
+        let mut output = anstream::StripStream::new(Vec::new());
+        write_report(&mut output, report, lane).unwrap();
+        String::from_utf8(output.into_inner()).unwrap()
+    }
+
+    #[test]
+    fn human_show_with_live_instance() {
+        insta::assert_snapshot!(rendered(&report(vec![live_instance()]), None));
+    }
+
+    #[test]
+    fn human_show_without_live_instance() {
+        insta::assert_snapshot!(rendered(&report(Vec::new()), Some("ended-lane")));
     }
 
     #[test]
     fn human_show_answers_when_a_selected_lane_is_not_live() {
-        let report = TeamReport {
-            name: "forge".to_owned(),
-            defined: true,
-            source: None,
-            layout: Some("planner".to_owned()),
-            leader: Some("planner".to_owned()),
-            roles: Vec::new(),
-            valid: true,
-            error: None,
-            instances: Vec::new(),
-        };
-        let mut output = Vec::new();
-
-        write_report(&mut output, &report, Some("ended-lane")).unwrap();
-
-        let output = String::from_utf8(output).unwrap();
+        let output = rendered(&report(Vec::new()), Some("ended-lane"));
         assert!(output.contains("no live instance in #ended-lane"));
+    }
+
+    #[test]
+    fn human_show_omits_ambiguous_reach_hint() {
+        let mut second = live_instance();
+        second.channel = "feat-y".to_owned();
+
+        let output = rendered(&report(vec![live_instance(), second]), None);
+
+        assert!(!output.contains("Reach:"));
+        assert!(output.contains("Focus: rimz teams focus forge"));
     }
 }

--- a/crates/rimz/src/cli/teams/snapshots/rimz__cli__teams__show__tests__human_show_with_live_instance.snap
+++ b/crates/rimz/src/cli/teams/snapshots/rimz__cli__teams__show__tests__human_show_with_live_instance.snap
@@ -1,0 +1,20 @@
+---
+source: crates/rimz/src/cli/teams/show.rs
+expression: "rendered(&report(vec![live_instance()]), None)"
+---
+forge
+  source:     /tmp/.agents/teams/forge/team.toml
+  layout:     planner,coder+reviewer
+  leader:     planner
+  validation: ready
+
+  ROLE     PROFILE  KIND    MODEL  EFFORT  MODE
+  planner  claude   claude  fable  high    auto
+  (prompt stack: rimz teams show forge --json)
+
+Live instances
+  LANE     MEMBER    STATUS   CTX   COST
+  #feat-x  @planner  running  42%  $0.25
+
+Reach: rimz message @planner#feat-x '<text>'
+Focus: rimz teams focus forge

--- a/crates/rimz/src/cli/teams/snapshots/rimz__cli__teams__show__tests__human_show_with_live_instance.snap
+++ b/crates/rimz/src/cli/teams/snapshots/rimz__cli__teams__show__tests__human_show_with_live_instance.snap
@@ -17,4 +17,4 @@ Live instances
   #feat-x  @planner  running  42%  $0.25
 
 Reach: rimz message @planner#feat-x '<text>'
-Focus: rimz teams focus forge
+Focus: rimz teams focus forge#feat-x

--- a/crates/rimz/src/cli/teams/snapshots/rimz__cli__teams__show__tests__human_show_without_live_instance.snap
+++ b/crates/rimz/src/cli/teams/snapshots/rimz__cli__teams__show__tests__human_show_without_live_instance.snap
@@ -1,0 +1,18 @@
+---
+source: crates/rimz/src/cli/teams/show.rs
+expression: "rendered(&report(Vec::new()), Some(\"ended-lane\"))"
+---
+forge
+  source:     /tmp/.agents/teams/forge/team.toml
+  layout:     planner,coder+reviewer
+  leader:     planner
+  validation: ready
+
+  ROLE     PROFILE  KIND    MODEL  EFFORT  MODE
+  planner  claude   claude  fable  high    auto
+  (prompt stack: rimz teams show forge --json)
+
+no live instance in #ended-lane
+
+Launch: rimz teams forge -w <worktree>
+Resume: rimz teams resume forge

--- a/docs/reference/cli/teams.md
+++ b/docs/reference/cli/teams.md
@@ -39,23 +39,23 @@ rimz teams show forge --json
 When a role has system-prompt files, the human report points to `--json`, whose `system_prompt_file` and `append_system_prompt_files` fields expose the complete resolved stack.
 Live instances include the lane, member handle and status, context fill, and tracked session cost.
 Use `team#worktree` or `-w NAME` to narrow the live section by exact lane or member worktree; an ended or not-yet-live lane reports that no instance is live and still exits successfully.
-The report ends with copy-ready launch and resume forms when no instance is live, or reach and focus forms for a live cohort.
+The report ends with copy-ready launch and resume forms when no instance is live, or lane-qualified reach and focus forms when exactly one live cohort is shown.
 
 ## Launch a team
 
 ```sh
 rimz teams forge
-rimz teams launch forge
-rimz teams launch forge#feat-rate-limits "add rate limiting"
+rimz teams forge#feat-rate-limits "add rate limiting"
 rimz teams forge -w feat-rate-limits "add rate limiting"
 rimz teams forge --channel triage
 rimz teams forge --from-pr 91 --bg
+rimz teams launch forge
 ```
 
 The bare-name form and `launch` verb accept a configured team name and send an optional trailing prompt to its configured leader.
 It uses the same launch and relaunch-reconciliation path as `rimz agents <team>`, including worktree creation, channel placement, pull-request checkout, and existing-cohort focus or recovery.
 When an agent launches a team, its members are top-level peers rather than children of the caller.
-After opening the panes, a fresh launch prints the minted member handles as `starting`, marks the configured leader, and includes copy-ready `Check` and `Reach` commands.
+After opening the panes, a fresh launch prints the minted member handles as `starting`, marks the effective leader, and includes copy-ready `Check` and `Reach` commands.
 Members report their live status asynchronously, so `rimz teams show team#worktree` remains the source of truth rather than the receipt.
 
 `rimz teams` sets where a cohort runs, whether it resumes, and what each member may spend.

--- a/docs/reference/cli/teams.md
+++ b/docs/reference/cli/teams.md
@@ -35,10 +35,11 @@ rimz teams inspect forge
 rimz teams show forge --json
 ```
 
-`show` and its `inspect` alias name the best-effort definition source, layout, leader, and validation result, then list each resolved role's profile or kind, model, effort, mode, and prompt files.
+`show` and its `inspect` alias name the best-effort definition source, layout, leader, and validation result, then list each resolved role's profile or kind, model, effort, and mode.
+When a role has system-prompt files, the human report points to `--json`, whose `system_prompt_file` and `append_system_prompt_files` fields expose the complete resolved stack.
 Live instances include the lane, member handle and status, context fill, and tracked session cost.
 Use `team#worktree` or `-w NAME` to narrow the live section by exact lane or member worktree; an ended or not-yet-live lane reports that no instance is live and still exits successfully.
-The report ends with copy-ready launch and resume forms.
+The report ends with copy-ready launch and resume forms when no instance is live, or reach and focus forms for a live cohort.
 
 ## Launch a team
 
@@ -54,7 +55,7 @@ rimz teams forge --from-pr 91 --bg
 The bare-name form and `launch` verb accept a configured team name and send an optional trailing prompt to its configured leader.
 It uses the same launch and relaunch-reconciliation path as `rimz agents <team>`, including worktree creation, channel placement, pull-request checkout, and existing-cohort focus or recovery.
 When an agent launches a team, its members are top-level peers rather than children of the caller.
-After opening the panes, a fresh launch prints the minted member handles as `starting` and copy-ready `Check` and `Reach` commands.
+After opening the panes, a fresh launch prints the minted member handles as `starting`, marks the configured leader, and includes copy-ready `Check` and `Reach` commands.
 Members report their live status asynchronously, so `rimz teams show team#worktree` remains the source of truth rather than the receipt.
 
 `rimz teams` sets where a cohort runs, whether it resumes, and what each member may spend.

--- a/examples/README.md
+++ b/examples/README.md
@@ -50,7 +50,7 @@ cp -r examples/teams/forge ~/.agents/teams/
 
 `rimz teams install forge --force` replaces files in a same-named installed directory; the plain install preserves it. Entries in `~/.config/rimz/agents.toml` override fragment entries with the same names.
 
-Launch with `rimz teams launch forge`; the lifecycle grammar lives in the [teams CLI reference](../docs/reference/cli/teams.md). Each role answers to `@planner`, `@coder`, or `@reviewer`.
+Launch with `rimz teams forge`; the lifecycle grammar lives in the [teams CLI reference](../docs/reference/cli/teams.md). Each role answers to `@planner`, `@coder`, or `@reviewer`.
 
 The `claude` and `codex` CLIs must be on `PATH`. The profiles in `team.toml` pin models (`fable`, `opus`) and Codex feature flags; adjust them there to taste. The coder's PR step expects a `pr` skill and falls back to plain `gh` or `tea` without it.
 

--- a/examples/teams/README.md
+++ b/examples/teams/README.md
@@ -60,7 +60,7 @@ The plain install preserves a same-named directory in `~/.agents/teams`; pass `-
 Launch the team into an isolated worktree and hand the task to the planner — type into its pane, or message it:
 
 ```sh
-rimz teams launch forge -w feat-complex
+rimz teams forge -w feat-complex
 rimz message @planner#feat-complex "add rate limiting to the ingest API"
 ```
 


### PR DESCRIPTION
## Context

`rimz teams show` printed a PROMPT column with only the role's base `system_prompt_file`. The `RoleReport` also carries `append_system_prompt_files`, and the renderer dropped them. Those fragments are part of the launched prompt, so the column was incomplete.

Both surfaces had also drifted from house style. STATUS was the one uncolored status cell in the CLI. The footer hints were unconditional and named a non-canonical launch form. Definition paths skipped `home_relative`. Neither surface had snapshot coverage.

## Design choices

- **Remove the PROMPT column instead of completing it.** A multi-file prompt stack does not fit one table cell. The human report now shows a muted pointer, `(prompt stack: rimz teams show <team> --json)`. The `--json` output keeps `system_prompt_file` and `append_system_prompt_files` unchanged.
- **Bind each action hint to the cohort it describes.** The report prints Reach and Focus only when it shows exactly one live cohort, and both hints carry the resolved `team#lane`. A bare `rimz teams focus <team>` resolves through the caller's current channel, and it fails when several cohorts are live. An unqualified hint can therefore fail, or drive a cohort other than the one on screen.
- **Make `rimz teams <name> -w <worktree>` the canonical launch form** across the repository. It agrees with the quick reference. The `teams launch` verb still parses, and the command reference documents it once.
- **Mark the effective leader on the receipt.** The effective leader is the member that receives the launch prompt. Without a configured `leader`, it is the first identity. The receipt marks it only when the launch has more than one member.

## Implementation

`crates/rimz/src/cli/teams/show.rs` drops the PROMPT column and its cell assembly. It sends `source` through `home_relative` and colors STATUS through the shared `render::status::agent` mapping. The footer is now contextual. It shows launch and resume forms when no cohort is live, lane-qualified reach and focus forms when it shows exactly one cohort, and nothing when the target is ambiguous.

`crates/rimz/src/cli/teams/list.rs` keeps the typed status instead of a string. `LiveMember` now carries `AgentStatus` and a render-only `TurnPhase`. `AgentStatus` serializes to the same lowercase words that `as_str()` gives, so the JSON stays identical. `TurnPhase` is `#[serde(skip)]` and stays out of the contract. A test holds the status word and both prompt-stack field names.

`crates/rimz/src/cli/agents_cmd/launch.rs` marks the leader row on multi-member receipts. It also separates the hint block with a blank line, on the fresh-launch receipt and the resume receipt.

Tests move from `contains` assertions to ANSI-stripped insta snapshots. There is one snapshot for the live show, one for the no-live show, and one for the team launch receipt. Focused tests stay for the conditional behaviors: the ambiguous cohort, the implicit leader, and the resume spacing. `docs/reference/cli/teams.md` moves with the change.

Two parts deviate from the plan. @planner ruled on both during the run.

- The plan showed `Focus: rimz teams focus {name}`. That form fails or misfires when more than one cohort is live. Focus now carries the lane, and it is suppressed together with Reach when no single cohort resolves.
- The plan scoped the leader marker to the configured `leader`. The marker now uses the effective leader, so it can never name a different member than the `Reach:` line.

## Advisories

- `write_launch_receipt` evaluates `identities.first().map(launch_identity_handle)` at two points, three lines apart. `write_launch_hints` then applies the same `.or()` again. The three agree today. One hoisted binding would remove the duplication. `write_launch_hints` cannot collapse further, because `write_resume_receipt` gives it a different fallback.
- One pre-existing flake is unrelated to this change. `hooks::internal_app_server_hook_is_suppressed_and_records_nothing` failed once under full-gate parallel load, with `write stdin: BrokenPipe` at `crates/rimz/tests/integration/common/env.rs:342`. `spawn_payload` calls `.expect("write stdin")` on a child that the test expects to be suppressed, so the child can exit before the write completes. The test passed 5 times of 5 in isolation, and the gate then ran green. It can still redden CI at random until the write tolerates `BrokenPipe`.
- The launch receipt still prints the literal `starting`, not live status. This is deliberate, because members report asynchronously and `teams show` stays the status truth. The receipt can therefore only be current or stale, never wrong.

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>forge</code> team · 3 agents · 56m active · $18.53 · 12 messages (4 from you)</summary>

- **planner** — Claude `claude-fable-5@high`
  - effort: 9m active · $5.80 incl. subagents
  - calls: 1 ask · 33 tool calls
  - messages: 3 from you · 1 from teammates · 2 to teammates
  - tokens: 174 input, 30.7k output, 248.4k cache write, 4.7m cache read
  - subagents: 2 × explore ($1.02)
- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 26m active · $7.33
  - calls: 66 tool calls
  - messages: 1 from you · 4 from teammates · 4 to teammates
  - tokens: 259.7k input, 29.2k output, 14.3m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 20m active · $5.40
  - calls: 77 tool calls
  - messages: 3 from teammates · 2 to teammates
  - tokens: 124 input, 48k output, 140.3k cache write, 5.6m cache read

</details>