### PR TITLE
feat(subagents): builtin `general` child spec and per-profile subagent allowlist

### DIFF
--- a/crates/rimz/src/cli/agents_cmd/mod.rs
+++ b/crates/rimz/src/cli/agents_cmd/mod.rs
@@ -576,6 +576,8 @@ pub fn run(args: AgentsArgs, globals: &GlobalFlags) -> Result<()> {
                 &config.agents.commands,
                 &sources,
                 rimz::config::effective::ProfileScope::Agents,
+                Vec::new(),
+                None,
                 json,
                 path,
             );

--- a/crates/rimz/src/cli/agents_cmd/mod.rs
+++ b/crates/rimz/src/cli/agents_cmd/mod.rs
@@ -572,12 +572,13 @@ pub fn run(args: AgentsArgs, globals: &GlobalFlags) -> Result<()> {
             let (config, sources) = rimz::config::MachineConfig::load_with_agent_spec_sources()
                 .context("loading machine config")?;
             return crate::cli::profile_report::list_profiles(
-                &config.agents.profiles,
-                &config.agents.commands,
-                &sources,
+                crate::cli::profile_report::available_profiles(
+                    &config.agents.profiles,
+                    &config.agents.commands,
+                    &sources,
+                    rimz::config::effective::ProfileScope::Agents,
+                ),
                 rimz::config::effective::ProfileScope::Agents,
-                Vec::new(),
-                None,
                 json,
                 path,
             );

--- a/crates/rimz/src/cli/agents_cmd/tests.rs
+++ b/crates/rimz/src/cli/agents_cmd/tests.rs
@@ -30,6 +30,7 @@ fn planner_profiles() -> ProfilesConfig {
         Profile {
             agent: "claude".to_owned(),
             description: None,
+            subagents: None,
             mode: None,
             model: None,
             effort: None,
@@ -73,6 +74,7 @@ fn agent_profiles_list_only_agent_profiles_with_descriptions() {
         Profile {
             agent: "claude".to_owned(),
             description: Some("Plans the main lane".to_owned()),
+            subagents: None,
             mode: None,
             model: None,
             effort: None,
@@ -87,6 +89,7 @@ fn agent_profiles_list_only_agent_profiles_with_descriptions() {
         Profile {
             agent: "codex".to_owned(),
             description: Some("Child profile".to_owned()),
+            subagents: None,
             mode: None,
             model: None,
             effort: None,
@@ -1061,6 +1064,7 @@ mod launch_options {
             rimz::config::Profile {
                 agent: "codex".to_owned(),
                 description: None,
+                subagents: None,
                 mode: None,
                 model: Some("declared".to_owned()),
                 effort: None,

--- a/crates/rimz/src/cli/complete.rs
+++ b/crates/rimz/src/cli/complete.rs
@@ -166,7 +166,12 @@ pub(crate) fn agent_specs() -> Vec<CompletionCandidate> {
 
 pub(crate) fn subagent_specs() -> Vec<CompletionCandidate> {
     let config = MachineConfig::load_lenient();
-    launch_specs_from(&config, &config.subagents.profiles)
+    let mut candidates = vec![candidate(
+        rimz::harness::subagent_policy::GENERAL_SPEC,
+        "builtin · caller's kind",
+    )];
+    candidates.extend(launch_specs_from(&config, &config.subagents.profiles));
+    candidates
 }
 
 pub(crate) fn team_names() -> Vec<CompletionCandidate> {
@@ -456,6 +461,15 @@ mod tests {
             !candidates
                 .iter()
                 .any(|candidate| candidate.get_value() == "writer")
+        );
+    }
+
+    #[test]
+    fn subagent_completion_starts_with_general() {
+        let candidates = subagent_specs();
+        assert_eq!(
+            candidates[0].get_value().to_string_lossy(),
+            rimz::harness::subagent_policy::GENERAL_SPEC
         );
     }
 

--- a/crates/rimz/src/cli/profile_report.rs
+++ b/crates/rimz/src/cli/profile_report.rs
@@ -70,7 +70,7 @@ pub(crate) fn general_report(caller: Option<&rimz::agents::AgentState>) -> Agent
         model: caller.and_then(|caller| caller.model.clone()),
         effort: caller.and_then(|caller| caller.effort.clone()),
         description: Some(
-            "General-purpose child of the caller's kind; inherits its model and effort unless overridden"
+            "General-purpose child of the caller's kind; inherits its current model and effort unless overridden"
                 .to_owned(),
         ),
         path: None,
@@ -302,10 +302,10 @@ mod tests {
 
         insta::assert_snapshot!(String::from_utf8(output).expect("utf-8"), @r"
         general — claude · opus · high
-          General-purpose child of the caller's kind; inherits its model and effort unless overridden
+          General-purpose child of the caller's kind; inherits its current model and effort unless overridden
 
         general — caller's kind
-          General-purpose child of the caller's kind; inherits its model and effort unless overridden
+          General-purpose child of the caller's kind; inherits its current model and effort unless overridden
         ");
         assert_eq!(reports[0].source, "builtin");
     }

--- a/crates/rimz/src/cli/profile_report.rs
+++ b/crates/rimz/src/cli/profile_report.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 
 use super::render;
 use rimz::config::effective::ProfileScope;
+use rimz::harness::subagent_policy::GENERAL_SPEC;
 
 #[derive(Debug, PartialEq, Eq, Serialize)]
 pub(crate) struct AgentProfileReport {
@@ -59,6 +60,30 @@ pub(crate) fn available_profiles(
     reports
 }
 
+pub(crate) fn general_report(caller: Option<&rimz::agents::AgentState>) -> AgentProfileReport {
+    let kind = caller.map(|caller| caller.kind.to_string());
+    AgentProfileReport {
+        name: GENERAL_SPEC.to_owned(),
+        source: "builtin",
+        brand_kind: kind.clone(),
+        agent: kind,
+        model: caller.and_then(|caller| caller.model.clone()),
+        effort: caller.and_then(|caller| caller.effort.clone()),
+        description: Some(
+            "General-purpose child of the caller's kind; inherits its model and effort unless overridden"
+                .to_owned(),
+        ),
+        path: None,
+    }
+}
+
+pub(crate) fn retain_allowed(reports: &mut Vec<AgentProfileReport>, allowed: Option<&[String]>) {
+    let Some(allowed) = allowed else {
+        return;
+    };
+    reports.retain(|report| allowed.contains(&report.name));
+}
+
 fn provider_brand_kind<'a>(
     raw_agent: &'a str,
     profiles: &'a rimz::config::ProfilesConfig,
@@ -87,10 +112,14 @@ pub(crate) fn list_profiles(
     commands: &rimz::config::CommandsConfig,
     sources: &rimz::config::AgentSpecSources,
     scope: ProfileScope,
+    prepend: Vec<AgentProfileReport>,
+    allowed: Option<&[String]>,
     json: bool,
     show_path: bool,
 ) -> Result<()> {
     let mut reports = available_profiles(profiles, commands, sources, scope);
+    reports.splice(0..0, prepend);
+    retain_allowed(&mut reports, allowed);
     apply_path_visibility(&mut reports, show_path);
     if json {
         return render::json_pretty(&reports);
@@ -137,6 +166,7 @@ fn profile_cards(
                 let brand_kind = report.brand_kind.as_deref().unwrap_or(agent);
                 (render::palette::identity(brand_kind).bold(), segments)
             }
+            None if report.source == "builtin" => (render::palette::muted(), vec!["caller's kind"]),
             None => (render::palette::muted(), vec!["command"]),
         };
         writeln!(
@@ -262,6 +292,72 @@ mod tests {
     }
 
     #[test]
+    fn general_report_uses_caller_identity_or_labels_the_unknown_kind() {
+        let mut caller =
+            rimz::agents::AgentState::stub("claude", "caller", rimz::agents::AgentStatus::Running);
+        caller.model = Some("opus".to_owned());
+        caller.effort = Some("high".to_owned());
+        let reports = [general_report(Some(&caller)), general_report(None)];
+        let mut output = Vec::new();
+
+        profile_cards(
+            &reports,
+            ProfileScope::Subagents,
+            &mut anstream::StripStream::new(&mut output),
+        )
+        .expect("render general cards");
+
+        insta::assert_snapshot!(String::from_utf8(output).expect("utf-8"), @r"
+        general — claude · opus · high
+          General-purpose child of the caller's kind; inherits its model and effort unless overridden
+
+        general — caller's kind
+          General-purpose child of the caller's kind; inherits its model and effort unless overridden
+        ");
+        assert_eq!(reports[0].source, "builtin");
+    }
+
+    #[test]
+    fn profile_allowlist_filters_builtin_profiles_and_commands() {
+        let mut reports = vec![
+            general_report(None),
+            AgentProfileReport {
+                name: "explorer".to_owned(),
+                source: "profile",
+                brand_kind: Some("claude".to_owned()),
+                agent: Some("claude".to_owned()),
+                model: None,
+                effort: None,
+                description: None,
+                path: None,
+            },
+            AgentProfileReport {
+                name: "lint".to_owned(),
+                source: "command",
+                brand_kind: None,
+                agent: None,
+                model: None,
+                effort: None,
+                description: None,
+                path: None,
+            },
+        ];
+
+        retain_allowed(
+            &mut reports,
+            Some(&["general".to_owned(), "lint".to_owned()]),
+        );
+
+        assert_eq!(
+            reports
+                .iter()
+                .map(|report| report.name.as_str())
+                .collect::<Vec<_>>(),
+            ["general", "lint"]
+        );
+    }
+
+    #[test]
     fn chained_profiles_resolve_the_provider_for_brand_tint() {
         let profiles = rimz::config::ProfilesConfig(
             [
@@ -309,6 +405,7 @@ mod tests {
         rimz::config::Profile {
             agent: agent.to_owned(),
             description: None,
+            subagents: None,
             mode: None,
             model: None,
             effort: None,

--- a/crates/rimz/src/cli/profile_report.rs
+++ b/crates/rimz/src/cli/profile_report.rs
@@ -108,18 +108,11 @@ fn provider_brand_kind<'a>(
 }
 
 pub(crate) fn list_profiles(
-    profiles: &rimz::config::ProfilesConfig,
-    commands: &rimz::config::CommandsConfig,
-    sources: &rimz::config::AgentSpecSources,
+    mut reports: Vec<AgentProfileReport>,
     scope: ProfileScope,
-    prepend: Vec<AgentProfileReport>,
-    allowed: Option<&[String]>,
     json: bool,
     show_path: bool,
 ) -> Result<()> {
-    let mut reports = available_profiles(profiles, commands, sources, scope);
-    reports.splice(0..0, prepend);
-    retain_allowed(&mut reports, allowed);
     apply_path_visibility(&mut reports, show_path);
     if json {
         return render::json_pretty(&reports);

--- a/crates/rimz/src/cli/subagents/mod.rs
+++ b/crates/rimz/src/cli/subagents/mod.rs
@@ -186,7 +186,7 @@ pub fn run(args: SubagentsArgs, globals: &GlobalFlags) -> Result<()> {
         Some(SubagentsSubcmd::Launch(args)) => launch_child(args.launch, args.json, globals),
         Some(SubagentsSubcmd::Fanout(fanout)) => fanout_children(fanout, globals),
         Some(SubagentsSubcmd::List { json }) => list_children(json, globals),
-        Some(SubagentsSubcmd::Profiles { json, path }) => list_profiles(json, path),
+        Some(SubagentsSubcmd::Profiles { json, path }) => list_profiles(json, path, globals),
         Some(SubagentsSubcmd::Wait {
             names,
             any,
@@ -554,14 +554,41 @@ fn list_children(json: bool, globals: &GlobalFlags) -> Result<()> {
     table.render(&mut render::out()).map_err(Into::into)
 }
 
-fn list_profiles(json: bool, path: bool) -> Result<()> {
+fn list_profiles(json: bool, path: bool, globals: &GlobalFlags) -> Result<()> {
     let (config, sources) = rimz::config::MachineConfig::load_with_agent_spec_sources()
         .context("loading machine config")?;
-    crate::cli::profile_report::list_profiles(
+    if !crate::cli::send::agent_caller() {
+        return crate::cli::profile_report::list_profiles(
+            &config.subagents.profiles,
+            &config.agents.commands,
+            &sources,
+            rimz::config::effective::ProfileScope::Subagents,
+            vec![crate::cli::profile_report::general_report(None)],
+            None,
+            json,
+            path,
+        );
+    }
+    let ctx = Ctx::open(globals)?;
+    let projection = ctx
+        .store
+        .runtime_projection(rimz::RuntimeScope::Audit)
+        .context("reading agent history")?;
+    let caller = rimz::harness::ancestry::resolve_launch_caller_from_env(&projection.agents)?;
+    let effective = rimz::config::effective::load(
+        &config.agents,
         &config.subagents.profiles,
+        &ctx.workspace.project_root,
+        &rimz::store::paths::config_home(),
+    )?;
+    let allowed = rimz::harness::subagent_policy::allowed_specs(caller, &effective.profiles);
+    crate::cli::profile_report::list_profiles(
+        &effective.subagent_profiles,
         &config.agents.commands,
         &sources,
         rimz::config::effective::ProfileScope::Subagents,
+        vec![crate::cli::profile_report::general_report(Some(caller))],
+        allowed,
         json,
         path,
     )

--- a/crates/rimz/src/cli/subagents/mod.rs
+++ b/crates/rimz/src/cli/subagents/mod.rs
@@ -555,44 +555,43 @@ fn list_children(json: bool, globals: &GlobalFlags) -> Result<()> {
 }
 
 fn list_profiles(json: bool, path: bool, globals: &GlobalFlags) -> Result<()> {
-    let (config, sources) = rimz::config::MachineConfig::load_with_agent_spec_sources()
+    let (config, mut sources) = rimz::config::MachineConfig::load_with_agent_spec_sources()
         .context("loading machine config")?;
-    if !crate::cli::send::agent_caller() {
-        let mut reports = crate::cli::profile_report::available_profiles(
-            &config.subagents.profiles,
-            &config.agents.commands,
-            &sources,
-            rimz::config::effective::ProfileScope::Subagents,
-        );
-        reports.insert(0, crate::cli::profile_report::general_report(None));
-        return crate::cli::profile_report::list_profiles(
-            reports,
-            rimz::config::effective::ProfileScope::Subagents,
-            json,
-            path,
-        );
-    }
-    let ctx = Ctx::open(globals)?;
-    let projection = ctx
-        .store
-        .runtime_projection(rimz::RuntimeScope::Audit)
-        .context("reading agent history")?;
-    let caller = rimz::harness::ancestry::resolve_launch_caller_from_env(&projection.agents)?;
+    let (project_root, caller) = if crate::cli::send::agent_caller() {
+        let ctx = Ctx::open(globals)?;
+        let projection = ctx
+            .store
+            .runtime_projection(rimz::RuntimeScope::Audit)
+            .context("reading agent history")?;
+        let caller =
+            rimz::harness::ancestry::resolve_launch_caller_from_env(&projection.agents)?.clone();
+        (ctx.workspace.project_root, Some(caller))
+    } else {
+        let workspace = rimz::WorkspaceResolver::resolve(".", globals.root.clone())
+            .context("resolving current project")?;
+        (workspace.project_root, None)
+    };
     let effective = rimz::config::effective::load(
         &config.agents,
         &config.subagents.profiles,
-        &ctx.workspace.project_root,
+        &project_root,
         &rimz::store::paths::config_home(),
     )?;
-    let allowed = rimz::harness::subagent_policy::allowed_specs(caller, &effective.profiles);
+    effective.overlay_profile_sources(&mut sources);
     let mut reports = crate::cli::profile_report::available_profiles(
         &effective.subagent_profiles,
         &config.agents.commands,
         &sources,
         rimz::config::effective::ProfileScope::Subagents,
     );
-    reports.insert(0, crate::cli::profile_report::general_report(Some(caller)));
-    crate::cli::profile_report::retain_allowed(&mut reports, allowed);
+    reports.insert(
+        0,
+        crate::cli::profile_report::general_report(caller.as_ref()),
+    );
+    if let Some(caller) = caller.as_ref() {
+        let allowed = rimz::harness::subagent_policy::allowed_specs(caller, &effective.profiles);
+        crate::cli::profile_report::retain_allowed(&mut reports, allowed);
+    }
     crate::cli::profile_report::list_profiles(
         reports,
         rimz::config::effective::ProfileScope::Subagents,

--- a/crates/rimz/src/cli/subagents/mod.rs
+++ b/crates/rimz/src/cli/subagents/mod.rs
@@ -558,13 +558,16 @@ fn list_profiles(json: bool, path: bool, globals: &GlobalFlags) -> Result<()> {
     let (config, sources) = rimz::config::MachineConfig::load_with_agent_spec_sources()
         .context("loading machine config")?;
     if !crate::cli::send::agent_caller() {
-        return crate::cli::profile_report::list_profiles(
+        let mut reports = crate::cli::profile_report::available_profiles(
             &config.subagents.profiles,
             &config.agents.commands,
             &sources,
             rimz::config::effective::ProfileScope::Subagents,
-            vec![crate::cli::profile_report::general_report(None)],
-            None,
+        );
+        reports.insert(0, crate::cli::profile_report::general_report(None));
+        return crate::cli::profile_report::list_profiles(
+            reports,
+            rimz::config::effective::ProfileScope::Subagents,
             json,
             path,
         );
@@ -582,13 +585,17 @@ fn list_profiles(json: bool, path: bool, globals: &GlobalFlags) -> Result<()> {
         &rimz::store::paths::config_home(),
     )?;
     let allowed = rimz::harness::subagent_policy::allowed_specs(caller, &effective.profiles);
-    crate::cli::profile_report::list_profiles(
+    let mut reports = crate::cli::profile_report::available_profiles(
         &effective.subagent_profiles,
         &config.agents.commands,
         &sources,
         rimz::config::effective::ProfileScope::Subagents,
-        vec![crate::cli::profile_report::general_report(Some(caller))],
-        allowed,
+    );
+    reports.insert(0, crate::cli::profile_report::general_report(Some(caller)));
+    crate::cli::profile_report::retain_allowed(&mut reports, allowed);
+    crate::cli::profile_report::list_profiles(
+        reports,
+        rimz::config::effective::ProfileScope::Subagents,
         json,
         path,
     )

--- a/crates/rimz/src/cli/subagents/tests.rs
+++ b/crates/rimz/src/cli/subagents/tests.rs
@@ -318,6 +318,7 @@ fn available_profiles_include_profiles_and_commands_but_not_kinds_or_teams() {
         rimz::config::Profile {
             agent: "claude".to_owned(),
             description: None,
+            subagents: None,
             mode: None,
             model: None,
             effort: None,
@@ -332,6 +333,7 @@ fn available_profiles_include_profiles_and_commands_but_not_kinds_or_teams() {
         rimz::config::Profile {
             agent: "claude".to_owned(),
             description: Some("Plans supervised work".to_owned()),
+            subagents: None,
             mode: None,
             model: Some("fable".to_owned()),
             effort: Some("high".to_owned()),
@@ -346,6 +348,7 @@ fn available_profiles_include_profiles_and_commands_but_not_kinds_or_teams() {
         rimz::config::Profile {
             agent: "claude".to_owned(),
             description: None,
+            subagents: None,
             mode: None,
             model: None,
             effort: None,

--- a/crates/rimz/src/cli/supervised/run.rs
+++ b/crates/rimz/src/cli/supervised/run.rs
@@ -68,7 +68,7 @@ pub(super) fn prepare_supervised_launch_layout(
     workspace: &rimz::ResolvedWorkspace,
     machine_config: &rimz::config::MachineConfig,
     scope: rimz::config::effective::ProfileScope,
-    inherited: Option<&rimz::harness::subagent_policy::GeneralLaunch>,
+    inherited: Option<&rimz::agents::LaunchPreset>,
 ) -> Result<rimz::harness::plan::ResolvedLaunch> {
     let effective = rimz::config::effective::load(
         &machine_config.agents,
@@ -426,9 +426,9 @@ fn prepare_supervised(
             request.agent.as_deref(),
         )?;
         if spec.trim() == rimz::harness::subagent_policy::GENERAL_SPEC {
-            let general = rimz::harness::subagent_policy::general_launch(caller);
-            spec = Cow::Owned(general.kind.to_string());
-            inherited = Some(general);
+            let (kind, preset) = rimz::harness::subagent_policy::general_launch(caller);
+            spec = Cow::Owned(kind.to_string());
+            inherited = Some(preset);
         }
     }
     let lane = request

--- a/crates/rimz/src/cli/supervised/run.rs
+++ b/crates/rimz/src/cli/supervised/run.rs
@@ -93,25 +93,20 @@ pub(super) fn prepare_supervised_launch_layout(
         &machine_config.agents.commands,
         &effective.teams,
     )?;
-    let inherit_model = inherited.is_some_and(|(caller_kind, _)| {
-        resolved
-            .layout
-            .agent_cells()
-            .next()
-            .is_some_and(|cell| &cell.kind == caller_kind)
-    });
+    let inherited = inherited
+        .filter(|(caller_kind, _)| {
+            resolved
+                .layout
+                .agent_cells()
+                .next()
+                .is_some_and(|cell| &cell.kind == caller_kind)
+        })
+        .map(|(_, preset)| preset);
     let preset = rimz::agents::LaunchPreset {
-        model: rimz::harness::plan::normalized_preset_value(request.model.as_deref()).or_else(
-            || {
-                if inherit_model {
-                    inherited.and_then(|(_, launch)| launch.model.clone())
-                } else {
-                    None
-                }
-            },
-        ),
+        model: rimz::harness::plan::normalized_preset_value(request.model.as_deref())
+            .or_else(|| inherited.and_then(|preset| preset.model.clone())),
         effort: rimz::harness::plan::normalized_preset_value(request.effort.as_deref())
-            .or_else(|| inherited.and_then(|(_, launch)| launch.effort.clone())),
+            .or_else(|| inherited.and_then(|preset| preset.effort.clone())),
         system_prompt_file: request.system_prompt_file.clone(),
         append_system_prompt_files: request.append_system_prompt_files.clone(),
     };

--- a/crates/rimz/src/cli/supervised/run.rs
+++ b/crates/rimz/src/cli/supervised/run.rs
@@ -68,7 +68,7 @@ pub(super) fn prepare_supervised_launch_layout(
     workspace: &rimz::ResolvedWorkspace,
     machine_config: &rimz::config::MachineConfig,
     scope: rimz::config::effective::ProfileScope,
-    inherited: Option<&rimz::agents::LaunchPreset>,
+    inherited: Option<&(AgentKind, rimz::agents::LaunchPreset)>,
 ) -> Result<rimz::harness::plan::ResolvedLaunch> {
     let effective = rimz::config::effective::load(
         &machine_config.agents,
@@ -90,11 +90,25 @@ pub(super) fn prepare_supervised_launch_layout(
         &machine_config.agents.commands,
         &effective.teams,
     )?;
+    let inherit_model = inherited.is_some_and(|(caller_kind, _)| {
+        resolved
+            .layout
+            .agent_cells()
+            .next()
+            .is_some_and(|cell| &cell.kind == caller_kind)
+    });
     let preset = rimz::agents::LaunchPreset {
-        model: rimz::harness::plan::normalized_preset_value(request.model.as_deref())
-            .or_else(|| inherited.and_then(|launch| launch.model.clone())),
+        model: rimz::harness::plan::normalized_preset_value(request.model.as_deref()).or_else(
+            || {
+                if inherit_model {
+                    inherited.and_then(|(_, launch)| launch.model.clone())
+                } else {
+                    None
+                }
+            },
+        ),
         effort: rimz::harness::plan::normalized_preset_value(request.effort.as_deref())
-            .or_else(|| inherited.and_then(|launch| launch.effort.clone())),
+            .or_else(|| inherited.and_then(|(_, launch)| launch.effort.clone())),
         system_prompt_file: request.system_prompt_file.clone(),
         append_system_prompt_files: request.append_system_prompt_files.clone(),
     };
@@ -117,6 +131,36 @@ pub(super) fn prepare_supervised_launch_layout(
         writeln!(std::io::stderr(), "{warning}")?;
     }
     Ok(resolved)
+}
+
+pub(super) fn prepare_supervised_selection<'a>(
+    request: &'a SupervisedRunRequest,
+    caller: Option<&rimz::agents::AgentState>,
+    profiles: &rimz::config::ProfilesConfig,
+) -> Result<(
+    Cow<'a, str>,
+    Option<(AgentKind, rimz::agents::LaunchPreset)>,
+)> {
+    let mut spec = Cow::Borrowed(request.spec.as_str());
+    let mut inherited = None;
+    if !request.subagent {
+        return Ok((spec, inherited));
+    }
+    let Some(caller) = caller else {
+        return Ok((spec, inherited));
+    };
+    rimz::harness::subagent_policy::check_allowed(
+        caller,
+        profiles,
+        &spec,
+        request.agent.as_deref(),
+    )?;
+    if spec.trim() == rimz::harness::subagent_policy::GENERAL_SPEC {
+        let general = rimz::harness::subagent_policy::general_launch(caller);
+        spec = Cow::Owned(general.0.to_string());
+        inherited = Some(general);
+    }
+    Ok((spec, inherited))
 }
 
 pub(in crate::cli) fn run_print(
@@ -414,23 +458,7 @@ fn prepare_supervised(
     } else {
         rimz::config::effective::ProfileScope::Agents
     };
-    let mut spec = Cow::Borrowed(request.spec.as_str());
-    let mut inherited = None;
-    if request.subagent
-        && let Some(caller) = caller
-    {
-        rimz::harness::subagent_policy::check_allowed(
-            caller,
-            &effective.profiles,
-            &spec,
-            request.agent.as_deref(),
-        )?;
-        if spec.trim() == rimz::harness::subagent_policy::GENERAL_SPEC {
-            let (kind, preset) = rimz::harness::subagent_policy::general_launch(caller);
-            spec = Cow::Owned(kind.to_string());
-            inherited = Some(preset);
-        }
-    }
+    let (mut spec, inherited) = prepare_supervised_selection(request, caller, &effective.profiles)?;
     let lane = request
         .channel
         .clone()

--- a/crates/rimz/src/cli/supervised/run.rs
+++ b/crates/rimz/src/cli/supervised/run.rs
@@ -18,6 +18,9 @@ use std::borrow::Cow;
 use std::io::{IsTerminal as _, Write as _};
 use std::sync::Arc;
 
+pub(super) type InheritedLaunch = (AgentKind, rimz::agents::LaunchPreset);
+pub(super) type SupervisedSelection<'a> = (Cow<'a, str>, Option<InheritedLaunch>);
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum RunPlacement {
     Split,
@@ -68,7 +71,7 @@ pub(super) fn prepare_supervised_launch_layout(
     workspace: &rimz::ResolvedWorkspace,
     machine_config: &rimz::config::MachineConfig,
     scope: rimz::config::effective::ProfileScope,
-    inherited: Option<&(AgentKind, rimz::agents::LaunchPreset)>,
+    inherited: Option<&InheritedLaunch>,
 ) -> Result<rimz::harness::plan::ResolvedLaunch> {
     let effective = rimz::config::effective::load(
         &machine_config.agents,
@@ -137,10 +140,7 @@ pub(super) fn prepare_supervised_selection<'a>(
     request: &'a SupervisedRunRequest,
     caller: Option<&rimz::agents::AgentState>,
     profiles: &rimz::config::ProfilesConfig,
-) -> Result<(
-    Cow<'a, str>,
-    Option<(AgentKind, rimz::agents::LaunchPreset)>,
-)> {
+) -> Result<SupervisedSelection<'a>> {
     let mut spec = Cow::Borrowed(request.spec.as_str());
     let mut inherited = None;
     if !request.subagent {

--- a/crates/rimz/src/cli/supervised/run.rs
+++ b/crates/rimz/src/cli/supervised/run.rs
@@ -67,6 +67,8 @@ pub(super) fn prepare_supervised_launch_layout(
     spec: &str,
     workspace: &rimz::ResolvedWorkspace,
     machine_config: &rimz::config::MachineConfig,
+    scope: rimz::config::effective::ProfileScope,
+    inherited: Option<&rimz::harness::subagent_policy::GeneralLaunch>,
 ) -> Result<rimz::harness::plan::ResolvedLaunch> {
     let effective = rimz::config::effective::load(
         &machine_config.agents,
@@ -74,11 +76,6 @@ pub(super) fn prepare_supervised_launch_layout(
         &workspace.project_root,
         &rimz::store::paths::config_home(),
     )?;
-    let scope = if request.subagent {
-        rimz::config::effective::ProfileScope::Subagents
-    } else {
-        rimz::config::effective::ProfileScope::Agents
-    };
     let mut resolved = rimz::harness::plan::resolve_launch(
         &effective,
         scope,
@@ -94,8 +91,10 @@ pub(super) fn prepare_supervised_launch_layout(
         &effective.teams,
     )?;
     let preset = rimz::agents::LaunchPreset {
-        model: rimz::harness::plan::normalized_preset_value(request.model.as_deref()),
-        effort: rimz::harness::plan::normalized_preset_value(request.effort.as_deref()),
+        model: rimz::harness::plan::normalized_preset_value(request.model.as_deref())
+            .or_else(|| inherited.and_then(|launch| launch.model.clone())),
+        effort: rimz::harness::plan::normalized_preset_value(request.effort.as_deref())
+            .or_else(|| inherited.and_then(|launch| launch.effort.clone())),
         system_prompt_file: request.system_prompt_file.clone(),
         append_system_prompt_files: request.append_system_prompt_files.clone(),
     };
@@ -396,34 +395,72 @@ fn prepare_supervised(
         &workspace.project_root,
         &rimz::store::paths::config_home(),
     )?;
-    let lane = request
-        .channel
-        .clone()
-        .or_else(|| crate::cli::current_channel(&workspace));
-    let mut spec = Cow::Borrowed(request.spec.as_str());
-    let mut inferred_lane = None;
+    let projection = rimz::harness::ancestry::launch_ancestry_required()
+        .then(|| store.runtime_projection(rimz::RuntimeScope::Audit))
+        .transpose()?;
+    let caller = projection
+        .as_ref()
+        .map(|projection| {
+            rimz::harness::ancestry::resolve_launch_caller_from_env(&projection.agents)
+        })
+        .transpose()?;
+    let ancestry = rimz::harness::ancestry::resolve_launch_ancestry(
+        caller,
+        request.subagent,
+        machine_config.agents.max_chain_length,
+    )?;
     let scope = if request.subagent {
         rimz::config::effective::ProfileScope::Subagents
     } else {
         rimz::config::effective::ProfileScope::Agents
     };
+    let mut spec = Cow::Borrowed(request.spec.as_str());
+    let mut inherited = None;
+    if request.subagent
+        && let Some(caller) = caller
+    {
+        rimz::harness::subagent_policy::check_allowed(
+            caller,
+            &effective.profiles,
+            &spec,
+            request.agent.as_deref(),
+        )?;
+        if spec.trim() == rimz::harness::subagent_policy::GENERAL_SPEC {
+            let general = rimz::harness::subagent_policy::general_launch(caller);
+            spec = Cow::Owned(general.kind.to_string());
+            inherited = Some(general);
+        }
+    }
+    let lane = request
+        .channel
+        .clone()
+        .or_else(|| crate::cli::current_channel(&workspace));
+    let mut inferred_lane = None;
     if let Some(channel) = lane.as_deref() {
         let snapshot = store.snapshot_cached().context("reading agent snapshot")?;
         if let Some(team) = rimz::harness::target::channel_team(&snapshot.agents, channel) {
-            spec = rimz::harness::spec::qualify_spec_in_channel(
-                &request.spec,
+            let qualified = rimz::harness::spec::qualify_spec_in_channel(
+                &spec,
                 channel,
                 team,
                 &effective.teams,
                 effective.profiles_for(scope),
                 &machine_config.agents.commands,
             )?;
-            if matches!(spec, Cow::Owned(_)) {
+            if let Cow::Owned(qualified) = qualified {
+                spec = Cow::Owned(qualified);
                 inferred_lane = Some(channel.to_owned());
             }
         }
     }
-    let resolved = prepare_supervised_launch_layout(request, &spec, &workspace, &machine_config)?;
+    let resolved = prepare_supervised_launch_layout(
+        request,
+        &spec,
+        &workspace,
+        &machine_config,
+        scope,
+        inherited.as_ref(),
+    )?;
     let team_name = resolved.team_name;
     let layout = resolved.layout;
     let agent_cells = layout.agent_cells().collect::<Vec<_>>();
@@ -437,16 +474,6 @@ fn prepare_supervised(
     let adapter = rimz::agents::find_definition(&agent_cell.kind)
         .ok_or_else(|| anyhow::anyhow!("unknown agent kind `{}`", agent_cell.kind))?;
     let prompt = supervised_prompt(request, adapter);
-    let ancestry = if rimz::harness::ancestry::launch_ancestry_required() {
-        let projection = store.runtime_projection(rimz::RuntimeScope::Audit)?;
-        rimz::harness::ancestry::resolve_launch_ancestry_from_env(
-            &projection.agents,
-            request.subagent,
-            machine_config.agents.max_chain_length,
-        )?
-    } else {
-        None
-    };
     let worktree_launch = request.worktree.is_some() || request.from_pr.is_some();
     if worktree_launch && !crate::cli::confirm_cross_repo_worktree(&workspace)? {
         return Ok(None);

--- a/crates/rimz/src/cli/supervised/tests.rs
+++ b/crates/rimz/src/cli/supervised/tests.rs
@@ -311,9 +311,9 @@ fn general_inheritance_is_a_preset_below_explicit_overrides() {
 }
 
 #[test]
-fn general_cross_kind_rebase_drops_current_model_but_keeps_effort() {
+fn general_cross_kind_rebase_drops_current_model_and_effort() {
     let mut request = supervised_request("fix-it", true);
-    request.agent = Some("codex".to_owned());
+    request.agent = Some("cursor".to_owned());
     let dir = tempfile::tempdir().expect("temp dir");
     let workspace =
         rimz::workspace::WorkspaceResolver::resolve(dir.path(), None).expect("resolve workspace");
@@ -339,9 +339,9 @@ fn general_cross_kind_rebase_drops_current_model_but_keeps_effort() {
     .layout;
     let cell = prepared.agent_cells().next().expect("agent cell");
 
-    assert_eq!(cell.kind.as_str(), "codex");
-    assert_eq!(cell.launch.model.as_deref(), Some("gpt-5.5-codex"));
-    assert_eq!(cell.launch.effort.as_deref(), Some("high"));
+    assert_eq!(cell.kind.as_str(), "cursor");
+    assert_eq!(cell.launch.model, None);
+    assert_eq!(cell.launch.effort, None);
 }
 
 #[test]

--- a/crates/rimz/src/cli/supervised/tests.rs
+++ b/crates/rimz/src/cli/supervised/tests.rs
@@ -284,10 +284,11 @@ fn general_inheritance_is_a_preset_below_explicit_overrides() {
     let dir = tempfile::tempdir().expect("temp dir");
     let workspace =
         rimz::workspace::WorkspaceResolver::resolve(dir.path(), None).expect("resolve workspace");
-    let inherited = rimz::harness::subagent_policy::GeneralLaunch {
-        kind: rimz::ids::AgentKind::new_unchecked("claude"),
+    let inherited = rimz::agents::LaunchPreset {
         model: Some("opus".to_owned()),
         effort: Some("high".to_owned()),
+        system_prompt_file: None,
+        append_system_prompt_files: Vec::new(),
     };
 
     let prepared = super::run::prepare_supervised_launch_layout(

--- a/crates/rimz/src/cli/supervised/tests.rs
+++ b/crates/rimz/src/cli/supervised/tests.rs
@@ -284,12 +284,15 @@ fn general_inheritance_is_a_preset_below_explicit_overrides() {
     let dir = tempfile::tempdir().expect("temp dir");
     let workspace =
         rimz::workspace::WorkspaceResolver::resolve(dir.path(), None).expect("resolve workspace");
-    let inherited = rimz::agents::LaunchPreset {
-        model: Some("opus".to_owned()),
-        effort: Some("high".to_owned()),
-        system_prompt_file: None,
-        append_system_prompt_files: Vec::new(),
-    };
+    let inherited = (
+        AgentKind::new_unchecked("claude"),
+        rimz::agents::LaunchPreset {
+            model: Some("opus".to_owned()),
+            effort: Some("high".to_owned()),
+            system_prompt_file: None,
+            append_system_prompt_files: Vec::new(),
+        },
+    );
 
     let prepared = super::run::prepare_supervised_launch_layout(
         &request,
@@ -305,6 +308,72 @@ fn general_inheritance_is_a_preset_below_explicit_overrides() {
 
     assert_eq!(cell.launch.model.as_deref(), Some("opus"));
     assert_eq!(cell.launch.effort.as_deref(), Some("low"));
+}
+
+#[test]
+fn general_cross_kind_rebase_drops_current_model_but_keeps_effort() {
+    let mut request = supervised_request("fix-it", true);
+    request.agent = Some("codex".to_owned());
+    let dir = tempfile::tempdir().expect("temp dir");
+    let workspace =
+        rimz::workspace::WorkspaceResolver::resolve(dir.path(), None).expect("resolve workspace");
+    let inherited = (
+        AgentKind::new_unchecked("claude"),
+        rimz::agents::LaunchPreset {
+            model: Some("opus".to_owned()),
+            effort: Some("high".to_owned()),
+            system_prompt_file: None,
+            append_system_prompt_files: Vec::new(),
+        },
+    );
+
+    let prepared = super::run::prepare_supervised_launch_layout(
+        &request,
+        "claude",
+        &workspace,
+        &rimz::config::MachineConfig::default(),
+        rimz::config::effective::ProfileScope::Subagents,
+        Some(&inherited),
+    )
+    .expect("prepare cross-kind inherited launch")
+    .layout;
+    let cell = prepared.agent_cells().next().expect("agent cell");
+
+    assert_eq!(cell.kind.as_str(), "codex");
+    assert_eq!(cell.launch.model.as_deref(), Some("gpt-5.5-codex"));
+    assert_eq!(cell.launch.effort.as_deref(), Some("high"));
+}
+
+#[test]
+fn supervised_selection_wires_general_rewrite_and_allowlist_refusal() {
+    let mut caller = AgentState::stub("claude", "parent", AgentStatus::Running);
+    caller.profile = Some("planner".to_owned());
+    caller.model = Some("opus".to_owned());
+    caller.effort = Some("high".to_owned());
+    let profiles: rimz::config::ProfilesConfig = toml::from_str(
+        r#"
+        [planner]
+        agent = "claude"
+        subagents = ["general"]
+        "#,
+    )
+    .expect("profiles");
+    let mut request = supervised_request("fix-it", true);
+    request.spec = "general".to_owned();
+
+    let (spec, inherited) =
+        super::run::prepare_supervised_selection(&request, Some(&caller), &profiles)
+            .expect("allowed general selection");
+    assert_eq!(spec, "claude");
+    assert_eq!(
+        inherited,
+        Some(rimz::harness::subagent_policy::general_launch(&caller))
+    );
+
+    request.spec = "codex".to_owned();
+    let error = super::run::prepare_supervised_selection(&request, Some(&caller), &profiles)
+        .expect_err("unlisted selection");
+    assert!(error.to_string().contains("profile `planner`"), "{error:#}");
 }
 
 #[test]

--- a/crates/rimz/src/cli/supervised/tests.rs
+++ b/crates/rimz/src/cli/supervised/tests.rs
@@ -259,6 +259,8 @@ fn supervised_launch_normalizes_model_and_effort_overrides() {
         &request.spec,
         &workspace,
         &rimz::config::MachineConfig::default(),
+        rimz::config::effective::ProfileScope::Agents,
+        None,
     )
     .expect("prepare supervised launch")
     .layout;
@@ -276,6 +278,35 @@ fn supervised_launch_normalizes_model_and_effort_overrides() {
 }
 
 #[test]
+fn general_inheritance_is_a_preset_below_explicit_overrides() {
+    let mut request = supervised_request("fix-it", true);
+    request.effort = Some("low".to_owned());
+    let dir = tempfile::tempdir().expect("temp dir");
+    let workspace =
+        rimz::workspace::WorkspaceResolver::resolve(dir.path(), None).expect("resolve workspace");
+    let inherited = rimz::harness::subagent_policy::GeneralLaunch {
+        kind: rimz::ids::AgentKind::new_unchecked("claude"),
+        model: Some("opus".to_owned()),
+        effort: Some("high".to_owned()),
+    };
+
+    let prepared = super::run::prepare_supervised_launch_layout(
+        &request,
+        "claude",
+        &workspace,
+        &rimz::config::MachineConfig::default(),
+        rimz::config::effective::ProfileScope::Subagents,
+        Some(&inherited),
+    )
+    .expect("prepare inherited launch")
+    .layout;
+    let cell = prepared.agent_cells().next().expect("agent cell");
+
+    assert_eq!(cell.launch.model.as_deref(), Some("opus"));
+    assert_eq!(cell.launch.effort.as_deref(), Some("low"));
+}
+
+#[test]
 fn unsupported_adapter_keeps_subagent_reminder_in_user_prompt() {
     let request = supervised_request("amp", true);
     let dir = tempfile::tempdir().expect("temp dir");
@@ -287,6 +318,8 @@ fn unsupported_adapter_keeps_subagent_reminder_in_user_prompt() {
         "claude",
         &workspace,
         &rimz::config::MachineConfig::default(),
+        rimz::config::effective::ProfileScope::Subagents,
+        None,
     )
     .expect_err("spec-like prompt");
     assert!(

--- a/crates/rimz/src/config.rs
+++ b/crates/rimz/src/config.rs
@@ -1624,7 +1624,8 @@ fn validate_agents_base(
 ) -> std::result::Result<(), InvalidAgentsLayer> {
     validate_agents_config(agents, path).map_err(InvalidAgentsLayer::Agents)?;
     validate_subagent_profiles_config(subagents, agents, path)
-        .map_err(InvalidAgentsLayer::Subagents)
+        .map_err(InvalidAgentsLayer::Subagents)?;
+    validate_subagent_allowlists_config(agents, subagents, path).map_err(InvalidAgentsLayer::Agents)
 }
 
 fn effective_with_fragments<'a>(
@@ -1670,7 +1671,24 @@ fn validate_agents_file(
     path: &Path,
 ) -> Result<()> {
     validate_agents_config(agents, path)?;
-    validate_subagent_profiles_config(subagents, agents, path)
+    validate_subagent_profiles_config(subagents, agents, path)?;
+    validate_subagent_allowlists_config(agents, subagents, path)
+}
+
+fn validate_subagent_allowlists_config(
+    agents: &AgentsConfig,
+    subagents: &SubagentProfilesConfig,
+    path: &Path,
+) -> Result<()> {
+    crate::harness::spec::validate_subagent_allowlists(
+        &agents.profiles,
+        &subagents.profiles,
+        &agents.commands,
+    )
+    .map_err(|source| ConfigErr::Agents {
+        path: path.to_path_buf(),
+        source,
+    })
 }
 
 fn validate_subagent_profiles_config(
@@ -1678,7 +1696,7 @@ fn validate_subagent_profiles_config(
     agents: &AgentsConfig,
     path: &Path,
 ) -> Result<()> {
-    crate::harness::spec::validate_profile_namespace(
+    crate::harness::spec::validate_subagent_profile_namespace(
         &subagents.profiles,
         &agents.commands,
         &agents.teams,

--- a/crates/rimz/src/config/agents.rs
+++ b/crates/rimz/src/config/agents.rs
@@ -115,6 +115,10 @@ pub struct Profile {
     pub agent: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Specs this profile's agents may launch through `rimz subagents`.
+    /// `None` allows all specs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subagents: Option<Vec<String>>,
     #[serde(default)]
     pub mode: Option<PermissionMode>,
     #[serde(default)]

--- a/crates/rimz/src/config/edit.rs
+++ b/crates/rimz/src/config/edit.rs
@@ -967,6 +967,7 @@ const ANIMATION_FIELDS: &[&str] = &["frames", "color", "effect", "speed"];
 const PROFILE_FIELDS: &[&str] = &[
     "agent",
     "description",
+    "subagents",
     "mode",
     "model",
     "effort",

--- a/crates/rimz/src/config/edit/tests.rs
+++ b/crates/rimz/src/config/edit/tests.rs
@@ -351,6 +351,7 @@ fn dynamic_profile_and_team_field_lists_match_serialized_schema() {
     let profile = Profile {
         agent: "claude".to_owned(),
         description: Some("test".to_owned()),
+        subagents: Some(vec!["general".to_owned()]),
         mode: Some(PermissionMode::Yolo),
         model: Some("model".to_owned()),
         effort: Some("high".to_owned()),

--- a/crates/rimz/src/config/effective.rs
+++ b/crates/rimz/src/config/effective.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use crate::config::{
-    AgentsConfig, CommandsConfig, ConfigFileDiagnosis, ProfilesConfig, TaskEntry, Tasks,
-    TeamsConfig,
+    AgentSpecSources, AgentsConfig, CommandsConfig, ConfigFileDiagnosis, ProfilesConfig, TaskEntry,
+    Tasks, TeamsConfig,
 };
 use crate::harness::schedule::{self, ScheduleErr};
 use crate::harness::spec::{self as agents_spec, LayoutErr};
@@ -103,6 +103,7 @@ pub struct LaunchAgents {
     pub profiles: ProfilesConfig,
     pub subagent_profiles: ProfilesConfig,
     pub teams: TeamsConfig,
+    repo_sources: AgentSpecSources,
     state: TrustState,
     config_path: PathBuf,
 }
@@ -120,6 +121,7 @@ pub fn load(
             profiles: machine.profiles.clone(),
             subagent_profiles: machine_subagent_profiles.clone(),
             teams: machine.teams.clone(),
+            repo_sources: AgentSpecSources::default(),
             state: report.state,
             config_path,
         });
@@ -130,6 +132,7 @@ pub fn load(
             profiles: machine.profiles.clone(),
             subagent_profiles: machine_subagent_profiles.clone(),
             teams: machine.teams.clone(),
+            repo_sources: AgentSpecSources::default(),
             state: report.state,
             config_path,
         });
@@ -197,6 +200,22 @@ pub fn load(
         },
     )?;
 
+    let repo_sources = AgentSpecSources {
+        agent_profiles: repo
+            .profiles
+            .0
+            .keys()
+            .map(|name| (name.clone(), config_path.clone()))
+            .collect(),
+        subagent_profiles: repo
+            .subagent_profiles
+            .0
+            .keys()
+            .map(|name| (name.clone(), config_path.clone()))
+            .collect(),
+        commands: Default::default(),
+    };
+
     let mut profiles = machine.profiles.clone();
     profiles.0.extend(repo.profiles.0);
     let mut subagent_profiles = machine_subagent_profiles.clone();
@@ -212,6 +231,7 @@ pub fn load(
         profiles,
         subagent_profiles,
         teams,
+        repo_sources,
         state: report.state,
         config_path,
     })
@@ -312,6 +332,16 @@ fn task_has_prompt(entry: &TaskEntry) -> bool {
 }
 
 impl LaunchAgents {
+    /// Overlay trusted project profile provenance onto machine catalog sources.
+    pub fn overlay_profile_sources(&self, sources: &mut AgentSpecSources) {
+        sources
+            .agent_profiles
+            .extend(self.repo_sources.agent_profiles.clone());
+        sources
+            .subagent_profiles
+            .extend(self.repo_sources.subagent_profiles.clone());
+    }
+
     pub fn profiles_for(&self, scope: ProfileScope) -> &ProfilesConfig {
         match scope {
             ProfileScope::Agents => &self.profiles,

--- a/crates/rimz/src/config/effective.rs
+++ b/crates/rimz/src/config/effective.rs
@@ -177,7 +177,7 @@ pub fn load(
             }
         })?;
     }
-    agents_spec::validate_profile_namespace(
+    agents_spec::validate_subagent_profile_namespace(
         &repo.subagent_profiles,
         &CommandsConfig::default(),
         &TeamsConfig::default(),
@@ -203,6 +203,11 @@ pub fn load(
     subagent_profiles.0.extend(repo.subagent_profiles.0);
     let mut teams = machine.teams.clone();
     teams.0.extend(repo.teams.0);
+    agents_spec::validate_subagent_allowlists(&profiles, &subagent_profiles, &machine.commands)
+        .map_err(|source| EffectiveConfigErr::Agents {
+            path: config_path.clone(),
+            source,
+        })?;
     Ok(LaunchAgents {
         profiles,
         subagent_profiles,

--- a/crates/rimz/src/config/effective/tests.rs
+++ b/crates/rimz/src/config/effective/tests.rs
@@ -528,6 +528,16 @@ fn trusted_repo_allowlist_can_reference_repo_subagent_profile() {
         Some(["repo-child".to_owned()].as_slice())
     );
     assert!(effective.subagent_profiles.0.contains_key("repo-child"));
+    let mut sources = crate::config::AgentSpecSources::default();
+    effective.overlay_profile_sources(&mut sources);
+    assert_eq!(
+        sources.profile(ProfileScope::Agents, "planner"),
+        Some(project.path().join(".rimz/config.toml").as_path())
+    );
+    assert_eq!(
+        sources.profile(ProfileScope::Subagents, "repo-child"),
+        Some(project.path().join(".rimz/config.toml").as_path())
+    );
 }
 
 #[test]

--- a/crates/rimz/src/config/effective/tests.rs
+++ b/crates/rimz/src/config/effective/tests.rs
@@ -19,6 +19,7 @@ fn profile(agent: &str, args: Option<&str>) -> Profile {
     Profile {
         agent: agent.to_owned(),
         description: None,
+        subagents: None,
         mode: None,
         model: None,
         effort: None,
@@ -497,6 +498,36 @@ fn trusted_repo_subagent_profile_overlays_machine_profile() {
     let reviewer = effective.0.get("reviewer").expect("reviewer profile");
     assert_eq!(reviewer.agent, "codex");
     assert_eq!(reviewer.args.as_deref(), Some("--repo"));
+}
+
+#[test]
+fn trusted_repo_allowlist_can_reference_repo_subagent_profile() {
+    let project = tempdir().expect("project");
+    let config = tempdir().expect("config");
+    write_project_config(
+        &project,
+        "[profiles.planner]\nagent = \"claude\"\nsubagents = [\"repo-child\"]\n\
+         [subagents.profiles.repo-child]\nagent = \"codex\"\n",
+    );
+    crate::trust::grant_with_roots(project.path(), config.path()).expect("grant");
+
+    let effective = super::load(
+        &AgentsConfig::default(),
+        &ProfilesConfig::default(),
+        project.path(),
+        config.path(),
+    )
+    .expect("merged catalogs validate together");
+
+    assert_eq!(
+        effective
+            .profiles
+            .0
+            .get("planner")
+            .and_then(|profile| profile.subagents.as_deref()),
+        Some(["repo-child".to_owned()].as_slice())
+    );
+    assert!(effective.subagent_profiles.0.contains_key("repo-child"));
 }
 
 #[test]

--- a/crates/rimz/src/config/tests.rs
+++ b/crates/rimz/src/config/tests.rs
@@ -981,6 +981,7 @@ fn agents_toml_entries_override_agents_home_fragments() {
         Profile {
             agent: "claude".to_owned(),
             description: None,
+            subagents: None,
             mode: None,
             model: Some("opus".to_owned()),
             effort: None,
@@ -1114,6 +1115,7 @@ fn absent_agents_home_is_noop_and_malformed_fragment_leaves_config_unchanged() {
         Profile {
             agent: "claude".to_owned(),
             description: None,
+            subagents: None,
             mode: None,
             model: None,
             effort: None,
@@ -1378,6 +1380,7 @@ fn agent_profiles_commands_and_teams_parse() {
         Some(&Profile {
             agent: "codex".to_owned(),
             description: None,
+            subagents: None,
             mode: Some(PermissionMode::Yolo),
             model: Some("gpt-5-codex".to_owned()),
             effort: Some("high".to_owned()),
@@ -1392,6 +1395,7 @@ fn agent_profiles_commands_and_teams_parse() {
         Some(&Profile {
             agent: "claude".to_owned(),
             description: None,
+            subagents: None,
             mode: None,
             model: None,
             effort: None,
@@ -1512,6 +1516,58 @@ fn agent_and_subagent_profiles_parse_in_separate_namespaces_with_descriptions() 
         toml::from_str::<Profile>(&encoded).expect("round-trip profile"),
         *subagent
     );
+}
+
+#[test]
+fn agent_profile_subagent_allowlist_parses_round_trips_and_validates() {
+    let dir = tempdir().expect("tempdir");
+    let agents_home = dir.path().join("missing-agents-home");
+    let path = write_named(
+        &dir,
+        "agents.toml",
+        "[agents.profiles.planner]\nagent = \"claude\"\nsubagents = [\"general\", \"explorer\"]\n\
+         [subagents.profiles.explorer]\nagent = \"codex\"\n",
+    );
+    let config = MachineConfig::load_from(&path, &agents_home).expect("valid allowlist");
+    let planner = config
+        .agents
+        .profiles
+        .0
+        .get("planner")
+        .expect("planner profile");
+    assert_eq!(
+        planner.subagents.as_deref(),
+        Some(["general".to_owned(), "explorer".to_owned()].as_slice())
+    );
+    let encoded = toml::to_string(planner).expect("serialize profile");
+    assert_eq!(
+        toml::from_str::<Profile>(&encoded).expect("round-trip profile"),
+        *planner
+    );
+
+    let cases = [
+        (
+            "[agents.profiles.planner]\nagent = \"claude\"\nsubagents = [\"typo\"]\n",
+            "allows subagent `typo`",
+        ),
+        (
+            "[subagents.profiles.general]\nagent = \"claude\"\n",
+            "built-in `rimz subagents general`",
+        ),
+        (
+            "[subagents.profiles.explorer]\nagent = \"claude\"\nsubagents = []\n",
+            "a subagent cannot launch",
+        ),
+        (
+            "[agents.commands]\ngeneral = \"claude\"\n",
+            "built-in `rimz subagents general`",
+        ),
+    ];
+    for (text, expected) in cases {
+        let path = write_named(&dir, "agents.toml", text);
+        let error = MachineConfig::load_from(&path, &agents_home).expect_err("invalid config");
+        assert!(error.to_string().contains(expected), "{error:#}");
+    }
 }
 
 #[test]

--- a/crates/rimz/src/harness/mod.rs
+++ b/crates/rimz/src/harness/mod.rs
@@ -19,6 +19,7 @@ pub mod run_timeout;
 pub mod run_wake;
 pub mod schedule;
 pub mod spec;
+pub mod subagent_policy;
 pub mod target;
 
 pub use auto_continue::AutoContinueRequest;

--- a/crates/rimz/src/harness/plan/tests.rs
+++ b/crates/rimz/src/harness/plan/tests.rs
@@ -142,6 +142,7 @@ fn configured_profile(
     Profile {
         agent: agent.to_owned(),
         description: None,
+        subagents: None,
         mode,
         model: model.map(str::to_owned),
         effort: effort.map(str::to_owned),

--- a/crates/rimz/src/harness/rebirth/tests.rs
+++ b/crates/rimz/src/harness/rebirth/tests.rs
@@ -694,6 +694,7 @@ fn team_machine() -> MachineConfig {
         Profile {
             agent: "claude".to_owned(),
             description: None,
+            subagents: None,
             mode: None,
             model: None,
             effort: None,
@@ -708,6 +709,7 @@ fn team_machine() -> MachineConfig {
         Profile {
             agent: "codex".to_owned(),
             description: None,
+            subagents: None,
             mode: None,
             model: None,
             effort: None,

--- a/crates/rimz/src/harness/spec.rs
+++ b/crates/rimz/src/harness/spec.rs
@@ -343,6 +343,22 @@ pub enum LayoutErr {
     InvalidCommandName { name: String },
     #[error("command name `{name}` is reserved for `rimz agents`")]
     ReservedCommandName { name: String },
+    #[error(
+        "`{name}` is reserved for the built-in `rimz subagents general` spec; choose another name"
+    )]
+    ReservedSubagentSpec { name: String },
+    #[error(
+        "`[subagents.profiles.{profile}]` sets `subagents`, but a subagent cannot launch; remove the field"
+    )]
+    SubagentAllowlistOnSubagentProfile { profile: String },
+    #[error(
+        "profile `{profile}` allows subagent `{entry}`, which is not `general`, a [subagents.profiles] name, a command, or an agent kind; valid: {valid}"
+    )]
+    UnknownSubagentAllowlistEntry {
+        profile: String,
+        entry: String,
+        valid: String,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, LayoutErr>;
@@ -424,6 +440,63 @@ pub fn validate_profile_namespace(
     for name in teams.0.keys() {
         if is_cell_word(name, profiles, commands) {
             return Err(LayoutErr::ReservedTeamName(name.clone()));
+        }
+    }
+    Ok(())
+}
+
+/// Validate the profile namespace dedicated to the `rimz subagents` doorway.
+pub fn validate_subagent_profile_namespace(
+    profiles: &ProfilesConfig,
+    commands: &CommandsConfig,
+    teams: &TeamsConfig,
+) -> Result<()> {
+    validate_profile_namespace(profiles, commands, teams)?;
+    if profiles
+        .0
+        .contains_key(crate::harness::subagent_policy::GENERAL_SPEC)
+    {
+        return Err(LayoutErr::ReservedSubagentSpec {
+            name: crate::harness::subagent_policy::GENERAL_SPEC.to_owned(),
+        });
+    }
+    if let Some((profile, _)) = profiles
+        .0
+        .iter()
+        .find(|(_, profile)| profile.subagents.is_some())
+    {
+        return Err(LayoutErr::SubagentAllowlistOnSubagentProfile {
+            profile: profile.clone(),
+        });
+    }
+    Ok(())
+}
+
+pub fn validate_subagent_allowlists(
+    profiles: &ProfilesConfig,
+    subagent_profiles: &ProfilesConfig,
+    commands: &CommandsConfig,
+) -> Result<()> {
+    let valid = format!(
+        "{}, {}",
+        crate::harness::subagent_policy::GENERAL_SPEC,
+        valid_cells(subagent_profiles, commands)
+    );
+    for (profile_name, profile) in &profiles.0 {
+        let Some(allowed) = profile.subagents.as_ref() else {
+            continue;
+        };
+        for entry in allowed {
+            if entry == crate::harness::subagent_policy::GENERAL_SPEC
+                || is_cell_word(entry, subagent_profiles, commands)
+            {
+                continue;
+            }
+            return Err(LayoutErr::UnknownSubagentAllowlistEntry {
+                profile: profile_name.clone(),
+                entry: entry.clone(),
+                valid: valid.clone(),
+            });
         }
     }
     Ok(())
@@ -1390,6 +1463,9 @@ fn validate_command_names(commands: &CommandsConfig) -> Result<()> {
                 .any(|ch| ch.is_whitespace() || ch == ',' || ch == '+' || ch == '/')
         {
             return Err(LayoutErr::InvalidCommandName { name: name.clone() });
+        }
+        if name == crate::harness::subagent_policy::GENERAL_SPEC {
+            return Err(LayoutErr::ReservedSubagentSpec { name: name.clone() });
         }
         if petname::RESERVED_AGENT_WORDS.contains(&name.as_str()) {
             return Err(LayoutErr::ReservedCommandName { name: name.clone() });

--- a/crates/rimz/src/harness/spec.rs
+++ b/crates/rimz/src/harness/spec.rs
@@ -359,6 +359,14 @@ pub enum LayoutErr {
         entry: String,
         valid: String,
     },
+    #[error(
+        "launch refused: profile `{profile}` may only launch subagents {allowed}; `{spec}` is not one of them. Pick an allowed spec or ask the user to widen `[agents.profiles.{profile}] subagents`."
+    )]
+    SubagentSpecNotAllowed {
+        profile: String,
+        spec: String,
+        allowed: String,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, LayoutErr>;

--- a/crates/rimz/src/harness/spec/tests.rs
+++ b/crates/rimz/src/harness/spec/tests.rs
@@ -7,6 +7,7 @@ fn profile(agent: &str) -> Profile {
     Profile {
         agent: agent.to_owned(),
         description: None,
+        subagents: None,
         mode: None,
         model: None,
         effort: None,
@@ -517,6 +518,7 @@ fn cross_kind_override_replaces_provider_fields_and_carries_portable_fields() {
         Profile {
             agent: "claude".to_owned(),
             description: None,
+            subagents: None,
             mode: Some(PermissionMode::Auto),
             model: Some("claude-model".to_owned()),
             effort: Some("high".to_owned()),

--- a/crates/rimz/src/harness/subagent_policy.rs
+++ b/crates/rimz/src/harness/subagent_policy.rs
@@ -84,7 +84,7 @@ mod tests {
     }
 
     #[test]
-    fn general_inherits_launch_stamped_identity() {
+    fn general_inherits_current_model_and_effort() {
         let (caller, _) = caller(None);
         assert_eq!(
             general_launch(&caller),

--- a/crates/rimz/src/harness/subagent_policy.rs
+++ b/crates/rimz/src/harness/subagent_policy.rs
@@ -1,0 +1,141 @@
+//! What a `rimz subagents` caller may launch, and what `general` means for it.
+
+use crate::agents::AgentState;
+use crate::config::ProfilesConfig;
+use crate::ids::AgentKind;
+
+pub const GENERAL_SPEC: &str = "general";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GeneralLaunch {
+    pub kind: AgentKind,
+    pub model: Option<String>,
+    pub effort: Option<String>,
+}
+
+pub fn general_launch(caller: &AgentState) -> GeneralLaunch {
+    GeneralLaunch {
+        kind: caller.kind.clone(),
+        model: caller.model.clone(),
+        effort: caller.effort.clone(),
+    }
+}
+
+pub fn allowed_specs<'a>(
+    caller: &AgentState,
+    profiles: &'a ProfilesConfig,
+) -> Option<&'a [String]> {
+    caller
+        .profile
+        .as_deref()
+        .and_then(|name| profiles.0.get(name))
+        .and_then(|profile| profile.subagents.as_deref())
+}
+
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "launch refused: profile `{profile}` may only launch subagents {allowed}; `{spec}` is not one of them. Pick an allowed spec or ask the user to widen `[agents.profiles.{profile}] subagents`."
+)]
+pub struct SpecNotAllowed {
+    profile: String,
+    spec: String,
+    allowed: String,
+}
+
+pub fn check_allowed(
+    caller: &AgentState,
+    profiles: &ProfilesConfig,
+    spec: &str,
+    agent_override: Option<&str>,
+) -> Result<(), SpecNotAllowed> {
+    let Some(allowed) = allowed_specs(caller, profiles) else {
+        return Ok(());
+    };
+    for requested in [Some(spec), agent_override].into_iter().flatten() {
+        let requested = requested.trim();
+        if allowed.iter().any(|candidate| candidate == requested) {
+            continue;
+        }
+        return Err(SpecNotAllowed {
+            profile: caller.profile.clone().unwrap_or_default(),
+            spec: requested.to_owned(),
+            allowed: format!("[{}]", allowed.join(", ")),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::AgentStatus;
+    use crate::config::Profile;
+    use std::collections::BTreeMap;
+
+    fn caller(allowed: Option<Vec<&str>>) -> (AgentState, ProfilesConfig) {
+        let mut caller = AgentState::stub("claude", "parent", AgentStatus::Running);
+        caller.profile = Some("planner".to_owned());
+        caller.model = Some("opus".to_owned());
+        caller.effort = Some("high".to_owned());
+        let profiles = ProfilesConfig(BTreeMap::from([(
+            "planner".to_owned(),
+            Profile {
+                agent: "claude".to_owned(),
+                description: None,
+                subagents: allowed.map(|values| values.into_iter().map(str::to_owned).collect()),
+                mode: None,
+                model: None,
+                effort: None,
+                budget: None,
+                system_prompt_file: None,
+                append_system_prompt_files: Vec::new(),
+                args: None,
+            },
+        )]));
+        (caller, profiles)
+    }
+
+    #[test]
+    fn general_inherits_launch_stamped_identity() {
+        let (caller, _) = caller(None);
+        assert_eq!(
+            general_launch(&caller),
+            GeneralLaunch {
+                kind: AgentKind::new_unchecked("claude"),
+                model: Some("opus".to_owned()),
+                effort: Some("high".to_owned()),
+            }
+        );
+
+        let mut bare = caller;
+        bare.model = None;
+        bare.effort = None;
+        assert_eq!(general_launch(&bare).model, None);
+        assert_eq!(general_launch(&bare).effort, None);
+    }
+
+    #[test]
+    fn allowlist_checks_spec_and_agent_override() {
+        let (caller, profiles) = caller(Some(vec!["general", "explorer"]));
+        assert!(check_allowed(&caller, &profiles, " general ", None).is_ok());
+        assert!(check_allowed(&caller, &profiles, "general", Some("explorer")).is_ok());
+
+        let error = check_allowed(&caller, &profiles, "codex", None).unwrap_err();
+        assert!(error.to_string().contains("profile `planner`"));
+        assert!(error.to_string().contains("[general, explorer]"));
+        assert!(check_allowed(&caller, &profiles, "general", Some("codex")).is_err());
+    }
+
+    #[test]
+    fn missing_policy_allows_all_and_empty_policy_allows_none() {
+        let (unrestricted, profiles) = caller(None);
+        assert!(check_allowed(&unrestricted, &profiles, "codex", None).is_ok());
+
+        let mut bare = unrestricted;
+        bare.profile = None;
+        assert!(check_allowed(&bare, &profiles, "codex", None).is_ok());
+
+        let (caller, profiles) = caller(Some(Vec::new()));
+        assert!(check_allowed(&caller, &profiles, "general", None).is_err());
+    }
+}

--- a/crates/rimz/src/harness/subagent_policy.rs
+++ b/crates/rimz/src/harness/subagent_policy.rs
@@ -3,22 +3,20 @@
 use crate::agents::AgentState;
 use crate::config::ProfilesConfig;
 use crate::ids::AgentKind;
+use crate::{agents::LaunchPreset, harness::spec::LayoutErr};
 
 pub const GENERAL_SPEC: &str = "general";
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct GeneralLaunch {
-    pub kind: AgentKind,
-    pub model: Option<String>,
-    pub effort: Option<String>,
-}
-
-pub fn general_launch(caller: &AgentState) -> GeneralLaunch {
-    GeneralLaunch {
-        kind: caller.kind.clone(),
-        model: caller.model.clone(),
-        effort: caller.effort.clone(),
-    }
+pub fn general_launch(caller: &AgentState) -> (AgentKind, LaunchPreset) {
+    (
+        caller.kind.clone(),
+        LaunchPreset {
+            model: caller.model.clone(),
+            effort: caller.effort.clone(),
+            system_prompt_file: None,
+            append_system_prompt_files: Vec::new(),
+        },
+    )
 }
 
 pub fn allowed_specs<'a>(
@@ -32,22 +30,12 @@ pub fn allowed_specs<'a>(
         .and_then(|profile| profile.subagents.as_deref())
 }
 
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
-#[error(
-    "launch refused: profile `{profile}` may only launch subagents {allowed}; `{spec}` is not one of them. Pick an allowed spec or ask the user to widen `[agents.profiles.{profile}] subagents`."
-)]
-pub struct SpecNotAllowed {
-    profile: String,
-    spec: String,
-    allowed: String,
-}
-
 pub fn check_allowed(
     caller: &AgentState,
     profiles: &ProfilesConfig,
     spec: &str,
     agent_override: Option<&str>,
-) -> Result<(), SpecNotAllowed> {
+) -> crate::harness::spec::Result<()> {
     let Some(allowed) = allowed_specs(caller, profiles) else {
         return Ok(());
     };
@@ -56,7 +44,7 @@ pub fn check_allowed(
         if allowed.iter().any(|candidate| candidate == requested) {
             continue;
         }
-        return Err(SpecNotAllowed {
+        return Err(LayoutErr::SubagentSpecNotAllowed {
             profile: caller.profile.clone().unwrap_or_default(),
             spec: requested.to_owned(),
             allowed: format!("[{}]", allowed.join(", ")),
@@ -100,18 +88,22 @@ mod tests {
         let (caller, _) = caller(None);
         assert_eq!(
             general_launch(&caller),
-            GeneralLaunch {
-                kind: AgentKind::new_unchecked("claude"),
-                model: Some("opus".to_owned()),
-                effort: Some("high".to_owned()),
-            }
+            (
+                AgentKind::new_unchecked("claude"),
+                LaunchPreset {
+                    model: Some("opus".to_owned()),
+                    effort: Some("high".to_owned()),
+                    system_prompt_file: None,
+                    append_system_prompt_files: Vec::new(),
+                }
+            )
         );
 
         let mut bare = caller;
         bare.model = None;
         bare.effort = None;
-        assert_eq!(general_launch(&bare).model, None);
-        assert_eq!(general_launch(&bare).effort, None);
+        assert_eq!(general_launch(&bare).1.model, None);
+        assert_eq!(general_launch(&bare).1.effort, None);
     }
 
     #[test]

--- a/crates/rimz/src/trust.rs
+++ b/crates/rimz/src/trust.rs
@@ -1201,10 +1201,10 @@ mod tests {
     #[test]
     fn unknown_non_command_field_does_not_change_hash() {
         let base = project_with(
-            "display_name = \"Query Engine\"\n\n[[hooks]]\nevent = \"PreToolUse\"\ncommand = \"rimz hooks claude\"\n",
+            "display_name = \"Query Engine\"\n\n[profiles.x]\nagent = \"claude\"\n\n[[hooks]]\nevent = \"PreToolUse\"\ncommand = \"rimz hooks claude\"\n",
         );
         let extra = project_with(
-            "display_name = \"Query Engine dev\"\nsidebar = true\n\n[[hooks]]\nevent = \"PreToolUse\"\ncommand = \"rimz hooks claude\"\n",
+            "display_name = \"Query Engine dev\"\nsidebar = true\n\n[profiles.x]\nagent = \"claude\"\nsubagents = [\"explorer\"]\n\n[[hooks]]\nevent = \"PreToolUse\"\ncommand = \"rimz hooks claude\"\n",
         );
         let a = read_project_config(&base.path().join(CONFIG_REL))
             .expect("read base")
@@ -1213,21 +1213,6 @@ mod tests {
             .expect("read extra")
             .expect("config present");
         assert_eq!(executable_surface_hash(&a), executable_surface_hash(&b));
-    }
-
-    #[test]
-    fn subagent_allowlist_does_not_change_trust_hash() {
-        // The allowlist only narrows launches; it is not executable surface.
-        let base: ProjectConfig =
-            toml::from_str("[profiles.x]\nagent = \"claude\"\n").expect("base config");
-        let restricted: ProjectConfig =
-            toml::from_str("[profiles.x]\nagent = \"claude\"\nsubagents = [\"explorer\"]\n")
-                .expect("restricted config");
-
-        assert_eq!(
-            executable_surface_hash(&base),
-            executable_surface_hash(&restricted)
-        );
     }
 
     #[test]

--- a/crates/rimz/src/trust.rs
+++ b/crates/rimz/src/trust.rs
@@ -1216,6 +1216,21 @@ mod tests {
     }
 
     #[test]
+    fn subagent_allowlist_does_not_change_trust_hash() {
+        // The allowlist only narrows launches; it is not executable surface.
+        let base: ProjectConfig =
+            toml::from_str("[profiles.x]\nagent = \"claude\"\n").expect("base config");
+        let restricted: ProjectConfig =
+            toml::from_str("[profiles.x]\nagent = \"claude\"\nsubagents = [\"explorer\"]\n")
+                .expect("restricted config");
+
+        assert_eq!(
+            executable_surface_hash(&base),
+            executable_surface_hash(&restricted)
+        );
+    }
+
+    #[test]
     fn project_notifications_do_not_enter_trust_hash() {
         let base =
             project_with("[[hooks]]\nevent = \"PreToolUse\"\ncommand = \"rimz hooks claude\"\n");

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -468,7 +468,7 @@ timeout = "30m"
 
 These defaults apply only to the agent-only [`rimz subagents`](../reference/cli/subagents.md) doorway, which is the only launch path that creates a parented child. `timeout` is the wall-clock limit for each supervised child and defaults to 30 minutes; the producer enforces it even when no process is waiting on the result. Per-launch `--timeout` overrides this table. Subagents cannot launch agents or subagents.
 
-The `general` spec launches the caller's agent kind and current model and effort unless the launch overrides them. A cross-kind `--agent` rebase drops the caller's provider-specific model while keeping effort.
+The `general` spec launches the caller's agent kind and current model and effort unless the launch overrides them. A cross-kind `--agent` rebase drops the inherited model and effort.
 
 Child launch presets live separately under `[subagents.profiles.<name>]`; `[agents.subagents]` continues to hold only doorway defaults such as `timeout`.
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -394,6 +394,16 @@ mode = "plan"
 
 A profile is a named agent preset. `[agents.profiles]` entries belong to `rimz agents` and become addressable type handles; `[subagents.profiles]` entries belong only to `rimz subagents`. `agent` is the base, a built-in kind (`claude`, `codex`, …) or another profile in the same namespace, and the remaining **override fields** layer on top: `mode` (`auto` | `ask` | `plan` | `yolo`), `model`, `effort`, `budget`, `system-prompt-file`, `append-system-prompt-files`, and raw `args`. Optional `description` is listing metadata shown by `rimz agents profiles` or `rimz subagents profiles`; it is not inherited. `budget = "5"` caps the session and `budget = "20/day"` resets at the configured local day boundary. Team roles expose the launch fields; loop tasks expose the subset relevant to scheduled work.
 
+An `[agents.profiles]` entry may restrict delegation by listing the only specs its agents may launch through `rimz subagents`:
+
+```toml
+[agents.profiles.planner]
+agent = "claude"
+subagents = ["general", "explorer", "designer"]
+```
+
+With no `subagents` field, every subagent spec is allowed; an empty list allows none. Entries are literal spec names and are validated against `general`, `[subagents.profiles]`, commands, and agent kinds when config loads. Team roles inherit the policy through their bound profile. The field is invalid on `[subagents.profiles]` because a subagent cannot launch again.
+
 Drop-ins under `~/.agents/profiles/<name>/agent.toml` may declare either or both profile namespaces. Their relative prompt paths root at the drop-in directory, and same-named entries in the machine `agents.toml` take precedence.
 
 Inheritance flattens at launch to one concrete adapter kind, and **the nearest set value wins for every field except prompt fragments**: a child that sets `args` replaces the base `args`, while `append-system-prompt-files` concatenates parent-first through the profile chain and a team role appends last. Fragments require a resolved `system-prompt-file` base. RimZ reads the pieces, separates them with blank lines, materializes one content-addressed replacement, and passes that complete value through the adapter's existing replacement channel. A `~` expands to home and a relative path roots at the declaring config file. Every source file must exist at launch; a missing one fails with the path to fix.
@@ -427,7 +437,7 @@ An inline spec like `rimz agents "claude,codex+term"` keeps the same shape gramm
 
 The [agents CLI reference](../reference/cli/agents.md) lists the built-in virtual cells in full.
 
-`rimz subagents` uses the same resolution order except that step 2 reads `[subagents.profiles]`. If a profile exists only in the other namespace, launch fails with the section to move or copy it to.
+`rimz subagents` uses the same resolution order except that step 2 reads `[subagents.profiles]`; its built-in `general` spec is rewritten to the caller's kind before resolution. If a profile exists only in the other namespace, launch fails with the section to move or copy it to. `general` is reserved in `[subagents.profiles]` and `[agents.commands]`.
 
 Profiles and roles become addressable handles, so they must not shadow `@all`, agent kinds (`@claude`), kind ordinals (`@claude-2`), or the pane and channel sigils (`:`, `#`). Profile, command, and team names also reserve the `agents` subcommand verbs `list`, `ls`, `show`, `profiles`, `stop`, `focus`, `fork`, `wait`, `term`, and `exec`. A config that still uses a removed table fails fast naming the rename rather than silently dropping it: `[tab]` (with its `[tab.keywords]`/`[tab.layouts]` children) → `placement` under `[agents]` plus `[agents.teams]`; `[agents.aliases]` → `[agents.profiles]` and `[agents.commands]`; `[agents.layouts]` → `[agents.teams]`. The room degrades to defaults with a warning while `rimz config` and `rimz doctor` print the precise rename.
 
@@ -457,6 +467,8 @@ timeout = "30m"
 ```
 
 These defaults apply only to the agent-only [`rimz subagents`](../reference/cli/subagents.md) doorway, which is the only launch path that creates a parented child. `timeout` is the wall-clock limit for each supervised child and defaults to 30 minutes; the producer enforces it even when no process is waiting on the result. Per-launch `--timeout` overrides this table. Subagents cannot launch agents or subagents.
+
+The `general` spec launches the caller's agent kind and inherits its launch-stamped model and effort unless the launch overrides them.
 
 Child launch presets live separately under `[subagents.profiles.<name>]`; `[agents.subagents]` continues to hold only doorway defaults such as `timeout`.
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -468,7 +468,7 @@ timeout = "30m"
 
 These defaults apply only to the agent-only [`rimz subagents`](../reference/cli/subagents.md) doorway, which is the only launch path that creates a parented child. `timeout` is the wall-clock limit for each supervised child and defaults to 30 minutes; the producer enforces it even when no process is waiting on the result. Per-launch `--timeout` overrides this table. Subagents cannot launch agents or subagents.
 
-The `general` spec launches the caller's agent kind and inherits its launch-stamped model and effort unless the launch overrides them.
+The `general` spec launches the caller's agent kind and current model and effort unless the launch overrides them. A cross-kind `--agent` rebase drops the caller's provider-specific model while keeping effort.
 
 Child launch presets live separately under `[subagents.profiles.<name>]`; `[agents.subagents]` continues to hold only doorway defaults such as `timeout`.
 

--- a/docs/internals/harness/subagents.md
+++ b/docs/internals/harness/subagents.md
@@ -79,7 +79,7 @@ The doorway deliberately omits `--worktree`, `--from-pr`, `--channel`, `--stdin`
 
 The supervised runner resolves the durable caller before it resolves a subagent spec. [`subagent_policy.rs`](../../../crates/rimz/src/harness/subagent_policy.rs) then applies the caller's `[agents.profiles]` policy: when that profile sets `subagents = [...]`, both the positional spec and any `--agent` rebase must appear literally in the list. Refusal happens before provider preflight, store append, or mux mutation. The same policy filters `rimz subagents profiles` when invoked inside the agent; a user-shell catalog remains unfiltered.
 
-The built-in `general` spec is rewritten to the caller's `AgentKind` before ordinary subagent profile resolution. The caller's current provider-observed model and effort become presets below explicit launch flags. A cross-kind `--agent` rebase drops the provider-specific model while retaining portable effort, matching `rebase_onto`; same-kind profiles still supply mode, arguments, and prompt files. Keeping this caller-dependent rule out of the generic spec parser lets the rest of resolution remain unchanged.
+The built-in `general` spec is rewritten to the caller's `AgentKind` before ordinary subagent profile resolution. The caller's current provider-observed model and effort become presets below explicit launch flags. A cross-kind `--agent` rebase drops the inherited model and effort; same-kind profiles still supply mode, arguments, and prompt files. Keeping this caller-dependent rule out of the generic spec parser lets the rest of resolution remain unchanged.
 
 ## Single launch and fanout share one composition
 

--- a/docs/internals/harness/subagents.md
+++ b/docs/internals/harness/subagents.md
@@ -79,7 +79,7 @@ The doorway deliberately omits `--worktree`, `--from-pr`, `--channel`, `--stdin`
 
 The supervised runner resolves the durable caller before it resolves a subagent spec. [`subagent_policy.rs`](../../../crates/rimz/src/harness/subagent_policy.rs) then applies the caller's `[agents.profiles]` policy: when that profile sets `subagents = [...]`, both the positional spec and any `--agent` rebase must appear literally in the list. Refusal happens before provider preflight, store append, or mux mutation. The same policy filters `rimz subagents profiles` when invoked inside the agent; a user-shell catalog remains unfiltered.
 
-The built-in `general` spec is rewritten to the caller's `AgentKind` before ordinary subagent profile resolution. The caller's launch-stamped model and effort become presets below explicit launch flags and above profile defaults. Keeping this caller-dependent rule out of the generic spec parser lets the rest of resolution, including same-kind profiles and `--agent` rebasing, remain unchanged.
+The built-in `general` spec is rewritten to the caller's `AgentKind` before ordinary subagent profile resolution. The caller's current provider-observed model and effort become presets below explicit launch flags. A cross-kind `--agent` rebase drops the provider-specific model while retaining portable effort, matching `rebase_onto`; same-kind profiles still supply mode, arguments, and prompt files. Keeping this caller-dependent rule out of the generic spec parser lets the rest of resolution remain unchanged.
 
 ## Single launch and fanout share one composition
 

--- a/docs/internals/harness/subagents.md
+++ b/docs/internals/harness/subagents.md
@@ -75,6 +75,12 @@ The wrapper records its binding asynchronously after the mux starts it, so a sub
 
 The doorway deliberately omits `--worktree`, `--from-pr`, `--channel`, `--stdin`, `--resume`, placement flags, output and input formats, retries, and verification. Each of those needs a decision the delegating agent is not well placed to make, and each is still reachable by calling `rimz agents` directly. Its launch resolution and `profiles` catalog read `[subagents.profiles]`, while `rimz agents` reads `[agents.profiles]`; a wrong-doorway profile names both sections in the error. Commands and teams remain shared. `profiles` never lists teams because one launch produces one agent rather than a cohort.
 
+## Caller policy
+
+The supervised runner resolves the durable caller before it resolves a subagent spec. [`subagent_policy.rs`](../../../crates/rimz/src/harness/subagent_policy.rs) then applies the caller's `[agents.profiles]` policy: when that profile sets `subagents = [...]`, both the positional spec and any `--agent` rebase must appear literally in the list. Refusal happens before provider preflight, store append, or mux mutation. The same policy filters `rimz subagents profiles` when invoked inside the agent; a user-shell catalog remains unfiltered.
+
+The built-in `general` spec is rewritten to the caller's `AgentKind` before ordinary subagent profile resolution. The caller's launch-stamped model and effort become presets below explicit launch flags and above profile defaults. Keeping this caller-dependent rule out of the generic spec parser lets the rest of resolution, including same-kind profiles and `--agent` rebasing, remain unchanged.
+
 ## Single launch and fanout share one composition
 
 `rimz subagents fanout` accepts a JSON array and desugars every entry through the same `SubagentLaunchArgs::into_agent_launch` path above. Task `timeout` wins over the fanout flag, which wins over the configured default. Fanout-level `keep` applies uniformly; per-task foreground, retention, and passthrough argv are not part of the data format.
@@ -89,7 +95,7 @@ A runtime failure during that loop aborts the remaining launches and reports eve
 
 ## Launch generations and parentage
 
-Ancestry resolves in [`plan.rs`](../../../crates/rimz/src/harness/plan.rs) as step 4 of [the compile path](./fleet.md#from-spec-to-panes) — **before** provider preflight, worktree creation, store append, or any mux action, so a refusal leaves nothing behind.
+Ancestry resolves in the supervised runner before layout compilation — **before** provider preflight, worktree creation, store append, or any mux action, so a refusal leaves nothing behind.
 
 `resolve_launch_caller_from_env` finds the launching agent's durable row. It reads `RIMZ_AGENT_KIND` and `RIMZ_AGENT_ID`, then matches the row whose `launch_id` equals that id, with the kind corroborating the match so a stale cross-provider environment cannot attach a child to the wrong row. Only an agent process with no launch id at all — one that survived an upgrade — may fall back to an unambiguous live pane stamp.
 

--- a/docs/reference/cli/subagents.md
+++ b/docs/reference/cli/subagents.md
@@ -61,7 +61,7 @@ rimz subagents wait "$first" "$second"
 
 The bare form and `launch` verb are equivalent. A prompt is mandatory: the parent must supply the whole assignment as the second positional argument or with `--prompt-file PATH`. Relative paths resolve from the caller's current working directory. The child inherits the parent's current checkout and lane.
 
-The built-in `general` spec launches a child of the caller's provider kind and current model and effort; explicit `--model` and `--effort` values win. A same-kind `[subagents.profiles.<kind>]` entry still supplies mode, arguments, and prompt files, while the caller's current model and effort take precedence. `--agent` rebases `general` like any other spec: on a cross-kind rebase the caller's provider-specific model is dropped in favor of the rebased profile or provider default, while effort remains portable. Fanout entries may also set `"spec": "general"`.
+The built-in `general` spec launches a child of the caller's provider kind and current model and effort; explicit `--model` and `--effort` values win. A same-kind `[subagents.profiles.<kind>]` entry still supplies mode, arguments, and prompt files, while the caller's current model and effort take precedence. `--agent` rebases `general` like any other spec: a cross-kind rebase drops the inherited model and effort in favor of the rebased profile or provider defaults. Fanout entries may also set `"spec": "general"`.
 
 | Behavior | Default | Override |
 | --- | --- | --- |

--- a/docs/reference/cli/subagents.md
+++ b/docs/reference/cli/subagents.md
@@ -30,7 +30,7 @@ Each array entry has the single-launch fields that make sense for data-driven de
 
 | Field | Required | Meaning |
 | --- | --- | --- |
-| `spec` | yes | Agent kind or configured profile |
+| `spec` | yes | `general`, an agent kind, or a configured profile |
 | `prompt` | exactly one | Complete task supplied by the parent |
 | `prompt_file` | exactly one | File whose contents become the prompt; exclusive with `prompt` |
 | `name` | no | Durable child petname |
@@ -61,6 +61,8 @@ rimz subagents wait "$first" "$second"
 
 The bare form and `launch` verb are equivalent. A prompt is mandatory: the parent must supply the whole assignment as the second positional argument or with `--prompt-file PATH`. Relative paths resolve from the caller's current working directory. The child inherits the parent's current checkout and lane.
 
+The built-in `general` spec launches a child of the caller's provider kind. Its model and effort default to the caller's launch-stamped values; precedence is an explicit `--model`/`--effort`, then the caller's value, then a same-kind `[subagents.profiles]` value, then the provider default. `--agent` rebases it like any other spec. Fanout entries may also set `"spec": "general"`.
+
 | Behavior | Default | Override |
 | --- | --- | --- |
 | Execution | supervised print mode, background | `--wait[=DURATION]` joins and prints the result |
@@ -83,7 +85,9 @@ rimz subagents profiles --path
 rimz subagents profiles --json --path
 ```
 
-`profiles` lists `[subagents.profiles]` profiles and configured launch commands available for one child as compact cards. Profile cards include their optional descriptions; `--path` adds the defining-file path. JSON also omits `path` unless `--path` is passed, keeps that path absolute, and includes `source` to distinguish profiles from commands. `[agents.profiles]` entries are excluded. Built-in and registered agent kinds remain directly launchable but are omitted from this configured-profile catalog. It also works from a user shell. Team names are excluded because a subagent launch creates one agent, not a cohort.
+`profiles` lists the built-in `general` spec first, followed by `[subagents.profiles]` profiles and configured launch commands available for one child as compact cards. Profile cards include their optional descriptions; `--path` adds the defining-file path. JSON also omits `path` unless `--path` is passed, keeps that path absolute, and includes `source` (`builtin`, `profile`, or `command`). `[agents.profiles]` entries are excluded. Registered agent kinds remain directly launchable but are omitted from this catalog. It also works from a user shell.
+
+Inside an agent whose `[agents.profiles]` entry sets `subagents = [...]`, the catalog includes only listed specs. A launch naming any other positional spec or `--agent` rebase is refused before RimZ creates a run or pane. Team names are excluded because a subagent launch creates one agent, not a cohort.
 
 ## Join results
 

--- a/docs/reference/cli/subagents.md
+++ b/docs/reference/cli/subagents.md
@@ -61,7 +61,7 @@ rimz subagents wait "$first" "$second"
 
 The bare form and `launch` verb are equivalent. A prompt is mandatory: the parent must supply the whole assignment as the second positional argument or with `--prompt-file PATH`. Relative paths resolve from the caller's current working directory. The child inherits the parent's current checkout and lane.
 
-The built-in `general` spec launches a child of the caller's provider kind. Its model and effort default to the caller's launch-stamped values; precedence is an explicit `--model`/`--effort`, then the caller's value, then a same-kind `[subagents.profiles]` value, then the provider default. `--agent` rebases it like any other spec. Fanout entries may also set `"spec": "general"`.
+The built-in `general` spec launches a child of the caller's provider kind and current model and effort; explicit `--model` and `--effort` values win. A same-kind `[subagents.profiles.<kind>]` entry still supplies mode, arguments, and prompt files, while the caller's current model and effort take precedence. `--agent` rebases `general` like any other spec: on a cross-kind rebase the caller's provider-specific model is dropped in favor of the rebased profile or provider default, while effort remains portable. Fanout entries may also set `"spec": "general"`.
 
 | Behavior | Default | Override |
 | --- | --- | --- |

--- a/refactor-target.toml
+++ b/refactor-target.toml
@@ -202,7 +202,7 @@ allowed-imports = [
     "trust",
     "workspace",
 ]
-surface-budget = 578
+surface-budget = 585
 
 [[module]]
 path = "crates/rimz/src/ids.rs"

--- a/refactor-target.toml
+++ b/refactor-target.toml
@@ -112,7 +112,7 @@ allowed-imports = [
     "utils::time",
     "trust",
 ]
-surface-budget = 12
+surface-budget = 13
 
 [[module]]
 path = "crates/rimz/src/config/notifications.rs"


### PR DESCRIPTION
## Context

`rimz subagents <spec>` accepted only `[subagents.profiles]` names, agent kinds, virtual cells, and commands. A parent that wanted another agent of its own kind had to name that kind and repeat its model and effort. Every profile could also launch any spec in the catalog. There was no way to limit one profile to a small set of children.

This change adds two things at the `rimz subagents` doorway:

- `general`, a built-in spec. It launches a child of the caller's own provider kind. The child gets the caller's current model and effort.
- `subagents = [...]`, a new field on an `[agents.profiles]` entry. It lists the only specs that the agents of that profile can launch. No field means no limit.

## Design choices

- The policy lives in the harness, in `harness/subagent_policy.rs`. The CLI handler only calls it. This keeps the CLI contract: a handler parses, calls the domain, and presents.
- `general` is a spec rewrite, not a pseudo-profile in the spec parser. The supervised runner resolves the caller first. It then rewrites `general` to the caller's kind before it resolves the layout. The spec parser stays free of caller knowledge, and every later rule applies without change.
- The child gets the model and effort that the caller runs now, not the values stamped at the launch of the caller. A model change in mid-session is the truer meaning of "a child like me".
- The inherited model and effort apply only when the child kind is the caller kind. A cross-kind `--agent` rebase drops both. A model id is specific to one provider, and six built-in kinds cannot render an effort flag.
- The allowlist matches spec words literally, for the positional spec and for `--agent`. Entries are validated when the config loads. A typo fails early instead of blocking a launch in silence.
- The allowlist is not part of the trust hash. The field only narrows what a config can launch. It adds no executable surface.
- `rimz subagents profiles` still works from a user shell. Inside an agent it resolves the caller and shows only the allowed specs.

## Implementation

The supervised runner now resolves the caller before it resolves the spec, because both new rules need the caller first. One decision keeps or drops the whole inherited preset, so the model and the effort cannot diverge. The catalog command builds its list from the effective configuration in both doorways, so a user shell and an agent show the same profiles. Trusted project profiles also report their source path.

`general` is a reserved name in `[subagents.profiles]` and in `[agents.commands]`. A configuration that uses that name now fails to load, with the reason.

Deviations from the plan:

- The plan asked for two new public types, `GeneralLaunch` and `SpecNotAllowed`. The existing `LaunchPreset` and `LayoutErr` carry the same information. The reuse removes two public concepts and holds the harness surface budget down.
- The plan asked for new parameters on the profile renderer. The lint gate refused the wide signature. Each doorway now assembles and filters its own report list, and the renderer takes one narrow input.
- The plan asked for a new trust test. The coverage went into the existing unknown-field test instead, which keeps it inside the invariant that already guards the hash surface.

Verification: `cargo xtask gate` passes, with 5,916 tests. `cargo xtask invariants` and `cargo xtask docs-links` pass.

## Advisories

- The allowlist governs the `rimz subagents` doorway only. An agent of a limited profile can still call `rimz agents <spec>` and get an unlimited peer. Read `subagents = [...]` as a delegation limit, not as a sandbox.
- The allowlist stays out of the trust hash on purpose. A trusted project profile replaces a machine profile of the same name in full, so it can drop a limit that the machine configuration sets. This cannot happen in silence, because a project profile must declare `agent`, and that field is in the hash.
- Two surface budgets in `refactor-target.toml` go up: the harness from 578 to 585, and the config module from 12 to 13. The CLI reaches the new policy module and the new provenance method through the library path, so these items cannot be less than public.
- No real provider child was started in a disposable multiplexer, because that costs a live provider turn. Tests cover the launch composition, the refusal, the merged configuration, and the preset precedence.

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>forge</code> team · 3 agents · 1h19m active · $44.34 · 16 messages (1 from you)</summary>

- **planner** — Claude `claude-fable-5@high`
  - effort: 7m active · $11.96 incl. subagents
  - calls: 50 tool calls
  - messages: 1 from you · 4 from teammates · 5 to teammates
  - tokens: 22.3k input, 36.1k output, 420.2k cache write, 8.3m cache read
  - subagents: 1 × explore ($1.37)
- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 54m active · $22.09
  - calls: 214 tool calls · 1 compaction
  - messages: 6 from teammates · 5 to teammates
  - tokens: 996.6k input, 76.2k output, 41.4m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 17m active · $10.29 incl. subagents
  - calls: 86 tool calls
  - messages: 5 from teammates · 5 to teammates
  - tokens: 216 input, 71.1k output, 286.9k cache write, 11.9m cache read
  - subagents: 1 × general-purpose ($1.12)

</details>