### PR TITLE
fix(subagents): print the durable result of a completed child

### DIFF
--- a/crates/rimz/src/cli/agents_cmd/wait.rs
+++ b/crates/rimz/src/cli/agents_cmd/wait.rs
@@ -423,7 +423,10 @@ fn resolve_wait_target(
         crate::cli::resolve_agent_one(snapshot, reference, None, current_channel);
     let live_agent = live_agent_result.as_ref().ok().copied();
     if let Some(run) = newest_run_by_ref(store, reference, live_agent)?
-        && (!run.status.is_terminal() || live_agent.is_none() || run.run_id.as_str() == reference)
+        && (!run.status.is_terminal()
+            || live_agent.is_none()
+            || run.run_id.as_str() == reference
+            || (run.subagent && live_agent.is_some_and(AgentState::is_launched_child)))
     {
         let name = run
             .agent_name

--- a/crates/rimz/tests/integration/run.rs
+++ b/crates/rimz/tests/integration/run.rs
@@ -2147,6 +2147,118 @@ fn write_run_status(store: &rimz::Store, record: &mut RunRecord, status: RunStat
     rimz::harness::run::create(store.paths(), record).expect("write run status");
 }
 
+fn create_finished_subagent(
+    env: &Env,
+    store: &rimz::Store,
+) -> (RunRecord, AgentKind, AgentSessionId) {
+    let workspace = rimz::WorkspaceResolver::resolve(&env.project_root, None).expect("workspace");
+    let parent_kind = AgentKind::new_unchecked("claude");
+    let parent_id = AgentSessionId::from("parent-session");
+    let parent_launch_id = AgentSessionId::from("parent-launch");
+    store
+        .append_event(&EventEnvelope::agent_launched(
+            workspace.workspace_id.clone(),
+            &workspace.session_name,
+            &parent_kind,
+            AgentLaunchPayload {
+                agent_id: parent_id.clone(),
+                launch_id: Some(parent_launch_id.clone()),
+                agent_name: "parent".to_owned(),
+                agent_name_explicit: true,
+                launch: LaunchParams::default(),
+                state: AgentLaunchState::Bound,
+                run_id: None,
+                pane_id: None,
+                runtime_owner: None,
+                worktree_path: Some(env.project_root.display().to_string()),
+                worktree_branch: None,
+                prompt: None,
+                description: None,
+            },
+        ))
+        .expect("seed subagent parent");
+
+    let child_kind = AgentKind::new_unchecked("codex");
+    let child_id = AgentSessionId::from("child-session");
+    let child_launch_id = AgentSessionId::from("child-launch");
+    let mut record = RunRecord::new(
+        workspace.workspace_id.clone(),
+        child_kind.clone(),
+        PermissionMode::Auto,
+        "inspect the wait path".to_owned(),
+        env.project_root.clone(),
+    );
+    record.agent_id = Some(child_id.clone());
+    record.agent_name = Some("quiet-fox".to_owned());
+    record.subagent = true;
+    record.last_message = Some("durable child answer\n".to_owned());
+    record.status = RunStatus::Completed;
+    record.completed_at = Some(record.updated_at);
+    rimz::harness::run::create(store.paths(), &record).expect("create completed subagent run");
+
+    store
+        .append_event(&EventEnvelope::agent_launched(
+            workspace.workspace_id.clone(),
+            &workspace.session_name,
+            &child_kind,
+            AgentLaunchPayload {
+                agent_id: child_id.clone(),
+                launch_id: Some(child_launch_id),
+                agent_name: "quiet-fox".to_owned(),
+                agent_name_explicit: true,
+                launch: LaunchParams {
+                    parent_agent_id: Some(parent_id),
+                    parent_agent_kind: Some(parent_kind.clone()),
+                    launch_depth: Some(1),
+                    ..LaunchParams::default()
+                },
+                state: AgentLaunchState::Bound,
+                run_id: Some(record.run_id.clone()),
+                pane_id: None,
+                runtime_owner: None,
+                worktree_path: Some(env.project_root.display().to_string()),
+                worktree_branch: None,
+                prompt: Some(record.prompt.clone()),
+                description: None,
+            },
+        ))
+        .expect("seed completed subagent");
+    store
+        .append_event(&EventEnvelope::agent_lifecycle(
+            workspace.workspace_id.clone(),
+            &workspace.session_name,
+            child_kind.as_str(),
+            "Stop",
+            &AgentLifecycleObservation::new(
+                Some(child_id.clone()),
+                LifecycleSignal::TurnEnded {
+                    errored: false,
+                    parked_on_background: false,
+                },
+            ),
+        ))
+        .expect("settle completed subagent");
+    store
+        .append_event(&EventEnvelope::agent_lifecycle(
+            workspace.workspace_id,
+            workspace.session_name,
+            child_kind.as_str(),
+            "SessionEnd",
+            &AgentLifecycleObservation::new(Some(child_id.clone()), LifecycleSignal::Ended),
+        ))
+        .expect("end completed subagent");
+    let child = store
+        .runtime_projection(rimz::RuntimeScope::Audit)
+        .expect("read completed subagent")
+        .agents
+        .into_iter()
+        .find(|agent| agent.agent_id == child_id)
+        .expect("completed subagent remains in audit history");
+    assert!(child.ended_at.is_some());
+
+    (record, parent_kind, parent_launch_id)
+}
+
 fn register_running_wait_agent(env: &Env, store: &rimz::Store, name: &str, session_id: &str) {
     let workspace = rimz::WorkspaceResolver::resolve(&env.project_root, None).expect("workspace");
     let agent_id = AgentSessionId::from(session_id);
@@ -2237,6 +2349,52 @@ fn wait_single_run_json_prints_full_record() {
     assert_eq!(json["last_message"], "done");
     assert_eq!(json["cost_usd"], 0.42);
     assert!(json.get("exit").is_none(), "must not use wait summary JSON");
+}
+
+#[test]
+fn completed_subagent_wait_prints_the_durable_result_after_the_child_ends() {
+    let env = Env::new();
+    let store = env.store();
+    let (record, parent_kind, parent_launch_id) = create_finished_subagent(&env, &store);
+
+    let out = env
+        .rimz()
+        .args(["subagents", "wait", "quiet-fox"])
+        .env(rimz::harness::launch::ENV_AGENT_KIND, parent_kind.as_str())
+        .env(
+            rimz::harness::launch::ENV_AGENT_ID,
+            parent_launch_id.as_str(),
+        )
+        .output()
+        .expect("wait for completed subagent");
+
+    assert!(
+        out.status.success(),
+        "completed subagent wait failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout),
+        "durable child answer\n"
+    );
+    assert!(out.stderr.is_empty());
+
+    let out = env
+        .rimz()
+        .args(["subagents", "wait", "quiet-fox", "--json"])
+        .env(rimz::harness::launch::ENV_AGENT_KIND, parent_kind.as_str())
+        .env(
+            rimz::harness::launch::ENV_AGENT_ID,
+            parent_launch_id.as_str(),
+        )
+        .output()
+        .expect("wait for completed subagent JSON");
+
+    assert!(out.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("subagent run JSON");
+    assert_eq!(json["run_id"], record.run_id.as_str());
+    assert_eq!(json["last_message"], "durable child answer\n");
 }
 
 #[test]


### PR DESCRIPTION
## Context

`rimz subagents wait <name>` printed nothing after a child finished. The fleet digest carries statuses only, and it names `rimz subagents wait @…` as the command that reads the result. The documents promise that the run record, not the pane, is the truth, and that the result stays available after the pane closes.

Target resolution disagreed with that promise. RimZ keeps an ended child in the runtime projection below its live parent. The wait command found that retained agent row and selected it in place of the durable run. The agent branch of the wait printer has no result text. Thus the text output was empty, `--json` printed the agent record in place of the run record, and a failed child or a timed-out child exited with code 0.

## Implementation

Wait-target resolution keeps the durable run as the target when the run has the `subagent` mark and the resolved row is a launched child (`crates/rimz/src/cli/agents_cmd/wait.rs`). A completed-child join goes to the existing run renderer. Text prints `last_message`, single-target `--json` prints the full run record, and the exit code comes from the run status again. The inline-join mark and the digest cancellation also operate again, because the agent branch skipped both.

A new integration test seeds a durable parent and child history, completes and ends the child, then runs `rimz subagents wait quiet-fox` in text mode and in `--json` mode (`crates/rimz/tests/integration/run.rs`).

Departures from the task:

- The first proposal treated each row with an `ended_at` stamp as absent. That rule drops a `--keep` child, whose pane and row stay alive by design after the run settles. The condition uses the run's `subagent` mark with the launch ancestry instead, which covers both children. It also stops an old child run from taking a live interactive agent that uses the same name.
- No document changed. The subagents reference page and the internals page already describe durable result reads and `last_message`. The code now agrees with them.
- The review moved the branch onto `origin/main`, because an unrelated local commit was below it. This pull request carries the fix only.

## Advisories

- A restarted child can give an old result. Launch a child with `--keep`, then run `rimz agents restart` on it: the child stays a launched child, it keeps its name, and no new run record exists. A subsequent `wait` reads the run from before the restart and returns immediately. Before this change the same command waited for the live turn, but printed no text. `rimz subagents restart` does not exist in v1, so you must use the general `rimz agents restart` command to reach this state. A full fix needs a freshness test between the run and the current turn, which is more machinery than this edge is worth now.
- The new test seeds lifecycle records. It does not drive a live multiplexer or a live provider. The changed code is target selection only, and the existing tests cover the run output after the target is selected.

## Verification

`cargo xtask gate` passes on the new base: fmt, invariants, conform, docs-links, lint, and 6,007 tests. Focused runs: every test that matches `wait` (137 passed) and every test that matches `subagent` (199 passed).

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>spot</code> team · 2 agents · 33m active · $8.43 · 2 messages (1 from you)</summary>

- **coder** — Codex `gpt-5.6-sol@high`
  - effort: 13m active · $3.04
  - calls: 38 tool calls
  - messages: 1 from you · 1 to teammates
  - tokens: 159k input, 14.7k output, 5.3m cache read
- **reviewer** — Claude `claude-opus-5@xhigh`
  - effort: 20m active · $5.39
  - calls: 66 tool calls
  - messages: 1 from teammates
  - tokens: 134 input, 45.9k output, 141.1k cache write, 5.7m cache read
  - subagents: 2 × general ($3.27)

</details>