### PR TITLE
fix(tmux): keep literal hashes in tmux window names

### DIFF
--- a/crates/rimz/src/mux/tmux/tests.rs
+++ b/crates/rimz/src/mux/tmux/tests.rs
@@ -41,7 +41,7 @@ fn existing_session_attach_targets_the_managed_server() {
 }
 
 #[test]
-fn rename_tab_targets_the_anchor_pane_and_sanitizes_the_name() {
+fn rename_tab_targets_the_anchor_pane_and_encodes_the_name() {
     let backend = TmuxBackend::with_socket("/run/user/1000/rimz/tmux/server");
     let pane = crate::PaneId::from_parts(crate::MuxName::Tmux, "%7");
     let spec = backend
@@ -50,7 +50,7 @@ fn rename_tab_targets_the_anchor_pane_and_sanitizes_the_name() {
 
     assert_eq!(
         verb_args(&spec),
-        ["rename-window", "-t", "%7", "#feat-one-2 ✓"]
+        ["rename-window", "-t", "%7", "##feat-one-2 ✓"]
     );
 }
 
@@ -242,6 +242,14 @@ fn window_name_neutralizes_tmux_target_separators() {
     assert_eq!(sanitize_window_name("run: codex"), "run- codex");
     assert_eq!(sanitize_window_name("feat: split.ci"), "feat- split-ci");
     assert_eq!(sanitize_window_name("plain-name"), "plain-name");
+}
+
+#[test]
+fn window_name_arg_encodes_literal_hashes_after_sanitizing() {
+    use super::window::window_name_arg;
+
+    assert_eq!(window_name_arg("#feat: split.ci##"), "##feat- split-ci####");
+    assert_eq!(window_name_arg("plain-name"), "plain-name");
 }
 
 #[test]

--- a/crates/rimz/src/mux/tmux/window.rs
+++ b/crates/rimz/src/mux/tmux/window.rs
@@ -41,6 +41,13 @@ pub(super) fn sanitize_window_name(raw: &str) -> String {
     raw.replace([':', '.'], "-")
 }
 
+/// The sanitized stored name encoded for a tmux name argument. tmux expands
+/// formats such as `#h` in `new-window -n` and `rename-window`; `##` writes one
+/// literal hash without changing the name read back from tmux.
+pub(super) fn window_name_arg(raw: &str) -> String {
+    sanitize_window_name(raw).replace('#', "##")
+}
+
 impl TmuxBackend {
     /// Attach a RimZ-owned display identity to one pane. Pane user options are
     /// not writable through terminal escape sequences, unlike `pane_title`.
@@ -73,7 +80,7 @@ impl TmuxBackend {
             "rename-window".to_owned(),
             "-t".to_owned(),
             anchor.raw().to_owned(),
-            sanitize_window_name(name),
+            window_name_arg(name),
         ]))
     }
 
@@ -97,7 +104,7 @@ impl TmuxBackend {
                 "-t".to_owned(),
                 session.to_owned(),
                 "-n".to_owned(),
-                sanitize_window_name(name),
+                window_name_arg(name),
                 "-c".to_owned(),
                 cwd.to_string_lossy().into_owned(),
             ])

