### PR TITLE
fix(sidebar): stop a pane's birth argv from outliving its agent

### DIFF
--- a/crates/rimz/src/agents/registry.rs
+++ b/crates/rimz/src/agents/registry.rs
@@ -142,13 +142,15 @@ fn adapter_for_program(
     program: crate::proc::command::EffectiveProgram<'_>,
 ) -> Option<&'static AgentDefinition> {
     let label = crate::proc::command::basename(program.program);
+    let from_launcher = program.program != program.root_program
+        && crate::proc::command::is_launcher(program.root_program);
     all_definitions()
         .find(|adapter| {
             adapter.spec().ambiguous_bin_identity(label).is_none()
                 && adapter_matches_program(adapter, program)
         })
         .or_else(|| {
-            (!program.from_launcher)
+            (!from_launcher)
                 .then(|| adapter_for_comm(program.program))
                 .flatten()
         })
@@ -160,9 +162,11 @@ fn adapter_matches_program(
 ) -> bool {
     let definition = adapter.spec();
     let label = crate::proc::command::basename(program.program);
+    let from_launcher = program.program != program.root_program
+        && crate::proc::command::is_launcher(program.root_program);
     definition.launches_as(label)
-        || (!program.from_launcher && definition.runs_as(label))
-        || (program.from_launcher
+        || (!from_launcher && definition.runs_as(label))
+        || (from_launcher
             && crate::proc::command::agent_script_path_names_kind(program.program, definition.kind))
 }
 

--- a/crates/rimz/src/diag/record.rs
+++ b/crates/rimz/src/diag/record.rs
@@ -1604,6 +1604,12 @@ pub enum AnomalyKind {
         pid: u32,
         reason: String,
     },
+    AgentCardWithoutProcess {
+        row_id: String,
+        pane_id: Option<String>,
+        pid: u32,
+        kind: String,
+    },
 }
 
 impl AnomalyKind {
@@ -1626,6 +1632,7 @@ impl AnomalyKind {
             Self::CardsExceedPanes { .. } => "cards_exceed_panes",
             Self::RowPaneMissingFromFrame { .. } => "row_pane_missing_from_frame",
             Self::DeadPid { .. } => "dead_pid",
+            Self::AgentCardWithoutProcess { .. } => "agent_card_without_process",
         }
     }
 
