### PR TITLE
fix(worktree): recreate a cohort worktree that a concurrent cleanup already removed

### DIFF
--- a/crates/rimz/src/cli/agents_cmd/reconcile.rs
+++ b/crates/rimz/src/cli/agents_cmd/reconcile.rs
@@ -57,7 +57,8 @@ pub(super) fn reconcile_cohort_launch(
         rimz::harness::resume::CohortRelaunchState::Closed => {
             let status = rimz::worktree::status(&path, &marker)?;
             // Cohort liveness was already decided above, so Git state alone
-            // separates "recreate it" from "resume into it".
+            // separates "recreate it" from "resume into it". A concurrent
+            // cleanup may still remove the checkout after this decision.
             let protections = rimz::worktree::ProtectionSet::default();
             if protections.assess(&path, status) == rimz::worktree::RemovalAssessment::Removable {
                 recreate_or_done(
@@ -139,13 +140,22 @@ fn recreate_or_done(
     )? {
         return Ok(Reconciled::Done);
     }
-    let removed = rimz::worktree::remove(
+    let removed = match rimz::worktree::remove(
         workspace.launch_repo_root(),
         &machine_config.agents.worktree,
         name,
         false,
         protections,
-    )?;
+    ) {
+        Err(rimz::worktree::WorktreeErr::Missing { .. }) => {
+            writeln!(
+                std::io::stderr().lock(),
+                "worktree `{name}` was already removed; recreating {subject}"
+            )?;
+            return Ok(Reconciled::Continue);
+        }
+        result => result?,
+    };
     let retirement = rimz::worktree::retire_removal(
         store,
         &removed,

--- a/crates/rimz/src/worktree.rs
+++ b/crates/rimz/src/worktree.rs
@@ -56,6 +56,8 @@ pub enum WorktreeErr {
     InvalidName(String),
     #[error("worktree `{name}` already exists at {path}")]
     Exists { name: String, path: PathBuf },
+    #[error("worktree `{name}` does not exist at {path}")]
+    Missing { name: String, path: PathBuf },
     #[error("worktree `{name}` is not a RimZ-managed worktree at {path}")]
     Unmarked { name: String, path: PathBuf },
     #[error(
@@ -622,10 +624,7 @@ pub fn remove(
 ) -> Result<RemovalOutcome> {
     ensure_repo(repo_root)?;
     let path = worktree_path(repo_root, config, name)?;
-    let marker = read_marker_for_worktree(&path)?.ok_or_else(|| WorktreeErr::Unmarked {
-        name: name.to_owned(),
-        path: path.clone(),
-    })?;
+    let marker = owned_marker(name, &path)?;
     let status = status(&path, &marker)?;
     if !force {
         match protections.assess(&path, status) {
@@ -654,10 +653,7 @@ pub fn resolve_owned(
 ) -> Result<ManagedWorktree> {
     ensure_repo(repo_root)?;
     let path = worktree_path(repo_root, config, name)?;
-    let marker = read_marker_for_worktree(&path)?.ok_or_else(|| WorktreeErr::Unmarked {
-        name: name.to_owned(),
-        path: path.clone(),
-    })?;
+    let marker = owned_marker(name, &path)?;
     let branch = current_branch(&path);
     Ok(ManagedWorktree {
         marker,
@@ -1020,6 +1016,23 @@ pub fn read_marker_for_worktree(path: &Path) -> Result<Option<WorktreeMarker>> {
         Err(err) => return Err(err),
     };
     read_marker_file(&marker)
+}
+
+fn owned_marker(name: &str, path: &Path) -> Result<WorktreeMarker> {
+    if let Some(marker) = read_marker_for_worktree(path)? {
+        return Ok(marker);
+    }
+    Err(if path.exists() {
+        WorktreeErr::Unmarked {
+            name: name.to_owned(),
+            path: path.to_owned(),
+        }
+    } else {
+        WorktreeErr::Missing {
+            name: name.to_owned(),
+            path: path.to_owned(),
+        }
+    })
 }
 
 /// Read a RimZ marker by following the checkout's `.git` metadata only. This

--- a/crates/rimz/tests/integration/worktree.rs
+++ b/crates/rimz/tests/integration/worktree.rs
@@ -117,6 +117,31 @@ fn worktree_new_list_and_remove_round_trip() {
 }
 
 #[test]
+fn worktree_remove_distinguishes_missing_from_unmarked() {
+    if git_missing() {
+        return;
+    }
+    let env = Env::new();
+    init_repo(&env.project_root);
+
+    env.rimz()
+        .args(["worktree", "remove", "ghost"])
+        .assert()
+        .failure()
+        .stderr(contains("worktree `ghost` does not exist at"));
+
+    let plain = env.home_root.join("project-worktrees/plain");
+    std::fs::create_dir_all(&plain).expect("create unmarked directory");
+    env.rimz()
+        .args(["worktree", "remove", "plain"])
+        .assert()
+        .failure()
+        .stderr(contains(
+            "worktree `plain` is not a RimZ-managed worktree at",
+        ));
+}
+
+#[test]
 fn worktree_sweep_previews_then_removes_only_safe_checkouts() {
     if git_missing() {
         return;


### PR DESCRIPTION
## Context

`rimz agents <team> -w <name>` reconciles a relaunch into a worktree that already exists. If the prior cohort is closed and the checkout is clean and merged, the command asks to remove the worktree and start fresh.

The marker and the Git status are read before the prompt. The removal runs after the answer. A concurrent remover can delete the checkout in that interval. Three removers can do this: the detached `rimz worktree cleanup` from the prior cohort's wrapper exit, `rimz gc`, or a manual `rimz worktree remove`. The removal then failed with "worktree `<name>` is not a RimZ-managed worktree". But the worktree was already in the requested state, and a second run succeeded.

The error text was also wrong. `read_marker_for_worktree` runs `git -C <path> rev-parse --git-dir`. A path that does not exist makes Git exit with an error, and the function maps that error to `Ok(None)`. Both callers turned `None` into `Unmarked`. Thus an absent directory reported as an unmanaged directory. `rimz worktree remove <unknown-name>` printed the same wrong text.

## Design choices

- Split the domain outcome. `WorktreeErr::Missing` reports a path that is not there. `WorktreeErr::Unmarked` keeps its meaning: a path that is there without a RimZ marker.
- Read the marker first, then classify. An existence check before the read reopens the same race, because the checkout can go away between the check and the read.
- Keep `worktree::remove` strict. A missing worktree stays an error for an explicit `rimz worktree remove`. Only the cohort recreation knows that "gone" equals "done".
- Do not retire the store records in the tolerant branch. Each RimZ removal path calls `retire_removal` itself: the explicit remove, the wrapper cleanup, and the `gc` sweep.

## Implementation

- `crates/rimz/src/worktree.rs` adds `WorktreeErr::Missing` and a private `owned_marker` helper. `remove` and `resolve_owned` both use it.
- `crates/rimz/src/cli/agents_cmd/reconcile.rs` accepts `Missing` in `recreate_or_done`. It prints one line to stderr and continues into fresh creation.
- `crates/rimz/tests/integration/worktree.rs` adds one test. The test drives the real binary and pins both sides of the split.

Deviations from the plan:

- The plan first put the existence check before the marker read. That order keeps the race. The design changed to read first and classify afterwards.
- The optional interactive end-to-end test is not included. The prompt needs a terminal on stdin, and the integration harness has no PTY driver. The short branch is covered through the domain error and the real CLI.
- No document changed. `docs/reference/cli/worktree.md` does not list the removal error text, so the conditional update in the plan does not apply.

## Advisories

- `resolve_fresh_worktree` still classifies a missing marker inline, after an existence check. A checkout that goes away between the two calls still reports the unmanaged text there. The window is very short, and the result is only a wrong message.
- The tolerant branch assumes that a RimZ remover did the removal. A removal by hand keeps the branch, and the later creation stops with `fatal: a branch named '<name>' already exists`. This behaviour is not new.
- `docs/internals/harness/fleet.md` holds the reconciliation outcome table. `docs/internals/harness/worktrees.md` describes the cohort relaunch. Neither document names the new tolerance or its stderr line.

## Verification

- `cargo xtask gate` passed with 5881 tests.
- `cargo xtask test 'worktree::'` passed with 128 tests. `cargo xtask test 'reconcile'` passed with 46 tests.
- Manual check in a disposable repository. A worktree removed out of band makes `rimz worktree remove` print "does not exist". After a RimZ removal, the fresh creation succeeds.

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>forge</code> team · 3 agents · 23m active · $10.86 · 5 messages (1 from you)</summary>

- **planner** — Claude `claude-fable-5@high`
  - effort: 5m active · $4.29
  - calls: 1 ask · 21 tool calls
  - messages: 1 from you · 1 from teammates · 2 to teammates
  - tokens: 4.5k input, 23.5k output, 88k cache write, 1.3m cache read
- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 9m active · $1.26
  - calls: 26 tool calls
  - messages: 2 from teammates · 2 to teammates
  - tokens: 88k input, 8.2k output, 1.9m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 8m active · $5.30 incl. subagents
  - calls: 51 tool calls
  - messages: 1 from teammates
  - tokens: 172 input, 37.1k output, 207.4k cache write, 5.4m cache read
  - subagents: 1 × general-purpose ($1.96)

</details>