### PR TITLE
perf(store): bound cached context reads and launch-identity resolution

### DIFF
--- a/crates/rimz/src/cli/hooks/binding.rs
+++ b/crates/rimz/src/cli/hooks/binding.rs
@@ -71,7 +71,7 @@ pub(super) fn recover_focused_pane_binding(
     };
 
     let kind_id = AgentKind::new_unchecked(kind);
-    let mut snapshot = match store.snapshot_cached() {
+    let snapshot = match store.snapshot_cached() {
         Ok(snapshot) => snapshot,
         Err(err) => {
             debug!(
@@ -98,29 +98,6 @@ pub(super) fn recover_focused_pane_binding(
     .already_stamped()
     {
         return;
-    }
-    // A provider-rested owner must not block the conversation replacing it;
-    // read only the keyed sidecars that can affect this hook's pane choice.
-    for agent in snapshot
-        .agents
-        .iter_mut()
-        .filter(|agent| agent.kind == kind_id)
-    {
-        if agent.ended_at.is_some()
-            || agent.is_provider_subagent()
-            || !matches!(
-                agent.status,
-                rimz::agents::AgentStatus::Running | rimz::agents::AgentStatus::Waiting
-            )
-        {
-            continue;
-        }
-        agent.context = rimz::store::agent_context::read_one(
-            store.runtime_paths(),
-            agent.kind.as_str(),
-            agent.agent_id.as_str(),
-        )
-        .map(|record| record.context);
     }
     let recovery = HookPaneRecoveryContext::new(
         &kind_id,

--- a/crates/rimz/src/store/agent_context.rs
+++ b/crates/rimz/src/store/agent_context.rs
@@ -480,7 +480,7 @@ pub fn read_all(runtime: &RuntimePaths) -> Vec<AgentContextRecord> {
 }
 
 /// Read context only for identities already present in the snapshot.
-pub fn read_for_keys<'a>(
+pub(super) fn read_for_keys<'a>(
     runtime: &RuntimePaths,
     keys: impl IntoIterator<Item = (&'a str, &'a str)>,
 ) -> Vec<AgentContextRecord> {

--- a/crates/rimz/src/store/agent_context.rs
+++ b/crates/rimz/src/store/agent_context.rs
@@ -479,6 +479,15 @@ pub fn read_all(runtime: &RuntimePaths) -> Vec<AgentContextRecord> {
     CONTEXT_PARSE_CACHE.with(|cache| sidecar::read_all(&runtime.agent_context_dir, cache))
 }
 
+/// Read context only for identities already present in the snapshot.
+pub fn read_for_keys<'a>(
+    runtime: &RuntimePaths,
+    keys: impl IntoIterator<Item = (&'a str, &'a str)>,
+) -> Vec<AgentContextRecord> {
+    CONTEXT_PARSE_CACHE
+        .with(|cache| sidecar::read_for_keys(&runtime.agent_context_dir, keys, cache))
+}
+
 /// Remove a session's sidecar on `SessionEnd` or reap. Best-effort:
 /// a missing file is success.
 pub fn remove(runtime: &RuntimePaths, kind: &str, agent_id: &str) -> std::io::Result<()> {

--- a/crates/rimz/src/store/mod.rs
+++ b/crates/rimz/src/store/mod.rs
@@ -181,7 +181,14 @@ impl Store {
             Some(snapshot) => snapshot,
             None => self.snapshot()?,
         };
-        Ok(snapshot.with_agent_context(agent_context::read_all(&self.inner.runtime)))
+        let context = agent_context::read_for_keys(
+            &self.inner.runtime,
+            snapshot
+                .agents
+                .iter()
+                .map(|agent| (agent.kind.as_str(), agent.agent_id.as_str())),
+        );
+        Ok(snapshot.with_agent_context(context))
     }
 
     /// Walk the event log, returning every parseable record and logging
@@ -312,12 +319,25 @@ mod tests {
             ..AgentContext::new("claude", error_at)
         };
         agent_context::write(&runtime, "claude", "agent-0", &context).unwrap();
+        agent_context::write(
+            &runtime,
+            "claude",
+            "unrelated-agent",
+            &AgentContext::new("claude", error_at),
+        )
+        .unwrap();
 
+        sidecar::testkit::reset_parse_reads();
         let snapshot = store.snapshot_cached().unwrap();
         let agent = &snapshot.agents[0];
 
         assert_eq!(agent.status, AgentStatus::Running);
         assert!(!agent.holds_open_turn());
+        assert_eq!(
+            sidecar::testkit::parse_reads(),
+            1,
+            "cached snapshots read context only for projected agent keys"
+        );
     }
 
     fn lifecycle(workspace_id: &WorkspaceId, index: usize) -> EventEnvelope {

--- a/crates/rimz/src/store/sidecar.rs
+++ b/crates/rimz/src/store/sidecar.rs
@@ -19,6 +19,27 @@ use sha2::{Digest, Sha256};
 
 use crate::store::atomic;
 
+#[cfg(test)]
+pub(crate) mod testkit {
+    use std::cell::Cell;
+
+    thread_local! {
+        static PARSE_READS: Cell<usize> = const { Cell::new(0) };
+    }
+
+    pub(crate) fn record_parse_read() {
+        PARSE_READS.set(PARSE_READS.get() + 1);
+    }
+
+    pub(crate) fn reset_parse_reads() {
+        PARSE_READS.set(0);
+    }
+
+    pub(crate) fn parse_reads() -> usize {
+        PARSE_READS.get()
+    }
+}
+
 pub(crate) trait SidecarRecord: Serialize + DeserializeOwned + Clone {
     const FILE_PREFIX: &'static str;
 
@@ -170,6 +191,8 @@ pub(crate) fn read_all<R: SidecarRecord>(dir: &Path, cache: &ParseCache<R>) -> V
         let record = match cache.get(&path) {
             Some(parsed) if parsed.mtime == mtime && parsed.len == len => parsed.record.clone(),
             _ => {
+                #[cfg(test)]
+                testkit::record_parse_read();
                 let record = fs::read(&path)
                     .ok()
                     .and_then(|bytes| serde_json::from_slice(&bytes).ok());
@@ -220,6 +243,8 @@ pub(crate) fn read_for_keys<'a, R: SidecarRecord>(
             let record = match cache.get(&record_path) {
                 Some(parsed) if parsed.mtime == mtime && parsed.len == len => parsed.record.clone(),
                 _ => {
+                    #[cfg(test)]
+                    testkit::record_parse_read();
                     let record = fs::read(&record_path)
                         .ok()
                         .and_then(|bytes| serde_json::from_slice(&bytes).ok());

--- a/crates/rimz/src/store/snapshot/project.rs
+++ b/crates/rimz/src/store/snapshot/project.rs
@@ -11,7 +11,7 @@ use crate::agents::lifecycle::{self, Transition};
 use crate::agents::state::{append_recent_prompt, usable_description};
 use crate::agents::{AgentLifecycleObservation, LaunchParams};
 use crate::agents::{AgentState, AgentStatus};
-use crate::ids::{AgentKind, AgentSessionId, PaneId};
+use crate::ids::{AgentKind, AgentSessionId};
 use crate::message::{MessageBody, MessageStatus};
 use crate::pane::{PaneRef, RuntimeOwner, RuntimeOwnerKind};
 use crate::store::event::{
@@ -26,7 +26,7 @@ pub(super) use identity::backfill_agent_identities;
 use identity::{CardIdentity, CardIdentityAllocator, usable_name};
 
 type AgentKey = (AgentKind, AgentSessionId);
-type LaunchInstanceKey = (AgentKind, PaneId, u32);
+type LaunchInstanceKey = (AgentKind, crate::ids::PaneId, u32);
 
 #[derive(Default)]
 struct LaunchIdentityIndex {

--- a/crates/rimz/src/store/snapshot/project.rs
+++ b/crates/rimz/src/store/snapshot/project.rs
@@ -2,7 +2,7 @@
 //! [`AgentState`] rollups, carrying turn, phase, subagent, and model
 //! state forward.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use jiff::Timestamp;
 use tracing::debug;
@@ -11,7 +11,7 @@ use crate::agents::lifecycle::{self, Transition};
 use crate::agents::state::{append_recent_prompt, usable_description};
 use crate::agents::{AgentLifecycleObservation, LaunchParams};
 use crate::agents::{AgentState, AgentStatus};
-use crate::ids::{AgentKind, AgentSessionId};
+use crate::ids::{AgentKind, AgentSessionId, PaneId};
 use crate::message::{MessageBody, MessageStatus};
 use crate::pane::{PaneRef, RuntimeOwner, RuntimeOwnerKind};
 use crate::store::event::{
@@ -24,6 +24,110 @@ mod identity;
 pub(crate) use identity::AgentIdentityState;
 pub(super) use identity::backfill_agent_identities;
 use identity::{CardIdentity, CardIdentityAllocator, usable_name};
+
+type AgentKey = (AgentKind, AgentSessionId);
+type LaunchInstanceKey = (AgentKind, PaneId, u32);
+
+#[derive(Default)]
+struct LaunchIdentityIndex {
+    by_instance: HashMap<LaunchInstanceKey, BTreeSet<AgentKey>>,
+    by_agent: HashMap<AgentKey, LaunchInstanceKey>,
+}
+
+impl LaunchIdentityIndex {
+    fn from_map(map: &BTreeMap<AgentKey, AgentState>) -> Self {
+        let mut index = Self::default();
+        for (key, state) in map {
+            index.replace(key, state);
+        }
+        index
+    }
+
+    fn replace(&mut self, key: &AgentKey, state: &AgentState) {
+        self.remove(key);
+        if state.launch_id.is_none() || state.is_provider_subagent() {
+            return;
+        }
+        let Some(instance) = launch_instance_key(state) else {
+            return;
+        };
+        self.by_instance
+            .entry(instance.clone())
+            .or_default()
+            .insert(key.clone());
+        self.by_agent.insert(key.clone(), instance);
+    }
+
+    fn remove(&mut self, key: &AgentKey) {
+        let Some(instance) = self.by_agent.remove(key) else {
+            return;
+        };
+        let Some(keys) = self.by_instance.get_mut(&instance) else {
+            return;
+        };
+        keys.remove(key);
+        if keys.is_empty() {
+            self.by_instance.remove(&instance);
+        }
+    }
+
+    fn predecessor<'a>(
+        &self,
+        map: &'a BTreeMap<AgentKey, AgentState>,
+        successor: &AgentState,
+    ) -> Option<&'a AgentState> {
+        let instance = launch_instance_key(successor)?;
+        self.by_instance
+            .get(&instance)?
+            .iter()
+            .filter_map(|key| {
+                #[cfg(test)]
+                launch_identity_testkit::record_candidate_inspection();
+                map.get(key)
+            })
+            .filter(|candidate| {
+                candidate.kind == successor.kind
+                    && candidate.agent_id != successor.agent_id
+                    && candidate.launch_id.is_some()
+                    && !candidate.is_provider_subagent()
+                    && crate::store::session_death::same_agent_instance(candidate, successor)
+            })
+            .min_by_key(|candidate| {
+                (
+                    candidate.registered_at.is_none(),
+                    candidate.registered_at,
+                    candidate.agent_id.clone(),
+                )
+            })
+    }
+}
+
+fn launch_instance_key(state: &AgentState) -> Option<LaunchInstanceKey> {
+    let pane_id = state.pane.as_ref()?.pane_id.clone();
+    let owner = state.runtime_owner.as_ref()?;
+    (owner.kind == RuntimeOwnerKind::Agent).then(|| (state.kind.clone(), pane_id, owner.pid))
+}
+
+#[cfg(test)]
+mod launch_identity_testkit {
+    use std::cell::Cell;
+
+    thread_local! {
+        static CANDIDATE_INSPECTIONS: Cell<usize> = const { Cell::new(0) };
+    }
+
+    pub(super) fn record_candidate_inspection() {
+        CANDIDATE_INSPECTIONS.set(CANDIDATE_INSPECTIONS.get() + 1);
+    }
+
+    pub(super) fn reset_candidate_inspections() {
+        CANDIDATE_INSPECTIONS.set(0);
+    }
+
+    pub(super) fn candidate_inspections() -> usize {
+        CANDIDATE_INSPECTIONS.get()
+    }
+}
 
 /// Strip a trailing capability tag (`claude-opus-4-8[1m]` → `claude-opus-4-8`)
 /// so the sidebar shows one stable model id per agent. The tag rides only on a
@@ -138,23 +242,38 @@ pub(super) fn reduce_agent_states_seeded_with_identity(
 ) {
     let mut map = seed;
     let mut identity = CardIdentityAllocator::from_map_and_state(&map, identity_state);
+    let mut launch_identity = LaunchIdentityIndex::from_map(&map);
     for event in events {
         let envelope = event.envelope;
         match &event.kind {
             EventKind::SessionRebirth => {
                 unstamp_for_rebirth(map.values_mut());
                 identity.reset_ordinals();
+                launch_identity = LaunchIdentityIndex::from_map(&map);
             }
             EventKind::AgentLaunch(payload) => {
                 let kind = AgentKind::new_unchecked(envelope.source.clone());
-                reduce_agent_launch(&mut map, &mut identity, envelope, &kind, payload);
+                reduce_agent_launch(
+                    &mut map,
+                    &mut identity,
+                    &mut launch_identity,
+                    envelope,
+                    &kind,
+                    payload,
+                );
             }
             EventKind::AgentAttach(payload) => {
                 let kind = AgentKind::new_unchecked(envelope.source.clone());
-                reduce_agent_attach(&mut map, envelope, &kind, payload);
+                reduce_agent_attach(&mut map, &mut launch_identity, envelope, &kind, payload);
             }
             EventKind::AgentLifecycle(payload) => {
-                reduce_lifecycle_event(&mut map, &mut identity, envelope, payload);
+                reduce_lifecycle_event(
+                    &mut map,
+                    &mut identity,
+                    &mut launch_identity,
+                    envelope,
+                    payload,
+                );
             }
             EventKind::Message { payload, .. } => {
                 stamp_compact_command(map.values_mut(), payload);
@@ -177,7 +296,8 @@ pub(super) fn reduce_agent_states_seeded_with_identity(
 }
 
 fn reduce_agent_attach(
-    map: &mut BTreeMap<(AgentKind, AgentSessionId), AgentState>,
+    map: &mut BTreeMap<AgentKey, AgentState>,
+    launch_identity: &mut LaunchIdentityIndex,
     event: &EventEnvelope,
     kind: &AgentKind,
     payload: &AgentAttachPayload,
@@ -196,7 +316,7 @@ fn reduce_agent_attach(
     // A discovered provider session may have no prior RimZ event. The resume
     // wrapper knows enough durable identity to seed it before the provider
     // process starts, so the process can launch children immediately.
-    let state = map.entry(key).or_insert_with(|| {
+    let state = map.entry(key.clone()).or_insert_with(|| {
         AgentState::seed(
             kind.clone(),
             payload.agent_id.clone(),
@@ -212,11 +332,13 @@ fn reduce_agent_attach(
         ..PaneRef::from_id(payload.pane_id.clone())
     });
     state.runtime_owner = Some(payload.runtime_owner.clone());
+    launch_identity.replace(&key, state);
 }
 
 fn reduce_lifecycle_event(
-    map: &mut BTreeMap<(AgentKind, AgentSessionId), AgentState>,
+    map: &mut BTreeMap<AgentKey, AgentState>,
     identity: &mut CardIdentityAllocator,
+    launch_identity: &mut LaunchIdentityIndex,
     event: &EventEnvelope,
     payload: &AgentLifecyclePayload,
 ) {
@@ -252,10 +374,17 @@ fn reduce_lifecycle_event(
         // provisional-release key.
         None
     } else if map.contains_key(&key) {
-        release_stamped_provisional_for_existing(map, identity, &kind, &key, observation);
+        release_stamped_provisional_for_existing(
+            map,
+            identity,
+            launch_identity,
+            &kind,
+            &key,
+            observation,
+        );
         None
     } else {
-        adopt_provisional(map, identity, &kind, &key, observation)
+        adopt_provisional(map, identity, launch_identity, &kind, &key, observation)
     };
     let event_name = payload.event_name.as_deref();
     let event_parent_agent_id =
@@ -306,7 +435,8 @@ fn reduce_lifecycle_event(
         card_identity,
     });
     inherit_compaction_registration(map, &mut state);
-    inherit_launch_identity(map, &mut state);
+    inherit_launch_identity(map, launch_identity, &mut state);
+    launch_identity.replace(&key, &state);
     map.insert(key, state);
 }
 
@@ -340,8 +470,9 @@ fn quarantine_reason(
 }
 
 fn adopt_provisional(
-    map: &mut BTreeMap<(AgentKind, AgentSessionId), AgentState>,
+    map: &mut BTreeMap<AgentKey, AgentState>,
     identity: &mut CardIdentityAllocator,
+    launch_identity: &mut LaunchIdentityIndex,
     kind: &AgentKind,
     key: &(AgentKind, AgentSessionId),
     observation: &AgentLifecycleObservation,
@@ -350,7 +481,7 @@ fn adopt_provisional(
         .agent_name
         .as_deref()
         .and_then(|name| identity.adoptable_owner_for_name(map, kind, name, key))
-        && let Some(prior) = retire_provisional(map, identity, &provisional_key)
+        && let Some(prior) = retire_provisional(map, identity, launch_identity, &provisional_key)
     {
         return Some(prior);
     }
@@ -358,12 +489,13 @@ fn adopt_provisional(
         .pane_id
         .as_ref()
         .and_then(|pane_id| identity.adoptable_owner_for_pane(map, kind, pane_id, key))?;
-    retire_provisional(map, identity, &provisional_key)
+    retire_provisional(map, identity, launch_identity, &provisional_key)
 }
 
 fn release_stamped_provisional_for_existing(
-    map: &mut BTreeMap<(AgentKind, AgentSessionId), AgentState>,
+    map: &mut BTreeMap<AgentKey, AgentState>,
     identity: &mut CardIdentityAllocator,
+    launch_identity: &mut LaunchIdentityIndex,
     kind: &AgentKind,
     key: &(AgentKind, AgentSessionId),
     observation: &AgentLifecycleObservation,
@@ -381,23 +513,26 @@ fn release_stamped_provisional_for_existing(
     else {
         return;
     };
-    let _ = retire_provisional(map, identity, &provisional_key);
+    let _ = retire_provisional(map, identity, launch_identity, &provisional_key);
 }
 
 fn retire_provisional(
-    map: &mut BTreeMap<(AgentKind, AgentSessionId), AgentState>,
+    map: &mut BTreeMap<AgentKey, AgentState>,
     identity: &mut CardIdentityAllocator,
-    key: &(AgentKind, AgentSessionId),
+    launch_identity: &mut LaunchIdentityIndex,
+    key: &AgentKey,
 ) -> Option<AgentState> {
     let prior = map.remove(key);
+    launch_identity.remove(key);
     identity.release_key(key);
     identity.consume_launch_key(key);
     prior
 }
 
 fn reduce_agent_launch(
-    map: &mut BTreeMap<(AgentKind, AgentSessionId), AgentState>,
+    map: &mut BTreeMap<AgentKey, AgentState>,
     identity: &mut CardIdentityAllocator,
+    launch_identity: &mut LaunchIdentityIndex,
     event: &EventEnvelope,
     kind: &AgentKind,
     payload: &AgentLaunchPayload,
@@ -441,6 +576,7 @@ fn reduce_agent_launch(
     let prior = map.get(&key);
     let card_identity = identity.assign_launch(kind, &payload.agent_id, payload, prior);
     let state = assemble_launch_state(kind, event, payload, prior, card_identity);
+    launch_identity.replace(&key, &state);
     map.insert(key, state);
 }
 
@@ -684,7 +820,8 @@ fn inherit_compaction_registration(
 /// conversation change. Card naming stays session-scoped, and only an explicit
 /// compaction edge inherits registration primacy.
 fn inherit_launch_identity(
-    map: &BTreeMap<(AgentKind, AgentSessionId), AgentState>,
+    map: &BTreeMap<AgentKey, AgentState>,
+    launch_identity: &LaunchIdentityIndex,
     successor: &mut AgentState,
 ) {
     if successor.launch_id.is_some()
@@ -694,23 +831,7 @@ fn inherit_launch_identity(
     {
         return;
     }
-    let Some(predecessor) = map
-        .values()
-        .filter(|candidate| {
-            candidate.kind == successor.kind
-                && candidate.agent_id != successor.agent_id
-                && candidate.launch_id.is_some()
-                && !candidate.is_provider_subagent()
-                && crate::store::session_death::same_agent_instance(candidate, successor)
-        })
-        .min_by_key(|candidate| {
-            (
-                candidate.registered_at.is_none(),
-                candidate.registered_at,
-                candidate.agent_id.clone(),
-            )
-        })
-    else {
+    let Some(predecessor) = launch_identity.predecessor(map, successor) else {
         return;
     };
 

--- a/crates/rimz/src/store/snapshot/project/tests/mod.rs
+++ b/crates/rimz/src/store/snapshot/project/tests/mod.rs
@@ -6,7 +6,7 @@ use super::super::view::{attach_sub_agents, row_from_agent, sub_agent_from_state
 use crate::agents::lifecycle::TurnPhase;
 use crate::agents::{AgentStatus, LaunchParams, PermissionMode, SessionOrigin};
 use crate::ids::{AgentKind, AgentSessionId, PaneId, WorkspaceId};
-use crate::pane::{RuntimeOwner, RuntimeOwnerKind};
+use crate::pane::{PaneRef, RuntimeOwner, RuntimeOwnerKind};
 use crate::store::event::{
     AgentAttachPayload, AgentLaunchPayload, AgentLaunchState, EventEnvelope,
 };
@@ -69,6 +69,28 @@ fn same_process_registration(
             },
         }),
     )
+}
+
+fn indexed_launch_agent(
+    id: &str,
+    pane_id: &str,
+    owner_pid: u32,
+    launch_id: Option<&str>,
+) -> AgentState {
+    let mut agent = crate::testkit::agent_state("codex", id, epoch());
+    agent.launch_id = launch_id.map(AgentSessionId::from);
+    agent.registered_at = Some(epoch());
+    agent.pane = Some(PaneRef {
+        pane_process_start: Some(epoch()),
+        ..PaneRef::from_id(PaneId::parse(pane_id).expect("pane id"))
+    });
+    agent.runtime_owner = Some(RuntimeOwner::new(
+        RuntimeOwnerKind::Agent,
+        id,
+        owner_pid,
+        Some("agent-start".to_owned()),
+    ));
+    agent
 }
 
 fn launch_payload(agent_id: &str, agent_name: &str) -> AgentLaunchPayload {
@@ -1094,6 +1116,79 @@ fn follow_latest_successor_inherits_launch_identity_without_origin() {
 
     assert_eq!(successor.launch_id.as_deref(), Some("launch_coder"));
     assert_eq!(successor.role.as_deref(), Some("coder"));
+}
+
+#[test]
+fn launch_identity_retry_inspects_only_same_instance_candidates() {
+    let pane_id = "tmux:%5";
+    let owner_pid = 210;
+    let mut seed = BTreeMap::new();
+    let mut predecessor = indexed_launch_agent("conversation-a", pane_id, owner_pid, None);
+    predecessor.role = Some("coder".to_owned());
+    let successor = indexed_launch_agent("conversation-b", pane_id, owner_pid, None);
+    seed.insert(
+        (predecessor.kind.clone(), predecessor.agent_id.clone()),
+        predecessor,
+    );
+    seed.insert(
+        (successor.kind.clone(), successor.agent_id.clone()),
+        successor,
+    );
+    for index in 0..128 {
+        let candidate = indexed_launch_agent(
+            &format!("unrelated-{index}"),
+            &format!("tmux:%{}", index + 10),
+            owner_pid + index + 1,
+            Some(&format!("launch-unrelated-{index}")),
+        );
+        seed.insert(
+            (candidate.kind.clone(), candidate.agent_id.clone()),
+            candidate,
+        );
+    }
+
+    let attach = EventEnvelope::agent_attached(
+        workspace(),
+        "session",
+        &AgentKind::new_unchecked("codex"),
+        AgentAttachPayload {
+            agent_id: AgentSessionId::from("conversation-a"),
+            launch_id: Some(AgentSessionId::from("launch-coder")),
+            pane_id: PaneId::parse(pane_id).expect("pane id"),
+            pane_pid: None,
+            runtime_owner: RuntimeOwner::new(
+                RuntimeOwnerKind::Agent,
+                "conversation-a",
+                owner_pid,
+                Some("agent-start".to_owned()),
+            ),
+        },
+    );
+    let heartbeat = raw_lifecycle_at(
+        "codex",
+        3,
+        json!({
+            "agent_id": "conversation-b",
+            "signal": { "signal": "turn_started" },
+        }),
+    );
+
+    launch_identity_testkit::reset_candidate_inspections();
+    let agents = reduce_agent_states_seeded(seed, &[attach, heartbeat]);
+    let successor = agents
+        .get(&(
+            AgentKind::new_unchecked("codex"),
+            AgentSessionId::from("conversation-b"),
+        ))
+        .expect("successor");
+
+    assert_eq!(successor.launch_id.as_deref(), Some("launch-coder"));
+    assert_eq!(successor.role.as_deref(), Some("coder"));
+    assert_eq!(
+        launch_identity_testkit::candidate_inspections(),
+        1,
+        "unrelated launch identities stay outside the same-instance bucket"
+    );
 }
 
 #[test]

--- a/crates/rimz/src/store/snapshot/project/tests/mod.rs
+++ b/crates/rimz/src/store/snapshot/project/tests/mod.rs
@@ -6,7 +6,7 @@ use super::super::view::{attach_sub_agents, row_from_agent, sub_agent_from_state
 use crate::agents::lifecycle::TurnPhase;
 use crate::agents::{AgentStatus, LaunchParams, PermissionMode, SessionOrigin};
 use crate::ids::{AgentKind, AgentSessionId, PaneId, WorkspaceId};
-use crate::pane::{PaneRef, RuntimeOwner, RuntimeOwnerKind};
+use crate::pane::{RuntimeOwner, RuntimeOwnerKind};
 use crate::store::event::{
     AgentAttachPayload, AgentLaunchPayload, AgentLaunchState, EventEnvelope,
 };
@@ -80,9 +80,9 @@ fn indexed_launch_agent(
     let mut agent = crate::testkit::agent_state("codex", id, epoch());
     agent.launch_id = launch_id.map(AgentSessionId::from);
     agent.registered_at = Some(epoch());
-    agent.pane = Some(PaneRef {
+    agent.pane = Some(crate::pane::PaneRef {
         pane_process_start: Some(epoch()),
-        ..PaneRef::from_id(PaneId::parse(pane_id).expect("pane id"))
+        ..crate::pane::PaneRef::from_id(PaneId::parse(pane_id).expect("pane id"))
     });
     agent.runtime_owner = Some(RuntimeOwner::new(
         RuntimeOwnerKind::Agent,

--- a/crates/rimz/src/store/snapshot/view.rs
+++ b/crates/rimz/src/store/snapshot/view.rs
@@ -457,11 +457,11 @@ impl SidebarSnapshot {
     /// Attach each session's rich context sidecar to its `AgentState` by
     /// `(kind, agent_id)`. Context is display-only and never changes durable
     /// lifecycle truth or `last_activity`; explicit context markers may refine
-    /// a displayed status and its attention rank. Context reaches rows only
-    /// through the live-pane fold. A context whose session is absent from the (already
-    /// reaped) rollup is dropped — the session is gone, so its context is just
-    /// history. Records carry no identity of their own; the key they're filed
-    /// under is authority.
+    /// a displayed status and its attention rank. Shared cached-snapshot and
+    /// live-pane folds both use this join. A context whose session is absent
+    /// from the (already reaped) rollup is dropped — the session is gone, so
+    /// its context is just history. Records carry no identity of their own;
+    /// the key they're filed under is authority.
     pub fn with_agent_context(mut self, records: Vec<AgentContextRecord>) -> Self {
         if records.is_empty() {
             return self;

--- a/crates/rimz/tests/integration/run.rs
+++ b/crates/rimz/tests/integration/run.rs
@@ -1689,6 +1689,29 @@ fn agents_cli_routes_launch_role_to_successful_same_instance_successor() {
     let store = env.store();
     let pane_id = PaneId::from_parts(MuxName::Tmux, "%1");
     let owner_pid = std::process::id();
+    let append_lifecycle =
+        |agent_id: &str, name: &str, origin: SessionOrigin, signal: LifecycleSignal| {
+            let mut observation =
+                AgentLifecycleObservation::new(Some(AgentSessionId::from(agent_id)), signal);
+            observation.agent_name = Some(name.to_owned());
+            observation.origin = Some(origin);
+            observation.worktree_path = Some(workspace.project_root.display().to_string());
+            observation.pane_id = Some(pane_id.clone());
+            observation.runtime_owner = Some(rimz::store::runtime::process_owner(
+                rimz::RuntimeOwnerKind::Agent,
+                agent_id,
+                owner_pid,
+            ));
+            store
+                .append_event(&EventEnvelope::agent_lifecycle(
+                    workspace.workspace_id.clone(),
+                    workspace.session_name.clone(),
+                    "codex",
+                    "agent-hook",
+                    &observation,
+                ))
+                .expect("append lifecycle");
+        };
     let launch_id = AgentSessionId::from("launch-coder");
     store
         .append_event(&EventEnvelope::agent_launched(
@@ -1743,26 +1766,8 @@ fn agents_cli_routes_launch_role_to_successful_same_instance_successor() {
             },
         ),
     ] {
-        append_card_state_lifecycle(
-            &store,
-            &workspace,
-            &pane_id,
-            owner_pid,
-            agent_id,
-            name,
-            origin,
-            LifecycleSignal::Registered,
-        );
-        append_card_state_lifecycle(
-            &store,
-            &workspace,
-            &pane_id,
-            owner_pid,
-            agent_id,
-            name,
-            origin,
-            terminal_signal,
-        );
+        append_lifecycle(agent_id, name, origin, LifecycleSignal::Registered);
+        append_lifecycle(agent_id, name, origin, terminal_signal);
     }
     for agent_id in ["first", "second"] {
         let at = Timestamp::now();
@@ -1796,38 +1801,6 @@ fn agents_cli_routes_launch_role_to_successful_same_instance_successor() {
     let shown =
         run_agents_json_command(&env, &workspace.session_name, &["agents", "show", "@coder"]);
     assert_eq!(shown["agent"]["id"], "successful");
-}
-
-fn append_card_state_lifecycle(
-    store: &rimz::Store,
-    workspace: &rimz::ResolvedWorkspace,
-    pane_id: &PaneId,
-    owner_pid: u32,
-    agent_id: &str,
-    name: &str,
-    origin: SessionOrigin,
-    signal: LifecycleSignal,
-) {
-    let mut observation =
-        AgentLifecycleObservation::new(Some(AgentSessionId::from(agent_id)), signal);
-    observation.agent_name = Some(name.to_owned());
-    observation.origin = Some(origin);
-    observation.worktree_path = Some(workspace.project_root.display().to_string());
-    observation.pane_id = Some(pane_id.clone());
-    observation.runtime_owner = Some(rimz::store::runtime::process_owner(
-        rimz::RuntimeOwnerKind::Agent,
-        agent_id,
-        owner_pid,
-    ));
-    store
-        .append_event(&EventEnvelope::agent_lifecycle(
-            workspace.workspace_id.clone(),
-            workspace.session_name.clone(),
-            "codex",
-            "agent-hook",
-            &observation,
-        ))
-        .expect("append lifecycle");
 }
 
 #[test]

--- a/crates/rimz/tests/integration/run.rs
+++ b/crates/rimz/tests/integration/run.rs
@@ -6,8 +6,9 @@ use crate::common::{
 use jiff::Timestamp;
 use rimz::agents::PermissionMode;
 use rimz::agents::{
-    AgentLifecycleObservation, AgentRateLimits, LaunchParams, LifecycleSignal, RateLimitCacheEntry,
-    RateLimitWindow, RateLimitsCache,
+    AgentContext, AgentLifecycleObservation, AgentRateLimits, AgentTurnError, LaunchParams,
+    LifecycleSignal, RateLimitCacheEntry, RateLimitWindow, RateLimitsCache, SessionOrigin,
+    TurnErrorClass,
 };
 use rimz::harness::run::{RunRecord, RunStatus};
 use rimz::ids::{AgentKind, AgentSessionId, MuxName, PaneId, ViewKind};
@@ -1682,6 +1683,154 @@ fn assert_agents_list_requires_live_room(env: &Env, args: &[&str]) {
 }
 
 #[test]
+fn agents_cli_routes_launch_role_to_successful_same_instance_successor() {
+    let env = Env::new();
+    let workspace = rimz::WorkspaceResolver::resolve(&env.project_root, None).expect("workspace");
+    let store = env.store();
+    let pane_id = PaneId::from_parts(MuxName::Tmux, "%1");
+    let owner_pid = std::process::id();
+    let launch_id = AgentSessionId::from("launch-coder");
+    store
+        .append_event(&EventEnvelope::agent_launched(
+            workspace.workspace_id.clone(),
+            workspace.session_name.clone(),
+            &AgentKind::new_unchecked("codex"),
+            AgentLaunchPayload {
+                agent_id: launch_id.clone(),
+                launch_id: Some(launch_id.clone()),
+                agent_name: "coder-card".to_owned(),
+                agent_name_explicit: true,
+                launch: LaunchParams {
+                    role: Some("coder".to_owned()),
+                    ..LaunchParams::default()
+                },
+                state: AgentLaunchState::Bound,
+                run_id: None,
+                pane_id: Some(pane_id.clone()),
+                runtime_owner: Some(rimz::store::runtime::process_owner(
+                    rimz::RuntimeOwnerKind::Agent,
+                    launch_id.as_str(),
+                    owner_pid,
+                )),
+                worktree_path: Some(env.project_root.display().to_string()),
+                worktree_branch: None,
+                prompt: None,
+                description: None,
+            },
+        ))
+        .expect("append launch");
+
+    for (agent_id, name, origin, terminal_signal) in [
+        (
+            "first",
+            "coder-card",
+            SessionOrigin::Fresh,
+            LifecycleSignal::TurnStarted,
+        ),
+        (
+            "second",
+            "second-card",
+            SessionOrigin::Fresh,
+            LifecycleSignal::TurnStarted,
+        ),
+        (
+            "successful",
+            "successful-card",
+            SessionOrigin::Forked,
+            LifecycleSignal::TurnEnded {
+                errored: false,
+                parked_on_background: false,
+            },
+        ),
+    ] {
+        append_card_state_lifecycle(
+            &store,
+            &workspace,
+            &pane_id,
+            owner_pid,
+            agent_id,
+            name,
+            origin,
+            LifecycleSignal::Registered,
+        );
+        append_card_state_lifecycle(
+            &store,
+            &workspace,
+            &pane_id,
+            owner_pid,
+            agent_id,
+            name,
+            origin,
+            terminal_signal,
+        );
+    }
+    for agent_id in ["first", "second"] {
+        let at = Timestamp::now();
+        let mut context = AgentContext::new("codex", at);
+        context.turn_error = Some(AgentTurnError {
+            class: TurnErrorClass::PausedOverloaded,
+            at,
+            label: Some("server_overloaded".to_owned()),
+        });
+        rimz::store::agent_context::write_record(
+            &env.runtime_paths(),
+            &rimz::store::agent_context::new_record("codex", agent_id, context),
+        )
+        .expect("write provider rest certificate");
+    }
+    publish_pane_frame(
+        &env,
+        &workspace.session_name,
+        vec![list_pane(
+            &workspace.session_name,
+            "%1",
+            "codex",
+            &env.project_root,
+        )],
+    );
+
+    let listed = run_agents_json_command(&env, &workspace.session_name, &["agents", "list"]);
+    assert_agent_ids(&listed, &["successful"]);
+    assert_eq!(listed["agents"][0]["handle"], "@coder");
+
+    let shown =
+        run_agents_json_command(&env, &workspace.session_name, &["agents", "show", "@coder"]);
+    assert_eq!(shown["agent"]["id"], "successful");
+}
+
+fn append_card_state_lifecycle(
+    store: &rimz::Store,
+    workspace: &rimz::ResolvedWorkspace,
+    pane_id: &PaneId,
+    owner_pid: u32,
+    agent_id: &str,
+    name: &str,
+    origin: SessionOrigin,
+    signal: LifecycleSignal,
+) {
+    let mut observation =
+        AgentLifecycleObservation::new(Some(AgentSessionId::from(agent_id)), signal);
+    observation.agent_name = Some(name.to_owned());
+    observation.origin = Some(origin);
+    observation.worktree_path = Some(workspace.project_root.display().to_string());
+    observation.pane_id = Some(pane_id.clone());
+    observation.runtime_owner = Some(rimz::store::runtime::process_owner(
+        rimz::RuntimeOwnerKind::Agent,
+        agent_id,
+        owner_pid,
+    ));
+    store
+        .append_event(&EventEnvelope::agent_lifecycle(
+            workspace.workspace_id.clone(),
+            workspace.session_name.clone(),
+            "codex",
+            "agent-hook",
+            &observation,
+        ))
+        .expect("append lifecycle");
+}
+
+#[test]
 fn agents_scope_positional_lists_one_lane_and_address_hint_is_actionable() {
     let env = Env::new();
     let workspace = rimz::WorkspaceResolver::resolve(&env.project_root, None).expect("workspace");
@@ -1706,11 +1855,11 @@ fn agents_scope_positional_lists_one_lane_and_address_hint_is_actionable() {
         ],
     );
 
-    let top_level = run_agents_json_list(&env, &workspace.session_name, &["agents", "#auth"]);
+    let top_level = run_agents_json_command(&env, &workspace.session_name, &["agents", "#auth"]);
     assert_agent_ids(&top_level, &["sess-auth"]);
 
     let subcommand =
-        run_agents_json_list(&env, &workspace.session_name, &["agents", "list", "#auth"]);
+        run_agents_json_command(&env, &workspace.session_name, &["agents", "list", "#auth"]);
     assert_agent_ids(&subcommand, &["sess-auth"]);
 
     let out = env
@@ -1794,7 +1943,7 @@ fn publish_pane_frame(env: &Env, session_name: &str, panes: Vec<rimz::pane::Pane
         .expect("publish pane frame");
 }
 
-fn run_agents_json_list(env: &Env, session_name: &str, args: &[&str]) -> serde_json::Value {
+fn run_agents_json_command(env: &Env, session_name: &str, args: &[&str]) -> serde_json::Value {
     let trace_log = env.project_root.join(format!("{}.log", args.join("-")));
     let mut command = env.rimz();
     command
@@ -1807,10 +1956,10 @@ fn run_agents_json_list(env: &Env, session_name: &str, args: &[&str]) -> serde_j
             "RIMZ_TEST_ZELLIJ_LIST_SESSIONS",
             format!("{session_name} [Created 1s ago]\n"),
         );
-    let out = command.output().expect("agents list json");
+    let out = command.output().expect("agents json command");
     assert!(
         out.status.success(),
-        "agents list failed\nstdout:\n{}\nstderr:\n{}",
+        "agents command failed\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
     );


### PR DESCRIPTION
## Context

The merged card-state work left three follow-up items on the launch-occupancy ownership model. Two read paths did full scans where a keyed lookup is enough, and the CLI-level regression for same-instance card routing was missing. This change keeps the accepted ownership model exactly as it is and makes the two scans proportional to the live agent set.

## Implementation

`Store::snapshot_cached` now derives its context keys from the agent rows it already projected, and reads only those sidecars through the existing keyed sidecar cache. Before, it read every file in the context directory and then dropped the records that no projected agent claimed. The keyed reader also confirms that each record's `(kind, agent_id)` agrees with the name it is filed under, which the full scan did not do.

Hook pane recovery in `cli/hooks/binding.rs` now consumes that attached context instead of re-reading the sidecars itself. Its loop became redundant when cached snapshots started to attach rest evidence; the loop landed first, and the attach landed after it.

Launch-identity inheritance keeps a reducer-local candidate index, keyed by provider kind, pane ID, and owner PID. This replaces a scan of the whole agent map for each successor that must find its predecessor. The index is a pre-filter only: `predecessor` still applies every accepted inheritance predicate, `same_agent_instance` included, against the live map. So the index can only drop a candidate, never match a wrong one, and predecessor choice keeps the established registration and ID ordering.

Two regressions cover the change. A reducer test drives a late launch identity that arrives through `agent.attached` after a successor exists, with 128 unrelated candidates, and proves resolution inspects only the one same-instance bucket. A CLI integration test drives a launch, lifecycle events, two provider rest certificates, and a successful same-instance successor through `rimz agents list --json`, then proves `rimz agents show @coder --json` resolves the same session.

### Departures from the plan

The plan proposed `RIMZ_TEST_PANE_LIST` for the CLI regression. `agents list` and `agents show` read through `PublishedSnapshotReader`, and the pane-list fixture bypasses the published pane cache on purpose, so that seam does not reach the consumer. The test publishes a production-shaped pane frame with the established integration helper instead.

The plan described the predecessor scan as wider than it is. Rows that already carry a launch ID return early. The change therefore indexes only launch-bearing root candidates, and adds no durable occupancy record.

## Verification

`cargo xtask gate` passes: fmt, invariants, conform, docs-links, lint, and 5,993 nextest tests. The review reproduced the gate independently.

## Advisories

These are open and deliberate. None of them blocks this change.

The enrichment path in `sidebar/enrich.rs` still does the full context scan. That path is what `agents list`, `agents show`, and the sidebar producer read, and it sits directly above two keyed reads over the same key iterator. The new keyed context reader is `pub(super)`, so that caller cannot use it today. Whether to bound that path, and whether the helper should get the wider visibility its sibling readers have, is an open design call.

The 128-candidate fixture does not pin the bucket key. Each decoy differs from the successor in both indexed dimensions, so the count assertion holds for a key of kind plus pane, kind plus PID, or all three. A later narrowing of the key would keep the test green.

The revised doc comment on `with_agent_context` names two callers. There are nine, across seven modules.

The new CLI test mixes the canonical project root with the raw one. Both are equal on the Linux CI host, and differ where the temporary directory resolves through a symbolic link.

A single pane and process bucket can hold several in-place conversations. Lookup stays proportional to that instance's conversation count. The test bounds unrelated-fleet work, not same-instance history.

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>spot</code> team · 2 agents · 41m active · $12.72 · 4 messages (1 from you)</summary>

- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 27m active · $6.03
  - calls: 87 tool calls
  - messages: 1 from you · 1 to teammates
  - tokens: 236k input, 35.1k output, 11m cache read
  - subagents: 2 × explorer ($1.44)
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 14m active · $6.69
  - calls: 64 tool calls
  - messages: 3 from teammates
  - tokens: 122 input, 61.4k output, 176.1k cache write, 6.8m cache read
  - subagents: 2 × finder ($15.71)

</details>