--- a/crates/rimz/tests/integration/backend/tmux/title.rs
+++ b/crates/rimz/tests/integration/backend/tmux/title.rs
@@ -11,9 +11,9 @@ fn window_names_keep_literal_hashes() {
 
     server
         .backend
-        .rename_tab(session, &anchor, "#health ✓")
+        .rename_tab(session, &anchor, "#health ready")
         .expect("rename window");
-    assert_eq!(server.window_names(session), ["#health ✓"]);
+    assert_eq!(server.window_names(session), ["#health ready"]);
 
     server
         .backend

--- a/crates/rimz/tests/integration/backend/tmux/title.rs
+++ b/crates/rimz/tests/integration/backend/tmux/title.rs
@@ -1,6 +1,51 @@
 use super::support::*;
 
 #[test]
+fn window_names_keep_literal_hashes() {
+    require_tmux!();
+
+    let session = "rimz-native-window-name";
+    let server = TmuxServer::new();
+    ensure_rimz_session(&server, session, Some((120, 40)));
+    let anchor = PaneId::from_parts(MuxName::Tmux, server.display(session, "#{pane_id}"));
+
+    server
+        .backend
+        .rename_tab(session, &anchor, "#health ✓")
+        .expect("rename window");
+    assert_eq!(server.window_names(session), ["#health ✓"]);
+
+    server
+        .backend
+        .open_tab(&TabOptions {
+            title: "#host#health".to_owned(),
+            panes: LayoutPanes {
+                columns: vec![tiled_column(vec![PaneCmd {
+                    argv: vec!["sleep".to_owned(), "30".to_owned()],
+                    name: None,
+                }])],
+            },
+            focus: true,
+            dock_sidebar: true,
+            sidebar: sidebar_opts(session, PathBuf::from("/bin/true"), Some(120)),
+        })
+        .expect("open named tab");
+    assert!(
+        server
+            .window_names(session)
+            .iter()
+            .any(|name| name == "#host#health"),
+        "opened window name did not preserve literal hashes: {:?}",
+        server.window_names(session),
+    );
+    assert_eq!(
+        server.display(&format!("{session}:#host#health"), "#{window_name}"),
+        "#host#health",
+        "literal hash names must remain valid tmux targets",
+    );
+}
+
+#[test]
 fn named_layout_pane_drives_the_terminal_title_format() {
     require_tmux!();
 


### PR DESCRIPTION
## Context

`rimz teams forge -w health` launched its cohort correctly, but the tmux tab showed a mangled name instead of `#health`. The cause is tmux, not RimZ string handling. tmux expands format specifiers in the name argument of `new-window -n` and `rename-window`, and `#h` is the specifier for the short hostname. So `#health` became the short hostname followed by `ealth`. Every `#<channel>` tab whose first letter forms a specifier (`#h`, `#H`, `#S`, `#T`, `#W`, `#F`, `#I`, `#P`, `#D`) was affected. Zellij takes its tab name literally and was never affected.

## Design choices

- Fix at the tmux write boundary only. The backend adapter owns the wire form, so domain code, Zellij, and all comparisons keep the literal stored name.
- Keep two name forms, one function each. `sanitize_window_name` stays the stored form (`:` and `.` become `-`), used for read-back comparisons, resume idempotency keys, and target specs. A new `window_name_arg` adds the `#` to `##` encoding and is used only where a name is a command argument.
- Do not encode `@rimz_title`. tmux stores option values literally and does not expand them again in `set-titles-string`. An encoded value would show a doubled hash in the terminal title.
- Do not migrate windows that already carry a mangled name. A relaunch or the next rename makes them correct.

## Implementation

- `crates/rimz/src/mux/tmux/window.rs`: added `window_name_arg`, then routed `rename_window_command` and `open_named_window` through it.
- `crates/rimz/src/mux/tmux/tests.rs`: unit coverage of the encoder and of the exact `rename-window` argv.
- `crates/rimz/tests/integration/backend/tmux/title.rs`: a live tmux regression. It renames and opens windows whose names carry `#h`, then proves the names read back literally and stay valid tmux targets. It self-skips when tmux is absent.

Two deviations from the plan, both deliberate:

- No unit test for the `new-window` argv. `open_named_window` runs its command inline, so a construction seam added only for a test would widen the interface. The live test covers that path against real tmux.
- No change to `docs/internals/multiplexers.md`. That page already states that resumed agents open windows named `#<channel>`, which this change makes true. The two-form contract lives beside the code in the `window.rs` doc comments.

## Advisories

- Minor, still open: the doc comment on `sanitize_window_name` still reads as the form that reaches tmux. It is now the stored and compare form. One clause that points at `window_name_arg` would stop a future write site from using the wrong function.
- Windows created before this change keep their mangled name until they are recreated or renamed. This is the accepted behavior, not a defect.

## Verification

- `cargo xtask gate` passed.
- `mux::tmux` unit module: 33 tests passed. `backend::tmux` live module: 38 tests passed.
- The new live test was proven red before the fix and green after it.

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>forge</code> team · 3 agents · 31m active · $7.35 · 5 messages (3 from you)</summary>

- **planner** — Claude `claude-fable-5@high`
  - effort: 9m active · $2.82 incl. subagents
  - calls: 10 tool calls
  - messages: 1 from you · 1 to teammates
  - tokens: 84 input, 18.6k output, 144.2k cache write, 2.2m cache read
  - subagents: 1 × explore ($0.63)
- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 11m active · $2.51
  - calls: 24 tool calls
  - messages: 1 from you · 1 from teammates · 1 to teammates
  - tokens: 136.8k input, 11.2k output, 4.4m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 9m active · $2.02
  - calls: 36 tool calls
  - messages: 1 from you · 1 from teammates
  - tokens: 50 input, 25.9k output, 66.8k cache write, 1.4m cache read

</details>