@@ -1641,7 +1648,8 @@ impl AnomalyKind {
             | Self::StatusChurn { row_id, .. }
             | Self::DuplicateRowId { row_id, .. }
             | Self::RowPaneMissingFromFrame { row_id, .. }
-            | Self::DeadPid { row_id, .. } => Some(Cow::Borrowed(row_id)),
+            | Self::DeadPid { row_id, .. }
+            | Self::AgentCardWithoutProcess { row_id, .. } => Some(Cow::Borrowed(row_id)),
             Self::DuplicatePaneRows { pane_id, .. } => Some(Cow::Borrowed(pane_id)),
             Self::StatusCountMismatch { group_key, .. } | Self::OrderFlap { group_key, .. } => {
                 Some(Cow::Borrowed(group_key))

--- a/crates/rimz/src/diag/record/tests.rs
+++ b/crates/rimz/src/diag/record/tests.rs
@@ -212,6 +212,34 @@ fn row_presence_gap_evidence_is_backward_compatible() {
 }
 
 #[test]
+fn agent_card_without_process_has_stable_diagnostic_identity() {
+    let anomaly = AnomalyKind::AgentCardWithoutProcess {
+        row_id: "agent:a".to_owned(),
+        pane_id: Some("tmux:%1".to_owned()),
+        pid: 123,
+        kind: "claude".to_owned(),
+    };
+    assert_eq!(anomaly.key(), "agent_card_without_process");
+    assert_eq!(anomaly.subject().as_deref(), Some("agent:a"));
+
+    let event = DiagEvent::FrameAnomaly {
+        role: ObserveRole::Elder,
+        anomaly,
+        window_ms: None,
+        frame: frame_stamp(1),
+        events_recent: EventsSig::default(),
+        gate_reject_streak: 0,
+        health_failure_streak: 0,
+        dropped_msgs: 0,
+    };
+    assert_eq!(event.severity(), DiagSeverity::Warn);
+    assert_eq!(
+        event.summary(),
+        "observed agent_card_without_process on agent:a"
+    );
+}
+
+#[test]
 fn severity_table_pins_conditional_and_regression_categories() {
     let info = [
         DiagEvent::SidebarWidthIntent {

--- a/crates/rimz/src/pane.rs
+++ b/crates/rimz/src/pane.rs
@@ -114,8 +114,8 @@ pub struct PaneRef {
     /// only a program basename. Display-only; never an identity key.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub foreground_cmdline: Option<String>,
-    /// Spawn command used to launch the pane, if the backend reports it.
-    /// Advisory identity/classification metadata; display prefers
+    /// Birth argv used to launch the pane, if the backend reports it. Advisory
+    /// identity/classification metadata, never liveness; display prefers
     /// [`Self::command`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub spawn_command: Option<String>,

--- a/crates/rimz/src/proc/command.rs
+++ b/crates/rimz/src/proc/command.rs
@@ -9,6 +9,22 @@ pub(crate) fn program_label(command: &str) -> String {
     basename(effective_program(command)).to_owned()
 }
 
+/// Whether pane birth argv still names the live foreground root. A missing or
+/// empty foreground is a reporting race; missing birth argv carries no identity.
+pub(crate) fn spawn_command_names_live_root(
+    command: Option<&str>,
+    spawn_command: Option<&str>,
+) -> bool {
+    let Some(spawn_command) = spawn_command else {
+        return false;
+    };
+    let Some(command) = command.filter(|command| !command.is_empty()) else {
+        return true;
+    };
+    let spawn = effective_program_info(spawn_command);
+    program_label(command) == basename(spawn.root_program)
+}
+
 /// The command with an absolute program path reduced to a basename: `/usr/bin/cargo
 /// build` reads as `cargo build`, while relative paths like
 /// `target/debug/xtask install-dev` stay verbatim as build-location context.
@@ -192,6 +208,17 @@ mod tests {
             "npm"
         );
         assert_eq!(program_label("/usr/bin/cargo build"), "cargo");
+    }
+
+    #[test]
+    fn spawn_identity_requires_its_root_to_remain_live() {
+        let spawn = Some("/bin/rimz agents exec claude --worktree-path /repo");
+
+        assert!(spawn_command_names_live_root(None, spawn));
+        assert!(spawn_command_names_live_root(Some(""), spawn));
+        assert!(spawn_command_names_live_root(Some("rimz"), spawn));
+        assert!(!spawn_command_names_live_root(Some("zsh"), spawn));
+        assert!(!spawn_command_names_live_root(Some("rimz"), None));
     }
 
     #[test]

--- a/crates/rimz/src/proc/command.rs
+++ b/crates/rimz/src/proc/command.rs
@@ -9,12 +9,6 @@ pub(crate) fn program_label(command: &str) -> String {
     basename(effective_program(command)).to_owned()
 }
 
-/// The program at the root of a command, seeing past `sudo` but not through
-/// RimZ or JavaScript launchers.
-pub(crate) fn root_program_label(command: &str) -> Option<&str> {
-    effective_program_and_args(command).map(|(program, _)| basename(program))
-}
-
 /// The command with an absolute program path reduced to a basename: `/usr/bin/cargo
 /// build` reads as `cargo build`, while relative paths like
 /// `target/debug/xtask install-dev` stay verbatim as build-location context.
@@ -115,20 +109,20 @@ fn effective_program(command: &str) -> &str {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct EffectiveProgram<'a> {
     pub(crate) program: &'a str,
-    pub(crate) from_launcher: bool,
+    pub(crate) root_program: &'a str,
 }
 
 pub(crate) fn effective_program_info(command: &str) -> EffectiveProgram<'_> {
     let Some((program, mut tokens)) = effective_program_and_args(command) else {
         return EffectiveProgram {
             program: command,
-            from_launcher: false,
+            root_program: command,
         };
     };
     if let Some(kind) = rimz_exec_kind(program, tokens.clone()) {
         return EffectiveProgram {
             program: kind,
-            from_launcher: false,
+            root_program: program,
         };
     }
     // A JS launcher runs the script named by its first non-flag argument, so the
@@ -138,12 +132,12 @@ pub(crate) fn effective_program_info(command: &str) -> EffectiveProgram<'_> {
     {
         return EffectiveProgram {
             program: script,
-            from_launcher: true,
+            root_program: program,
         };
     }
     EffectiveProgram {
         program,
-        from_launcher: false,
+        root_program: program,
     }
 }
 
@@ -184,7 +178,7 @@ mod tests {
             effective_program_info("node --inspect /usr/bin/codex"),
             EffectiveProgram {
                 program: "/usr/bin/codex",
-                from_launcher: true,
+                root_program: "node",
             }
         );
         assert_eq!(program_label("node /usr/bin/codex"), "codex");

--- a/crates/rimz/src/proc/command.rs
+++ b/crates/rimz/src/proc/command.rs
@@ -9,6 +9,12 @@ pub(crate) fn program_label(command: &str) -> String {
     basename(effective_program(command)).to_owned()
 }
 
+/// The program at the root of a command, seeing past `sudo` but not through
+/// RimZ or JavaScript launchers.
+pub(crate) fn root_program_label(command: &str) -> Option<&str> {
+    effective_program_and_args(command).map(|(program, _)| basename(program))
+}
+
 /// The command with an absolute program path reduced to a basename: `/usr/bin/cargo
 /// build` reads as `cargo build`, while relative paths like
 /// `target/debug/xtask install-dev` stay verbatim as build-location context.

--- a/crates/rimz/src/proc/mod.rs
+++ b/crates/rimz/src/proc/mod.rs
@@ -12,9 +12,7 @@ pub(crate) mod command;
 mod macos;
 mod pane_probe;
 
-pub(crate) use command::{
-    command_program_basename, program_label, rimz_exec_worktree_path, root_program_label,
-};
+pub(crate) use command::{command_program_basename, program_label, rimz_exec_worktree_path};
 
 use std::io::Read;
 use std::path::{Path, PathBuf};

--- a/crates/rimz/src/proc/mod.rs
+++ b/crates/rimz/src/proc/mod.rs
@@ -12,7 +12,9 @@ pub(crate) mod command;
 mod macos;
 mod pane_probe;
 
-pub(crate) use command::{command_program_basename, program_label, rimz_exec_worktree_path};
+pub(crate) use command::{
+    command_program_basename, program_label, rimz_exec_worktree_path, root_program_label,
+};
 
 use std::io::Read;
 use std::path::{Path, PathBuf};

--- a/crates/rimz/src/sidebar/agent_projection.rs
+++ b/crates/rimz/src/sidebar/agent_projection.rs
@@ -124,9 +124,24 @@ fn candidate_pane_agent_kind(pane: &PaneRef) -> Option<&'static str> {
         .or_else(|| {
             pane.spawn_command
                 .as_deref()
-                .filter(|_| crate::store::snapshot::spawn_command_names_live_root(pane))
+                .filter(|_| spawn_command_names_live_root(pane))
                 .and_then(crate::agents::registry::command_agent_kind_candidate)
         })
+}
+
+fn spawn_command_names_live_root(pane: &PaneRef) -> bool {
+    let Some(command) = pane
+        .command
+        .as_deref()
+        .filter(|command| !command.is_empty())
+    else {
+        return true;
+    };
+    pane.spawn_command
+        .as_deref()
+        .map(crate::proc::command::effective_program_info)
+        .map(|program| crate::proc::command::basename(program.root_program))
+        .is_some_and(|spawn_program| crate::proc::program_label(command) == spawn_program)
 }
 
 fn normalize_observations(observations: &mut Vec<LocalSessionObservation>) {

--- a/crates/rimz/src/sidebar/agent_projection.rs
+++ b/crates/rimz/src/sidebar/agent_projection.rs
@@ -124,24 +124,14 @@ fn candidate_pane_agent_kind(pane: &PaneRef) -> Option<&'static str> {
         .or_else(|| {
             pane.spawn_command
                 .as_deref()
-                .filter(|_| spawn_command_names_live_root(pane))
+                .filter(|_| {
+                    crate::proc::command::spawn_command_names_live_root(
+                        pane.command.as_deref(),
+                        pane.spawn_command.as_deref(),
+                    )
+                })
                 .and_then(crate::agents::registry::command_agent_kind_candidate)
         })
-}
-
-fn spawn_command_names_live_root(pane: &PaneRef) -> bool {
-    let Some(command) = pane
-        .command
-        .as_deref()
-        .filter(|command| !command.is_empty())
-    else {
-        return true;
-    };
-    pane.spawn_command
-        .as_deref()
-        .map(crate::proc::command::effective_program_info)
-        .map(|program| crate::proc::command::basename(program.root_program))
-        .is_some_and(|spawn_program| crate::proc::program_label(command) == spawn_program)
 }
 
 fn normalize_observations(observations: &mut Vec<LocalSessionObservation>) {

--- a/crates/rimz/src/sidebar/agent_projection.rs
+++ b/crates/rimz/src/sidebar/agent_projection.rs
@@ -112,19 +112,20 @@ impl LocalSessionInputs {
 /// card, so admitting an ambiguous basename here preserves hook-bound Cursor
 /// enrichment without turning that basename into pane presence or routing.
 fn candidate_pane_agent_kind(pane: &PaneRef) -> Option<&'static str> {
-    pane.spawn_command
+    pane.command
         .as_deref()
         .and_then(crate::agents::registry::command_agent_kind_candidate)
-        .or_else(|| {
-            pane.command
-                .as_deref()
-                .and_then(crate::agents::registry::command_agent_kind_candidate)
-        })
         .or_else(|| {
             pane.hosted_agent_kind
                 .as_ref()
                 .and_then(|kind| crate::agents::spec_by_kind(kind.as_str()))
                 .map(|definition| definition.kind)
+        })
+        .or_else(|| {
+            pane.spawn_command
+                .as_deref()
+                .filter(|_| crate::store::snapshot::spawn_command_names_live_root(pane))
+                .and_then(crate::agents::registry::command_agent_kind_candidate)
         })
 }
 
@@ -453,6 +454,16 @@ mod tests {
         assert_eq!(calls.get(), 1);
         assert_eq!(observed[0].session_id.as_str(), "a");
         assert_eq!(observed[1].session_id.as_str(), "b");
+    }
+
+    #[test]
+    fn local_session_inputs_ignore_agent_birth_argv_after_a_shell_takes_over() {
+        let mut pane = crate::sidebar::test_support::pane("1", "zsh", "/repo");
+        pane.spawn_command = Some("/bin/rimz agents exec claude --worktree-path /repo".to_owned());
+
+        assert_eq!(candidate_pane_agent_kind(&pane), None);
+        pane.command = Some("rimz".to_owned());
+        assert_eq!(candidate_pane_agent_kind(&pane), Some("claude"));
     }
 
     #[test]

--- a/crates/rimz/src/sidebar/observe.rs
+++ b/crates/rimz/src/sidebar/observe.rs
@@ -83,8 +83,16 @@ fn frame_stamp_from_sig(sig: &FrameSig) -> FrameStamp {
     FrameStamp {
         produced_at_ms: sig.panes_produced_at_ms,
         rows: sig.rows.len(),
-        agents: sig.rows.iter().filter(|row| row.is_agent).count(),
-        processes: sig.rows.iter().filter(|row| !row.is_agent).count(),
+        agents: sig
+            .rows
+            .iter()
+            .filter(|row| row.agent_kind.is_some())
+            .count(),
+        processes: sig
+            .rows
+            .iter()
+            .filter(|row| row.agent_kind.is_none())
+            .count(),
         pulled_rows: Some(sig.pulled_rows),
         pulled_panes_produced_at_ms: sig.pulled_panes_produced_at_ms,
     }
@@ -94,8 +102,16 @@ fn frame_stamp_from_roster(roster: &RosterSig) -> FrameStamp {
     FrameStamp {
         produced_at_ms: roster.panes_produced_at_ms,
         rows: roster.rows.len(),
-        agents: roster.rows.iter().filter(|row| row.is_agent).count(),
-        processes: roster.rows.iter().filter(|row| !row.is_agent).count(),
+        agents: roster
+            .rows
+            .iter()
+            .filter(|row| row.agent_kind.is_some())
+            .count(),
+        processes: roster
+            .rows
+            .iter()
+            .filter(|row| row.agent_kind.is_none())
+            .count(),
         pulled_rows: None,
         pulled_panes_produced_at_ms: None,
     }

--- a/crates/rimz/src/sidebar/observe/detect/tests.rs
+++ b/crates/rimz/src/sidebar/observe/detect/tests.rs
@@ -67,7 +67,6 @@ fn row(id: &str, pane: &str, group: &str) -> RowSig {
 fn row_with_status(id: &str, pane: &str, group: &str, status: &str) -> RowSig {
     RowSig {
         row_id: id.to_owned(),
-        is_agent: true,
         agent_kind: Some("claude".to_owned()),
         pane_id: Some(pane.to_owned()),
         pane_pid: None,

--- a/crates/rimz/src/sidebar/observe/detect/tests.rs
+++ b/crates/rimz/src/sidebar/observe/detect/tests.rs
@@ -68,6 +68,7 @@ fn row_with_status(id: &str, pane: &str, group: &str, status: &str) -> RowSig {
     RowSig {
         row_id: id.to_owned(),
         is_agent: true,
+        agent_kind: Some("claude".to_owned()),
         pane_id: Some(pane.to_owned()),
         pane_pid: None,
         pane_process_start: None,

--- a/crates/rimz/src/sidebar/observe/sig.rs
+++ b/crates/rimz/src/sidebar/observe/sig.rs
@@ -28,7 +28,6 @@ pub struct FrameSig {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct RowSig {
     pub row_id: String,
-    pub is_agent: bool,
     pub agent_kind: Option<String>,
     pub pane_id: Option<String>,
     pub pane_pid: Option<u32>,
@@ -158,7 +157,6 @@ pub struct RosterSig {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RosterRowSig {
     pub row_id: String,
-    pub is_agent: bool,
     pub agent_kind: Option<String>,
     pub pane_id: Option<String>,
     pub pane_pid: Option<u32>,
@@ -179,7 +177,6 @@ pub fn extract_sig(
         .flat_map(|group| {
             group.rows.iter().map(|row| RowSig {
                 row_id: row.id.clone(),
-                is_agent: row.is_agent(),
                 agent_kind: row.is_agent().then(|| row.name.clone()),
                 pane_id: row.pane.as_ref().map(|pane| pane.pane_id.to_string()),
                 pane_pid: row.pane.as_ref().and_then(|pane| pane.pane_pid),
@@ -340,7 +337,6 @@ impl RosterSig {
                 .iter()
                 .map(|row| RosterRowSig {
                     row_id: row.row_id.clone(),
-                    is_agent: row.is_agent,
                     agent_kind: row.agent_kind.clone(),
                     pane_id: row.pane_id.clone(),
                     pane_pid: row.pane_pid,

--- a/crates/rimz/src/sidebar/observe/sig.rs
+++ b/crates/rimz/src/sidebar/observe/sig.rs
@@ -29,6 +29,7 @@ pub struct FrameSig {
 pub struct RowSig {
     pub row_id: String,
     pub is_agent: bool,
+    pub agent_kind: Option<String>,
     pub pane_id: Option<String>,
     pub pane_pid: Option<u32>,
     pub pane_process_start: Option<jiff::Timestamp>,
@@ -158,6 +159,7 @@ pub struct RosterSig {
 pub struct RosterRowSig {
     pub row_id: String,
     pub is_agent: bool,
+    pub agent_kind: Option<String>,
     pub pane_id: Option<String>,
     pub pane_pid: Option<u32>,
     pub pane_process_start: Option<jiff::Timestamp>,
@@ -178,6 +180,7 @@ pub fn extract_sig(
             group.rows.iter().map(|row| RowSig {
                 row_id: row.id.clone(),
                 is_agent: row.is_agent(),
+                agent_kind: row.is_agent().then(|| row.name.clone()),
                 pane_id: row.pane.as_ref().map(|pane| pane.pane_id.to_string()),
                 pane_pid: row.pane.as_ref().and_then(|pane| pane.pane_pid),
                 pane_process_start: row.pane.as_ref().and_then(|pane| pane.pane_process_start),
@@ -338,6 +341,7 @@ impl RosterSig {
                 .map(|row| RosterRowSig {
                     row_id: row.row_id.clone(),
                     is_agent: row.is_agent,
+                    agent_kind: row.agent_kind.clone(),
                     pane_id: row.pane_id.clone(),
                     pane_pid: row.pane_pid,
                     pane_process_start: row.pane_process_start,

--- a/crates/rimz/src/sidebar/observe/writer.rs
+++ b/crates/rimz/src/sidebar/observe/writer.rs
@@ -302,7 +302,6 @@ mod tests {
                 .into_iter()
                 .map(|(row_id, pane)| RosterRowSig {
                     row_id: row_id.to_owned(),
-                    is_agent: true,
                     agent_kind: Some("claude".to_owned()),
                     pane_id: Some(pane_id(pane).to_string()),
                     pane_pid: None,
@@ -317,7 +316,6 @@ mod tests {
             panes_produced_at_ms: Some(10),
             rows: vec![RosterRowSig {
                 row_id: row_id.to_owned(),
-                is_agent: true,
                 agent_kind: Some("claude".to_owned()),
                 pane_id: Some(pane_id("terminal_1").to_string()),
                 pane_pid: Some(pid),
@@ -469,11 +467,9 @@ mod tests {
     fn hostless_agent_ignores_process_rows_pidless_rows_and_dead_pids() {
         let mut tracker = HostedAgentTracker::default();
         let mut rows = roster_with_pid("process", 123, Timestamp::from_second(10).unwrap());
-        rows.rows[0].is_agent = false;
         rows.rows[0].agent_kind = None;
         rows.rows.push(RosterRowSig {
             row_id: "pidless".to_owned(),
-            is_agent: true,
             agent_kind: Some("claude".to_owned()),
             pane_id: Some(pane_id("terminal_2").to_string()),
             pane_pid: None,

--- a/crates/rimz/src/sidebar/observe/writer.rs
+++ b/crates/rimz/src/sidebar/observe/writer.rs
@@ -12,7 +12,9 @@ use crate::sidebar::ProducerElectionTracker;
 use crate::sidebar::cache::read_snapshot_cache;
 use crate::sidebar::frame::PaneFrame;
 use crate::sidebar::timing::unix_now_ms;
-use crate::sidebar::timing::{OBSERVE_CROSSCHECK_TTL, OBSERVE_DEADPID_CONFIRMATIONS};
+use crate::sidebar::timing::{
+    OBSERVE_CROSSCHECK_TTL, OBSERVE_DEADPID_CONFIRMATIONS, OBSERVE_HOSTLESS_AGENT_CONFIRMATIONS,
+};
 use crate::store::paths::RuntimePaths;
 use jiff::Timestamp;
 
@@ -32,6 +34,7 @@ pub fn spawn(
             latest_roster: None,
             last_crosscheck: Instant::now(),
             dead_pids: DeadPidTracker::default(),
+            hostless_agents: HostedAgentTracker::default(),
         }
         .run(rx);
     })
@@ -48,6 +51,7 @@ struct Writer {
     latest_roster: Option<RosterSig>,
     last_crosscheck: Instant,
     dead_pids: DeadPidTracker,
+    hostless_agents: HostedAgentTracker,
 }
 
 impl Writer {
@@ -102,6 +106,13 @@ impl Writer {
         }
         if crate::proc::process_start(std::process::id()).is_some() {
             for kind in self.dead_pids.check(&roster, crate::proc::process_start) {
+                self.emit_anomaly(AnomalyDraft::from_roster(unix_now_ms(), &roster, kind));
+            }
+            for kind in self.hostless_agents.check(
+                &roster,
+                crate::proc::process_start,
+                &crate::proc::hosted_agent_absent_under_root,
+            ) {
                 self.emit_anomaly(AnomalyDraft::from_roster(unix_now_ms(), &roster, kind));
             }
         }
@@ -219,6 +230,58 @@ struct DeadPidObservation {
     reason: Option<String>,
 }
 
+#[derive(Default)]
+struct HostedAgentTracker {
+    by_pid: BTreeMap<(String, u32), HostedAgentObservation>,
+}
+
+impl HostedAgentTracker {
+    fn check(
+        &mut self,
+        roster: &RosterSig,
+        process_start: fn(u32) -> Option<Timestamp>,
+        hosted_agent_absent: &dyn Fn(&str, u32) -> bool,
+    ) -> Vec<AnomalyKind> {
+        let mut active = BTreeSet::new();
+        let mut anomalies = Vec::new();
+        for row in &roster.rows {
+            let (Some(kind), Some(pid)) = (row.agent_kind.as_deref(), row.pane_pid) else {
+                continue;
+            };
+            if process_start(pid).is_none() {
+                continue;
+            }
+            let key = (row.row_id.clone(), pid);
+            active.insert(key.clone());
+            if !hosted_agent_absent(kind, pid) {
+                self.by_pid.remove(&key);
+                continue;
+            }
+            let observation = self.by_pid.entry(key).or_default();
+            observation.confirmations = observation.confirmations.saturating_add(1);
+            if observation.confirmations >= OBSERVE_HOSTLESS_AGENT_CONFIRMATIONS
+                && !observation.emitted
+            {
+                anomalies.push(AnomalyKind::AgentCardWithoutProcess {
+                    row_id: row.row_id.clone(),
+                    pane_id: row.pane_id.clone(),
+                    pid,
+                    kind: kind.to_owned(),
+                });
+                observation.emitted = true;
+            }
+        }
+        self.by_pid.retain(|key, _| active.contains(key));
+        cap_vec(anomalies)
+    }
+}
+
+#[derive(Default)]
+struct HostedAgentObservation {
+    confirmations: u32,
+    emitted: bool,
+}
+
 fn timestamp_diff_gt(left: Timestamp, right: Timestamp, tolerance: std::time::Duration) -> bool {
     left.as_second().abs_diff(right.as_second()) > tolerance.as_secs()
 }
@@ -240,6 +303,7 @@ mod tests {
                 .map(|(row_id, pane)| RosterRowSig {
                     row_id: row_id.to_owned(),
                     is_agent: true,
+                    agent_kind: Some("claude".to_owned()),
                     pane_id: Some(pane_id(pane).to_string()),
                     pane_pid: None,
                     pane_process_start: None,
@@ -254,6 +318,7 @@ mod tests {
             rows: vec![RosterRowSig {
                 row_id: row_id.to_owned(),
                 is_agent: true,
+                agent_kind: Some("claude".to_owned()),
                 pane_id: Some(pane_id("terminal_1").to_string()),
                 pane_pid: Some(pid),
                 pane_process_start: Some(started_at),
@@ -271,6 +336,15 @@ mod tests {
 
     fn mismatched_process_start(_: u32) -> Option<Timestamp> {
         Some(Timestamp::from_second(100).unwrap())
+    }
+
+    fn check_hosted_agent(
+        tracker: &mut HostedAgentTracker,
+        roster: &RosterSig,
+        process_start: fn(u32) -> Option<Timestamp>,
+        absent: bool,
+    ) -> Vec<AnomalyKind> {
+        tracker.check(roster, process_start, &|_, _| absent)
     }
 
     fn pane_id(raw: &str) -> PaneId {
@@ -362,6 +436,55 @@ mod tests {
             [AnomalyKind::DeadPid { reason, .. }] if reason == "starttime-mismatch"
         ));
         assert!(tracker.check(&roster, mismatched_process_start).is_empty());
+    }
+
+    #[test]
+    fn hostless_agent_requires_confirmations_emits_once_and_re_arms() {
+        let mut tracker = HostedAgentTracker::default();
+        let roster = roster_with_pid("a", 123, Timestamp::from_second(10).unwrap());
+
+        assert!(check_hosted_agent(&mut tracker, &roster, live_process_start, true).is_empty());
+        assert!(check_hosted_agent(&mut tracker, &roster, live_process_start, false).is_empty());
+        assert!(check_hosted_agent(&mut tracker, &roster, live_process_start, true).is_empty());
+        assert!(matches!(
+            check_hosted_agent(&mut tracker, &roster, live_process_start, true).as_slice(),
+            [AnomalyKind::AgentCardWithoutProcess {
+                row_id,
+                pane_id: Some(pane_id),
+                pid: 123,
+                kind,
+            }] if row_id == "a" && pane_id == "zellij:terminal_1" && kind == "claude"
+        ));
+        assert!(check_hosted_agent(&mut tracker, &roster, live_process_start, true).is_empty());
+
+        assert!(check_hosted_agent(&mut tracker, &roster, live_process_start, false).is_empty());
+        assert!(check_hosted_agent(&mut tracker, &roster, live_process_start, true).is_empty());
+        assert_eq!(
+            check_hosted_agent(&mut tracker, &roster, live_process_start, true).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn hostless_agent_ignores_process_rows_pidless_rows_and_dead_pids() {
+        let mut tracker = HostedAgentTracker::default();
+        let mut rows = roster_with_pid("process", 123, Timestamp::from_second(10).unwrap());
+        rows.rows[0].is_agent = false;
+        rows.rows[0].agent_kind = None;
+        rows.rows.push(RosterRowSig {
+            row_id: "pidless".to_owned(),
+            is_agent: true,
+            agent_kind: Some("claude".to_owned()),
+            pane_id: Some(pane_id("terminal_2").to_string()),
+            pane_pid: None,
+            pane_process_start: None,
+        });
+        assert!(check_hosted_agent(&mut tracker, &rows, live_process_start, true).is_empty());
+        assert!(check_hosted_agent(&mut tracker, &rows, live_process_start, true).is_empty());
+
+        let agent = roster_with_pid("agent", 456, Timestamp::from_second(10).unwrap());
+        assert!(check_hosted_agent(&mut tracker, &agent, missing_process_start, true).is_empty());
+        assert!(check_hosted_agent(&mut tracker, &agent, missing_process_start, true).is_empty());
     }
 
     #[test]

--- a/crates/rimz/src/sidebar/produce/panes.rs
+++ b/crates/rimz/src/sidebar/produce/panes.rs
@@ -315,11 +315,10 @@ fn repair_pane_frame(
 }
 
 /// Recover a pane's spawn command from RimZ's supervised agent wrapper when the
-/// mux did not retain one. tmux reports only the foreground program basename
-/// and no spawn command, so a `rimz agents exec <kind>` wrapper pane otherwise
-/// classifies as neither its agent kind nor its worktree. Only an empty spawn
-/// command is filled, and only from a cmdline that classifies as an agent, so a
-/// real foreground is never overwritten.
+/// mux did not retain one. This covers panes born without backend spawn
+/// metadata; tmux otherwise reports its immutable `pane_start_command`. Only an
+/// empty spawn command is filled, and only from a cmdline that classifies as an
+/// agent, so real metadata is never overwritten.
 fn backfill_wrapper_spawn_commands(
     frame: &mut PaneFrame,
     proc_cmdline: &dyn Fn(u32) -> Option<String>,

--- a/crates/rimz/src/sidebar/timing.rs
+++ b/crates/rimz/src/sidebar/timing.rs
@@ -367,7 +367,7 @@ pub const OBSERVE_DEADPID_CONFIRMATIONS: u32 = 2;
 
 /// Consecutive writer-side `/proc` observations required before an agent card
 /// without a matching hosted process is logged.
-pub const OBSERVE_HOSTLESS_AGENT_CONFIRMATIONS: u32 = 2;
+pub(super) const OBSERVE_HOSTLESS_AGENT_CONFIRMATIONS: u32 = 2;
 
 /// Default render base grid: 100ms, or 10Hz.
 pub const DEFAULT_REFRESH_MS: u16 = 100;

--- a/crates/rimz/src/sidebar/timing.rs
+++ b/crates/rimz/src/sidebar/timing.rs
@@ -365,6 +365,10 @@ pub const OBSERVE_CROSSCHECK_TTL: Duration = Duration::from_secs(5);
 /// logged.
 pub const OBSERVE_DEADPID_CONFIRMATIONS: u32 = 2;
 
+/// Consecutive writer-side `/proc` observations required before an agent card
+/// without a matching hosted process is logged.
+pub const OBSERVE_HOSTLESS_AGENT_CONFIRMATIONS: u32 = 2;
+
 /// Default render base grid: 100ms, or 10Hz.
 pub const DEFAULT_REFRESH_MS: u16 = 100;
 

--- a/crates/rimz/src/store/snapshot/mod.rs
+++ b/crates/rimz/src/store/snapshot/mod.rs
@@ -43,7 +43,9 @@ pub(crate) use panes::{
 pub use panes::{SidebarOwnView, pane_start_allows_bind, stamped_agent_for_pane};
 pub use process::pane_agent_kind;
 pub(crate) use process::pane_worktree_path;
-pub(crate) use process::{command_is_sidebar_chrome, process_is_active};
+pub(crate) use process::{
+    command_is_sidebar_chrome, process_is_active, spawn_command_names_live_root,
+};
 pub use row::{
     AgentCard, PaneAgent, ProcessCard, ProcessState, RowCallSplit, RowCard, SidebarRow,
     SidebarSubAgent, compose_channel,

--- a/crates/rimz/src/store/snapshot/mod.rs
+++ b/crates/rimz/src/store/snapshot/mod.rs
@@ -43,9 +43,7 @@ pub(crate) use panes::{
 pub use panes::{SidebarOwnView, pane_start_allows_bind, stamped_agent_for_pane};
 pub use process::pane_agent_kind;
 pub(crate) use process::pane_worktree_path;
-pub(crate) use process::{
-    command_is_sidebar_chrome, process_is_active, spawn_command_names_live_root,
-};
+pub(crate) use process::{command_is_sidebar_chrome, process_is_active};
 pub use row::{
     AgentCard, PaneAgent, ProcessCard, ProcessState, RowCallSplit, RowCard, SidebarRow,
     SidebarSubAgent, compose_channel,

--- a/crates/rimz/src/store/snapshot/process.rs
+++ b/crates/rimz/src/store/snapshot/process.rs
@@ -6,9 +6,7 @@ use jiff::Timestamp;
 use super::row::{ProcessCard, ProcessState, RowCard, SidebarRow};
 use crate::agents::registry::command_agent_kind;
 use crate::pane::PaneRef;
-use crate::proc::{
-    command_program_basename, program_label, rimz_exec_worktree_path, root_program_label,
-};
+use crate::proc::{command_program_basename, program_label, rimz_exec_worktree_path};
 
 /// Whether a pane no agent has bound carries enough identity to render a
 /// process row. Foreground display wins, but a spawn command also admits the
@@ -125,7 +123,7 @@ pub fn pane_agent_kind(pane: &PaneRef) -> Option<&'static str> {
         })
 }
 
-pub(crate) fn spawn_command_names_live_root(pane: &PaneRef) -> bool {
+fn spawn_command_names_live_root(pane: &PaneRef) -> bool {
     let Some(command) = pane
         .command
         .as_deref()
@@ -135,7 +133,8 @@ pub(crate) fn spawn_command_names_live_root(pane: &PaneRef) -> bool {
     };
     pane.spawn_command
         .as_deref()
-        .and_then(root_program_label)
+        .map(crate::proc::command::effective_program_info)
+        .map(|program| crate::proc::command::basename(program.root_program))
         .is_some_and(|spawn_program| program_label(command) == spawn_program)
 }
 

--- a/crates/rimz/src/store/snapshot/process.rs
+++ b/crates/rimz/src/store/snapshot/process.rs
@@ -6,7 +6,9 @@ use jiff::Timestamp;
 use super::row::{ProcessCard, ProcessState, RowCard, SidebarRow};
 use crate::agents::registry::command_agent_kind;
 use crate::pane::PaneRef;
-use crate::proc::{command_program_basename, program_label, rimz_exec_worktree_path};
+use crate::proc::{
+    command_program_basename, program_label, rimz_exec_worktree_path, root_program_label,
+};
 
 /// Whether a pane no agent has bound carries enough identity to render a
 /// process row. Foreground display wins, but a spawn command also admits the
@@ -101,17 +103,40 @@ pub(super) fn row_from_process(pane: &PaneRef, now: Timestamp) -> SidebarRow {
     }
 }
 
+/// Agent identity named by live foreground truth, then a producer-confirmed
+/// hosted process, and finally pane birth argv while its root program is still
+/// live. Birth argv comes last because muxes retain it after an agent returns
+/// to a shell.
 pub fn pane_agent_kind(pane: &PaneRef) -> Option<&'static str> {
-    pane.spawn_command
+    pane.command
         .as_deref()
         .and_then(command_agent_kind)
-        .or_else(|| pane.command.as_deref().and_then(command_agent_kind))
         .or_else(|| {
             pane.hosted_agent_kind
                 .as_ref()
                 .and_then(|kind| crate::agents::spec_by_kind(kind.as_str()))
                 .map(|definition| definition.kind)
         })
+        .or_else(|| {
+            pane.spawn_command
+                .as_deref()
+                .filter(|_| spawn_command_names_live_root(pane))
+                .and_then(command_agent_kind)
+        })
+}
+
+pub(crate) fn spawn_command_names_live_root(pane: &PaneRef) -> bool {
+    let Some(command) = pane
+        .command
+        .as_deref()
+        .filter(|command| !command.is_empty())
+    else {
+        return true;
+    };
+    pane.spawn_command
+        .as_deref()
+        .and_then(root_program_label)
+        .is_some_and(|spawn_program| program_label(command) == spawn_program)
 }
 
 fn display_command(pane: &PaneRef) -> Option<&str> {
@@ -176,6 +201,18 @@ mod tests {
         assert!(!process_is_active("sudo codex"));
         assert!(!process_is_active("zsh"));
         assert!(!process_is_active("nvim src/main.rs"));
+    }
+
+    #[test]
+    fn pane_agent_kind_drops_birth_identity_after_the_root_returns_to_shell() {
+        let mut pane = pane("%1", "zsh", "/repo");
+        pane.spawn_command = Some("/bin/rimz agents exec claude --worktree-path /repo".to_owned());
+
+        assert_eq!(pane_agent_kind(&pane), None);
+        pane.command = Some("rimz".to_owned());
+        assert_eq!(pane_agent_kind(&pane), Some("claude"));
+        pane.command = None;
+        assert_eq!(pane_agent_kind(&pane), Some("claude"));
     }
 
     #[test]

--- a/crates/rimz/src/store/snapshot/process.rs
+++ b/crates/rimz/src/store/snapshot/process.rs
@@ -118,24 +118,14 @@ pub fn pane_agent_kind(pane: &PaneRef) -> Option<&'static str> {
         .or_else(|| {
             pane.spawn_command
                 .as_deref()
-                .filter(|_| spawn_command_names_live_root(pane))
+                .filter(|_| {
+                    crate::proc::command::spawn_command_names_live_root(
+                        pane.command.as_deref(),
+                        pane.spawn_command.as_deref(),
+                    )
+                })
                 .and_then(command_agent_kind)
         })
-}
-
-fn spawn_command_names_live_root(pane: &PaneRef) -> bool {
-    let Some(command) = pane
-        .command
-        .as_deref()
-        .filter(|command| !command.is_empty())
-    else {
-        return true;
-    };
-    pane.spawn_command
-        .as_deref()
-        .map(crate::proc::command::effective_program_info)
-        .map(|program| crate::proc::command::basename(program.root_program))
-        .is_some_and(|spawn_program| program_label(command) == spawn_program)
 }
 
 fn display_command(pane: &PaneRef) -> Option<&str> {

--- a/crates/rimz/src/store/snapshot/view/tests/pane_binding/agent_binding.rs
+++ b/crates/rimz/src/store/snapshot/view/tests/pane_binding/agent_binding.rs
@@ -48,7 +48,11 @@ fn stamped_codex_returned_to_shell_without_hosted_process_renders_process_row() 
     let codex = agent("codex", "sess-1", AgentStatus::Running, 1_000)
         .worktree("/repo/main")
         .in_pane("%1");
-    let snapshot = room(vec![codex]).with_live_panes(vec![pane("%1", "zsh", "/repo/main")], None);
+    let returned = PaneRef {
+        spawn_command: Some("/bin/rimz agents exec codex --worktree-path /repo/main".to_owned()),
+        ..pane("%1", "zsh", "/repo/main")
+    };
+    let snapshot = room(vec![codex]).with_live_panes(vec![returned], None);
 
     let rows = rows(&snapshot);
     assert_eq!(rows.len(), 1);

--- a/crates/rimz/src/store/snapshot/view/tests/pane_binding/identity.rs
+++ b/crates/rimz/src/store/snapshot/view/tests/pane_binding/identity.rs
@@ -56,6 +56,21 @@ fn commandless_panes_require_an_agent_or_spawn_identity() {
 }
 
 #[test]
+fn wired_agent_birth_argv_does_not_outlive_a_shell_foreground() {
+    let returned = PaneRef {
+        spawn_command: Some("/bin/rimz agents exec claude --worktree-path /repo/main".to_owned()),
+        ..pane("%1", "zsh", "/repo/main")
+    };
+    let mut snapshot = room(Vec::new());
+    snapshot.wired_kinds = vec!["claude".to_owned()];
+    let snapshot = snapshot.with_live_panes(vec![returned], None);
+
+    assert_eq!(rows(&snapshot).len(), 1);
+    assert!(rows(&snapshot)[0].is_process());
+    assert_eq!(rows(&snapshot)[0].name, "zsh");
+}
+
+#[test]
 fn duplicate_pane_or_agent_id_projects_one_row_identity() {
     let claude = agent("claude", "sess-a", AgentStatus::Running, 1_000)
         .worktree("/repo/main")

--- a/crates/rimz/tests/integration/backend/tmux/agent_lifecycle.rs
+++ b/crates/rimz/tests/integration/backend/tmux/agent_lifecycle.rs
@@ -594,11 +594,6 @@ fn failing_close_pane_agent_drops_to_shell() {
             .is_some_and(|command| command.contains("agents exec codex")),
         "tmux should retain the agent wrapper as immutable birth argv: {live_pane:?}",
     );
-    assert!(
-        live_pane.hosted_agent_kind.is_none(),
-        "the exited agent must leave no hosted-process stamp: {live_pane:?}",
-    );
-
     let mut snapshot = rimz::store::snapshot::SidebarSnapshot::build_with_agents(
         workspace.workspace_id,
         Vec::new(),

--- a/crates/rimz/tests/integration/backend/tmux/agent_lifecycle.rs
+++ b/crates/rimz/tests/integration/backend/tmux/agent_lifecycle.rs
@@ -583,10 +583,36 @@ fn failing_close_pane_agent_drops_to_shell() {
         )
         .expect("send shell marker command");
     wait_for_path(&shell_marker, "dropped shell did not run marker command");
+    let live_pane = list_session_panes(&server, &workspace.session_name)
+        .into_iter()
+        .find(|pane| pane.pane_id == pane_id)
+        .expect("clean startup failure should leave the pane open as a shell");
     assert!(
-        list_session_panes(&server, &workspace.session_name)
-            .iter()
-            .any(|pane| pane.pane_id == pane_id),
-        "clean startup failure should leave the pane open as a shell"
+        live_pane
+            .spawn_command
+            .as_deref()
+            .is_some_and(|command| command.contains("agents exec codex")),
+        "tmux should retain the agent wrapper as immutable birth argv: {live_pane:?}",
+    );
+    assert!(
+        live_pane.hosted_agent_kind.is_none(),
+        "the exited agent must leave no hosted-process stamp: {live_pane:?}",
+    );
+
+    let mut snapshot = rimz::store::snapshot::SidebarSnapshot::build_with_agents(
+        workspace.workspace_id,
+        Vec::new(),
+        jiff::Timestamp::now(),
+    );
+    snapshot.wired_kinds = vec!["codex".to_owned()];
+    let snapshot = snapshot.with_live_panes(vec![live_pane.clone()], None);
+    let row = snapshot.rows().next().expect("shell process row");
+    assert!(
+        row.is_process(),
+        "stale birth argv must not synthesize an agent: {row:?}"
+    );
+    assert_eq!(
+        row.name,
+        live_pane.command.as_deref().expect("live shell command")
     );
 }

--- a/crates/rimz/tests/integration/sidebar_snapshot.rs
+++ b/crates/rimz/tests/integration/sidebar_snapshot.rs
@@ -8,7 +8,30 @@ use rimz::agents::{AgentLifecycleObservation, LaunchParams};
 use rimz::store::event::EventEnvelope;
 use sha2::{Digest, Sha256};
 
-use crate::common::Env;
+use crate::common::{Env, tmux_pane};
+
+#[test]
+fn agent_birth_argv_returned_to_shell_renders_process_row() {
+    let env = Env::new();
+    env.install_agent_hooks("claude");
+    let mut pane = tmux_pane("%7", "zsh", &env.project_root);
+    pane.spawn_command = Some(format!(
+        "{} agents exec claude --worktree-path {}",
+        env.rimz_bin().display(),
+        env.project_root.display(),
+    ));
+
+    let snapshot = env.snapshot_json_with_panes(&[pane]);
+    let rows = snapshot["worktree_groups"]
+        .as_array()
+        .expect("worktree groups")
+        .iter()
+        .flat_map(|group| group["rows"].as_array().expect("rows"));
+    let row = rows.into_iter().next().expect("shell process row");
+
+    assert_eq!(row["row_kind"], "process");
+    assert_eq!(row["name"], "zsh");
+}
 
 fn inject_lifecycle(env: &Env, agent_kind: &str, agent_id: &str) {
     let obs = AgentLifecycleObservation {

--- a/docs/internals/diagnostics.md
+++ b/docs/internals/diagnostics.md
@@ -62,7 +62,7 @@ The emitter is the triage pointer. Producer kinds describe pane-source truth, re
 | `pane_cache_divergence`, `sidebar_orphan_reaped`, `subagent_orphan_reaped`, `subagent_orphan_repair_failed` | `reload` / `sidebar repair` | A fresh pane cache omitted a sidebar process that authoritative mux truth proved alive; a sidebar reap after two authoritative omissions; or a subagent repair attempt after its parent stayed durably ended or absent beyond the wrapper watchdog window, including the repair error when pane reclamation failed |
 | `client_reaped` | `cli::room::attach_exec` | Stale mux clients killed during attach, with the killed pids, client counts before and after, and whether the reap settled or timed out |
 | `row_conflict`, `newborn_quarantined`, `group_migration`, `local_session_bind_rejected`, `ghost_session_bind` | `store::snapshot::view` | Duplicate agent identity suppression, newborn known-command unknown-cwd quarantine, cwd-driven pane moves, contained evidence-free/stale local-session rejections, and an old exact session stamp contradicted by a newer durable launch |
-| `frame_anomaly` | `sidebar::observe` writer thread | Detector verdicts on the rendered stream: flaps, oscillations, resets, per-frame consistency violations, and elder cross-checks, each carrying its detector key, evidence, frame stamp, and the writer's role |
+| `frame_anomaly` | `sidebar::observe` writer thread | Detector verdicts on the rendered stream: flaps, oscillations, resets, per-frame consistency violations, and elder cross-checks such as `dead_pid` and `agent_card_without_process`, each carrying its detector key, evidence, frame stamp, and the writer's role |
 | `mixed_build_writers` | `sidebar::produce::panes` | A prior published frame stamped by a different build than the producing process |
 | `topology_writer_changed`, `topology_write_rejected` | `sidebar::presence` | Zellij topology writer generation flips and rejected stale attempts, with plugin id, loaded-at generation, accepted writer, and reject count |
 
@@ -137,6 +137,7 @@ The writer thread re-verifies the latest roster against the world every `OBSERVE
 
 - **Cards fit the frame.** Every roster pane id appears in the published frame (`row_pane_missing_from_frame`), and the roster never exceeds the frame's pane count (`cards_exceed_panes`). The comparison runs only when the roster's fold stamp equals the frame's `produced_at_ms`, since a producer republish between fold and read is normal skew.
 - **PIDs are alive.** A row's pane pid is checked through the process backend with the start-time pid-reuse guard (`dead_pid`). A pid must stay dead across `OBSERVE_DEADPID_CONFIRMATIONS` (2) consecutive passes before it logs, so a just-exited process the next frame removes leaves no record. Platforms without process metrics skip the check.
+- **Agent cards host an agent.** An agent row whose live pane root authoritatively hosts no process of that kind logs `agent_card_without_process` after `OBSERVE_HOSTLESS_AGENT_CONFIRMATIONS` (2) consecutive passes. Unreadable or branching process trees are indeterminate and stay silent; dead roots remain `dead_pid`'s verdict.
 
 ### Roles and cost
 

--- a/docs/internals/multiplexers.md
+++ b/docs/internals/multiplexers.md
@@ -143,7 +143,7 @@ Rebirth re-pins on both backends, and resume tabs are ordinary layout panes, so 
 
 `list_panes` reports each pane's foreground command, optional spawn command, optional title, cwd, view, and id.
 
-The sidebar uses foreground for display, spawn for stable identity where present, and cwd for worktree grouping ([sidebar.md → presence model](./sidebar/sidebar.md#presence-model)). Foreground, title, and cwd are cross-backend. Spawn stays optional because Zellij omits it for panes created through `action new-pane`, while tmux exposes the static `pane_start_command`. **The parity floor for presence is command plus cwd**, which both backends meet.
+The sidebar uses foreground for display, spawn for identity only while the pane root still runs the spawn program (or foreground is temporarily unreported), and cwd for worktree grouping ([sidebar.md → presence model](./sidebar/sidebar.md#presence-model)). A foreground shell therefore demotes historical agent birth argv. Foreground, title, and cwd are cross-backend. Spawn stays optional because Zellij omits it for panes created through `action new-pane`, while tmux exposes the static `pane_start_command`. **The parity floor for presence is command plus cwd**, which both backends meet.
 
 Two Zellij-side wrinkles: the foreground and cwd fields are version-spanning ladders, so the adapter takes the first non-empty field across the names Zellij has emitted, and a layout-named `rimz-sidebar` pane always reports `rimz-sidebar` as its foreground so it filters as chrome even when Zellij omits the command fields.
 

--- a/refactor-target.toml
+++ b/refactor-target.toml
@@ -362,7 +362,7 @@ allowed-imports = [
     "ids",
     "pane",
 ]
-surface-budget = 94
+surface-budget = 95
 
 [[module]]
 path = "crates/rimz/src/reload.rs"


### PR DESCRIPTION
## Context

A supervised agent pane keeps rendering as an idle `○ claude` agent card long after the agent exits.
When `rimz agents exec claude …` finishes, the wrapper drops back to a shell in the same pane — same
pid, foreground now `zsh`, hosted-process stamp gone — but tmux's `pane_start_command` is immutable
and still reports the wrapper argv forever. `pane_agent_kind` consulted that birth argv **first and
unconditionally**, so history outranked every piece of live evidence and the sidebar kept routing
attention to an agent that was no longer there.

Reproduced 3/3 on a live session; the same fixture with and without `spawn_command` flips the row
between `name=claude row_kind=agent` and `name=zsh row_kind=process`.

Zellij's `terminal_command` carries identical staleness, so this was never a tmux-only defect.

## Design choices

**Fix the consumer, not the producer.** Rewriting `spawn_command` when an agent exits was rejected:
Zellij's topology has no root pid to read, and `spawn_command`'s advisory meaning is relied on across
~35 files. The producer already carries process truth in `hosted_agent_kind`; the bug was purely the
binder's ranking. One decision point, backend-neutral by construction.

**Birth argv is history, not liveness.** The classification ladder is now live foreground →
producer-confirmed hosted process → birth argv, with the last arm admitted only while the pane root
still runs what it was born with: either the foreground is unreported (raced-null, cold start) or its
program label still matches the spawn command's own root program (`rimz` under
`…/rimz agents exec claude …`). Any other foreground with no hosted stamp means the tenant changed.

`display_command`, `pane_command_is_known`, and `pane_worktree_path` are deliberately unchanged —
display and worktree fallback from spawn are still correct, because the returned shell keeps the
worktree.

**A black-box guard, not just a fix.** The elder observer now re-derives "does this pane root host an
agent process?" from `/proc` alone and compares it to what the renderer painted. It would have caught
this bug before the fix and stays as the standing guard after it.

## Implementation

- `store/snapshot/process.rs` — `pane_agent_kind` reordered, with the spawn arm gated by
  `spawn_command_names_live_root`. This is the single decision point; `stamped_agent_matches_live_pane`
  inherits the fix, so a stamped agent whose pane returned to a shell now unbinds.
- `sidebar/agent_projection.rs` — the same gate on `candidate_pane_agent_kind`, so provider-local
  session discovery does not probe Claude sessions for a shell pane.
- `proc/command.rs` — `EffectiveProgram::from_launcher: bool` becomes `root_program: &str`. The gate
  needs the *raw* pre-resolution program (compare `rimz` to `rimz`, not `claude` to `rimz`), and the
  boolean was derived state the callers can now compute. Behaviour-preserving: `rimz` is not a
  launcher, so every existing call site sees the same answer. The admission rule itself lives here as
  `spawn_command_names_live_root`, so both consumers share one copy.
- `sidebar/observe/` — new `agent_card_without_process` cross-check beside `dead_pid`, elder-only,
  every `OBSERVE_CROSSCHECK_TTL`. Requires two consecutive authoritative-absent observations, emits
  once per episode, re-arms on recovery. Strict by construction: unreadable or branching process trees
  are indeterminate and stay silent, and dead roots remain `dead_pid`'s verdict. Adds no mux call.
- Docs — `multiplexers.md` narrows "spawn for stable identity where present"; `diagnostics.md` gains
  the cross-check bullet and taxonomy entry; two drifted comments corrected (`produce/panes.rs` claimed
  tmux reports no spawn command — it has reported `pane_start_command` since that was wired).
- Tests — unit coverage for all three ladder outcomes; the existing
  `stamped_codex_returned_to_shell_without_hosted_process_renders_process_row` fixture given the real
  tmux shape it was missing (it passed only because it had no `spawn_command`); a wired/no-session case
  matching the field report; an out-of-process CLI proof through the `RIMZ_TEST_PANE_LIST` seam; and
  the live tmux lifecycle journey extended to assert tmux really does retain the wrapper argv after the
  drop to shell.

### Deviations from the plan

- **The plan located agent kind on `AgentCard`; it does not exist there.** `SidebarRow::name` is the
  provider kind for every agent row, and the codebase already round-trips it that way. The observer
  signatures therefore replace `is_agent: bool` with `agent_kind: Option<String>` as a single row-type
  signal rather than carrying a parallel boolean.
- **The `proc` atlas surface budget goes up by one (94 → 95).** The first implementation kept two
  private copies of the admission rule, because every candidate home was at exactly its surface
  budget. Review flagged the drift risk, and the budget was then raised on purpose so this liveness
  invariant has one home. The bump is its own decision, recorded in the commit message.
- **The live tmux proof is split across two tests.** The integration harness launches through
  `/usr/bin/env … rimz --mux tmux …`, so its start command never takes the production-classifiable
  `rimz agents exec …` shape. The journey proves the real exit-to-shell and immutable-start signals;
  the CLI fixture test drives the exact production field shape.

## Advisories

- **The live tmux journey bypasses `sidebar/produce`**, building its snapshot directly, so it proves
  tmux's birth-argv persistence plus the consumer demotion — not the producer's stamping path. This is
  the plan's sanctioned fallback and is fine as scoped, but no single test covers the end-to-end chain.
- **`proc` is again at exactly its surface budget (95/95)** after the deliberate bump. The next
  crate-visible item in that module needs its own budget decision.

Two earlier advisories were raised in review and are fixed on this branch: the duplicated admission
rule now has one home (see Deviations), and a constant-true assertion in the tmux journey — it read
`hosted_agent_kind.is_none()` on a `PaneRef` taken straight from `backend.list_panes`, where that
field is hard-coded `None` at the mux parse layer — was removed.

## Verification

`cargo xtask gate` — fmt, invariants, conform, docs-links, lint, and 5,896 tests, all green, run
independently at review, before and after the delta. `cargo xtask atlas conform --verbose` — 86 rules,
0 regressions.

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>forge</code> team · 3 agents · 1h03m active · $28.26 · 9 messages (3 from you)</summary>

- **planner** — Claude `claude-fable-5@high`
  - effort: 5m active · $4.59
  - calls: 19 tool calls
  - messages: 3 from you · 1 from teammates · 3 to teammates
  - tokens: 4.4k input, 23.5k output, 89k cache write, 1.6m cache read
- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 40m active · $18.36
  - calls: 118 tool calls
  - messages: 3 from teammates · 2 to teammates
  - tokens: 394.8k input, 57.7k output, 39.1m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 17m active · $5.30
  - calls: 67 tool calls
  - messages: 2 from teammates · 1 to teammates
  - tokens: 114 input, 46.7k output, 133.6k cache write, 5.6m cache read

</details>