### PR TITLE
fix(resume): cohort resume matches the requested profile among root sessions only

### DIFF
--- a/crates/rimz/src/agents/state.rs
+++ b/crates/rimz/src/agents/state.rs
@@ -1024,6 +1024,11 @@ impl AgentState {
         self.parent_agent_id.is_some() && self.launch_depth.is_none()
     }
 
+    /// A top-level session, neither a launched child nor a provider-native subagent.
+    pub fn is_root(&self) -> bool {
+        self.parent_agent_id.is_none()
+    }
+
     /// Match the parent link to a candidate session or launch of the right kind.
     pub fn parent_is(&self, candidate: &AgentState) -> bool {
         self.parent_agent_id

--- a/crates/rimz/src/agents/state.rs
+++ b/crates/rimz/src/agents/state.rs
@@ -1024,11 +1024,6 @@ impl AgentState {
         self.parent_agent_id.is_some() && self.launch_depth.is_none()
     }
 
-    /// A top-level session, neither a launched child nor a provider-native subagent.
-    pub fn is_root(&self) -> bool {
-        self.parent_agent_id.is_none()
-    }
-
     /// Match the parent link to a candidate session or launch of the right kind.
     pub fn parent_is(&self, candidate: &AgentState) -> bool {
         self.parent_agent_id

--- a/crates/rimz/src/harness/plan.rs
+++ b/crates/rimz/src/harness/plan.rs
@@ -38,6 +38,8 @@ pub struct ResolvedLaunch {
 pub struct CohortCell {
     pub kind: crate::ids::AgentKind,
     pub role: Option<String>,
+    /// The profile the spec resolved; absent for a bare kind.
+    pub profile: Option<String>,
 }
 
 /// One agent cell's explicit-resume seed.
@@ -702,6 +704,7 @@ pub fn cohort_cells(layout: &LayoutSpec) -> Vec<CohortCell> {
         .map(|cell| CohortCell {
             kind: cell.kind.clone(),
             role: cell.launch.role.clone(),
+            profile: cell.launch.profile.clone(),
         })
         .collect()
 }

--- a/crates/rimz/src/harness/plan/tests.rs
+++ b/crates/rimz/src/harness/plan/tests.rs
@@ -208,6 +208,10 @@ fn profile_scope_selects_the_doorway_namespace_and_kind_shadowing() {
     )
     .expect("agent profile");
     assert_eq!(
+        cohort_cells(&agent.layout)[0].profile.as_deref(),
+        Some("shared")
+    );
+    assert_eq!(
         agent
             .layout
             .agent_cells()

--- a/crates/rimz/src/harness/resume.rs
+++ b/crates/rimz/src/harness/resume.rs
@@ -1911,15 +1911,17 @@ fn cohort_candidates<'a>(
 ) -> Vec<&'a AgentState> {
     agents
         .iter()
-        .filter(|agent| agent.parent_agent_id.is_none())
-        .filter(|agent| !agent.agent_id.is_empty())
-        // An unadopted placeholder has nothing to resume; only a live one needs protection.
-        .filter(|agent| {
-            !agent.agent_id.is_provisional()
-                || matches!(liveness(agent), AgentLiveness::Live { .. })
-        })
+        .filter(|agent| cohort_admits(agent, liveness))
         .filter(|agent| agent_worktree(agent).is_some_and(|path| worktree_exists(&path)))
         .collect()
+}
+
+// An unadopted placeholder has nothing to resume; only a live one needs protection.
+fn cohort_admits(agent: &AgentState, liveness: impl Fn(&AgentState) -> AgentLiveness) -> bool {
+    agent.parent_agent_id.is_none()
+        && !agent.agent_id.is_empty()
+        && (!agent.agent_id.is_provisional()
+            || matches!(liveness(agent), AgentLiveness::Live { .. }))
 }
 
 /// Match one launch layout to its newest prior cohort.
@@ -1957,7 +1959,7 @@ pub fn inspect_cohort_relaunch(
     let candidates = agents
         .iter()
         .filter(|agent| {
-            agent.parent_agent_id.is_none()
+            cohort_admits(agent, crate::store::runtime::agent_liveness)
                 && agent.worktree_path.as_deref().is_some_and(|path| {
                     crate::utils::path::normalize_path_lexical(Path::new(path)) == target
                 })
@@ -1968,17 +1970,10 @@ pub fn inspect_cohort_relaunch(
             .into_iter()
             .filter(|agent| agent.team.as_deref() == Some(team))
             .collect::<Vec<_>>(),
-        None => match_cohort(
-            &candidates
-                .into_iter()
-                .filter(|agent| !agent.agent_id.is_empty())
-                .collect::<Vec<_>>(),
-            cells,
-            None,
-        )
-        .into_iter()
-        .flatten()
-        .collect(),
+        None => match_cohort(&candidates, cells, None)
+            .into_iter()
+            .flatten()
+            .collect(),
     };
     if members.is_empty() {
         return CohortRelaunchState::Absent;

--- a/crates/rimz/src/harness/resume.rs
+++ b/crates/rimz/src/harness/resume.rs
@@ -1911,7 +1911,7 @@ fn cohort_candidates<'a>(
 ) -> Vec<&'a AgentState> {
     agents
         .iter()
-        .filter(|agent| agent.is_root())
+        .filter(|agent| agent.parent_agent_id.is_none())
         .filter(|agent| !agent.agent_id.is_empty())
         // An unadopted placeholder has nothing to resume; only a live one needs protection.
         .filter(|agent| {
@@ -1957,7 +1957,7 @@ pub fn inspect_cohort_relaunch(
     let candidates = agents
         .iter()
         .filter(|agent| {
-            agent.is_root()
+            agent.parent_agent_id.is_none()
                 && agent.worktree_path.as_deref().is_some_and(|path| {
                     crate::utils::path::normalize_path_lexical(Path::new(path)) == target
                 })
@@ -2357,7 +2357,7 @@ pub fn closed_cohort_specs(
 ) -> Vec<String> {
     let mut members = agents
         .iter()
-        .filter(|agent| agent.is_root())
+        .filter(|agent| agent.parent_agent_id.is_none())
         .filter(|agent| !agent.agent_id.is_empty())
         .filter(|agent| !matches!(liveness(agent), AgentLiveness::Live { .. }))
         .filter(|agent| supports_agent_resume(agent))

--- a/crates/rimz/src/harness/resume.rs
+++ b/crates/rimz/src/harness/resume.rs
@@ -1811,7 +1811,7 @@ pub fn plan_cohort_resume(
     session_backed: impl Fn(&AgentState) -> bool,
 ) -> Result<CohortResumePlan, CohortResumeErr> {
     let spec = cohort_spec_label(cells, team);
-    let candidates = cohort_candidates(agents, worktree_exists);
+    let candidates = cohort_candidates(agents, &liveness, worktree_exists);
     let matches = match_cohort(&candidates, cells, team);
 
     let matched_any = matches.iter().any(Option::is_some);
@@ -1892,34 +1892,39 @@ fn cohort_spec_label(cells: &[CohortCell], team: Option<&str>) -> String {
     if let Some(team) = team {
         return team.to_owned();
     }
-    let kinds = cells
+    let specs = cells
         .iter()
-        .map(|cell| cell.kind.as_str())
+        .map(|cell| cell.profile.as_deref().unwrap_or(cell.kind.as_str()))
         .collect::<Vec<_>>()
         .join(",");
-    if kinds.is_empty() {
+    if specs.is_empty() {
         "<empty>".to_owned()
     } else {
-        kinds
+        specs
     }
 }
 
-fn cohort_candidates(
-    agents: &[AgentState],
+fn cohort_candidates<'a>(
+    agents: &'a [AgentState],
+    liveness: &impl Fn(&AgentState) -> AgentLiveness,
     worktree_exists: impl Fn(&Path) -> bool,
-) -> Vec<&AgentState> {
+) -> Vec<&'a AgentState> {
     agents
         .iter()
-        .filter(|agent| !agent.is_provider_subagent())
+        .filter(|agent| agent.is_root())
         .filter(|agent| !agent.agent_id.is_empty())
+        // An unadopted placeholder has nothing to resume; only a live one needs protection.
+        .filter(|agent| {
+            !agent.agent_id.is_provisional()
+                || matches!(liveness(agent), AgentLiveness::Live { .. })
+        })
         .filter(|agent| agent_worktree(agent).is_some_and(|path| worktree_exists(&path)))
         .collect()
 }
 
 /// Match one launch layout to its newest prior cohort.
 ///
-/// Named teams match by team and role, single-agent inline specs match by kind,
-/// and multi-agent inline specs match by launch group and cell identity.
+/// Named teams match by team and role, single-agent inline specs match by kind and by profile when named, and multi-agent inline specs match by launch group and cell identity.
 fn match_cohort<'a>(
     candidates: &[&'a AgentState],
     cells: &[CohortCell],
@@ -1952,7 +1957,7 @@ pub fn inspect_cohort_relaunch(
     let candidates = agents
         .iter()
         .filter(|agent| {
-            !agent.is_provider_subagent()
+            agent.is_root()
                 && agent.worktree_path.as_deref().is_some_and(|path| {
                     crate::utils::path::normalize_path_lexical(Path::new(path)) == target
                 })
@@ -2040,12 +2045,13 @@ fn match_single_cohort<'a>(
     candidates: &[&'a AgentState],
     cell: &CohortCell,
 ) -> Vec<Option<&'a AgentState>> {
-    vec![
-        candidates
-            .iter()
-            .copied()
-            .find(|agent| agent.kind == cell.kind),
-    ]
+    vec![candidates.iter().copied().find(|agent| {
+        agent.kind == cell.kind
+            && cell
+                .profile
+                .as_deref()
+                .is_none_or(|profile| agent.profile.as_deref() == Some(profile))
+    })]
 }
 
 fn match_inline_cohort<'a>(
@@ -2194,8 +2200,6 @@ impl<'a> CohortAssignments<'a> {
 
 fn supports_agent_resume(agent: &AgentState) -> bool {
     // A provisional `launch_...` id only names RimZ's pre-adoption placeholder.
-    // Keep the matched cohort cell and relaunch it fresh instead of asking the
-    // adapter to resume an id outside the provider session store.
     if agent.agent_id.is_provisional() {
         return false;
     }
@@ -2353,7 +2357,7 @@ pub fn closed_cohort_specs(
 ) -> Vec<String> {
     let mut members = agents
         .iter()
-        .filter(|agent| !agent.is_provider_subagent())
+        .filter(|agent| agent.is_root())
         .filter(|agent| !agent.agent_id.is_empty())
         .filter(|agent| !matches!(liveness(agent), AgentLiveness::Live { .. }))
         .filter(|agent| supports_agent_resume(agent))

--- a/crates/rimz/src/harness/resume/tests/cohort.rs
+++ b/crates/rimz/src/harness/resume/tests/cohort.rs
@@ -4,6 +4,141 @@
 use super::*;
 
 #[test]
+fn cohort_resume_ignores_launched_children() {
+    let parent = AgentState {
+        profile: Some("astra".to_owned()),
+        launch_depth: Some(1),
+        ended_at: Some(Timestamp::UNIX_EPOCH),
+        ..agent("codex", "parent", "/code/feature", 30)
+    };
+    let child = AgentState {
+        profile: Some("general".to_owned()),
+        parent_agent_id: Some(parent.agent_id.clone()),
+        launch_depth: Some(2),
+        runtime_owner: Some(crate::store::runtime::current_process_owner(
+            crate::pane::RuntimeOwnerKind::Agent,
+            "child".to_owned(),
+        )),
+        ..agent("codex", "child", "/code/feature", 1)
+    };
+    let agents = [parent, child];
+    for child_live in [true, false] {
+        for cell in [profile_cell("codex", "astra"), cohort_cell("codex", None)] {
+            let plan = cohort_with(
+                &agents,
+                std::slice::from_ref(&cell),
+                None,
+                |row| {
+                    if row.is_launched_child() && child_live {
+                        live(row)
+                    } else {
+                        dead(row)
+                    }
+                },
+                |_| true,
+                |_| true,
+            )
+            .expect("child does not compete with root");
+            assert_eq!(resume_id(&plan.seeds[0]), Some("parent"));
+            assert_eq!(
+                inspect_cohort_relaunch(&agents, Path::new("/code/feature"), &[cell], None,),
+                CohortRelaunchState::Closed,
+            );
+        }
+    }
+    assert_eq!(closed_cohort_specs(&agents, dead), ["astra"]);
+}
+
+#[test]
+fn single_cell_resume_matches_requested_profile() {
+    let astra = AgentState {
+        profile: Some("astra".to_owned()),
+        ..agent("codex", "astra-session", "/code/feature", 30)
+    };
+    let debugger = AgentState {
+        profile: Some("debugger".to_owned()),
+        ..agent("codex", "debugger-session", "/code/feature", 10)
+    };
+    let agents = [astra, debugger, agent("codex", "bare", "/code/feature", 1)];
+    for (cell, expected) in [
+        (profile_cell("codex", "astra"), "astra-session"),
+        (profile_cell("codex", "debugger"), "debugger-session"),
+        (cohort_cell("codex", None), "bare"),
+    ] {
+        let plan = cohort(&agents, &[cell], None).expect("matching root");
+        assert_eq!(resume_id(&plan.seeds[0]), Some(expected));
+    }
+    assert_eq!(
+        cohort(&agents, &[profile_cell("codex", "nova")], None),
+        Err(CohortResumeErr::NothingToResume {
+            spec: "nova".to_owned(),
+        }),
+    );
+    assert!(matches!(
+        cohort_with(
+            &agents,
+            &[profile_cell("codex", "astra")],
+            None,
+            live,
+            |_| true,
+            |_| true,
+        ),
+        Err(CohortResumeErr::MembersStillLive { labels })
+            if labels == [cohort_agent_label(&agents[0])],
+    ));
+    let plan = cohort(&agents[..2], &[cohort_cell("codex", None)], None)
+        .expect("bare kind also matches profiled roots");
+    assert_eq!(resume_id(&plan.seeds[0]), Some("debugger-session"));
+}
+
+#[test]
+fn dead_placeholder_does_not_shadow_the_conversation() {
+    let session = AgentState {
+        profile: Some("astra".to_owned()),
+        ..agent("codex", "session", "/code/feature", 30)
+    };
+    let placeholder = AgentState {
+        profile: Some("astra".to_owned()),
+        ..agent(
+            "codex",
+            "launch_019f2cecea067320b667c5946d266e64",
+            "/code/feature",
+            1,
+        )
+    };
+    let agents = [session, placeholder];
+    let cells = [profile_cell("codex", "astra")];
+    for liveness in [AgentLiveness::Dead, AgentLiveness::Unknown] {
+        let plan = cohort_with(&agents, &cells, None, |_| liveness, |_| true, |_| true)
+            .expect("placeholder has no conversation to shadow the root");
+        assert_eq!(resume_id(&plan.seeds[0]), Some("session"));
+        assert_eq!(
+            cohort_with(&agents[1..], &cells, None, |_| liveness, |_| true, |_| true),
+            Err(CohortResumeErr::NothingToResume {
+                spec: "astra".to_owned(),
+            }),
+        );
+    }
+    assert_eq!(
+        cohort_with(
+            &agents,
+            &cells,
+            None,
+            |row| if row.agent_id.is_provisional() {
+                live(row)
+            } else {
+                dead(row)
+            },
+            |_| true,
+            |_| true,
+        ),
+        Err(CohortResumeErr::MembersStillLive {
+            labels: vec![cohort_agent_label(&agents[1])],
+        }),
+    );
+}
+
+#[test]
 fn cohort_resume_selects_newest_team_member_per_role() {
     let old_planner = team_agent("claude", "old-planner", "planner", "/code/forge", 30);
     let planner = AgentState {
@@ -199,8 +334,6 @@ fn cohort_refuses_live_and_unmatched_specs() {
 /// not there.
 #[test]
 fn cohort_relaunches_an_unresumable_match_fresh() {
-    let provisional = "launch_019f2cecea067320b667c5946d266e64";
-
     for (label, agents, cells, team, redeemable, fresh, cwd) in [
         (
             "a kind with no resume CLI",
@@ -210,15 +343,6 @@ fn cohort_relaunches_an_unresumable_match_fresh() {
             true,
             "ghost:query-engine",
             "/code/query-engine",
-        ),
-        (
-            "a provisional launch placeholder",
-            vec![team_agent("codex", provisional, "coder", "/code/pets-l", 4)],
-            vec![cohort_cell("codex", Some("coder"))],
-            Some("forge"),
-            true,
-            "codex:pets-l",
-            "/code/pets-l",
         ),
         (
             "a session the provider never persisted",
@@ -530,6 +654,18 @@ fn team_restore_tabs_seed_every_declared_role() {
             vec![coder, planner.clone()],
             teams.clone(),
             Some(vec![Some("planner"), Some("coder")]),
+        ),
+        (
+            "a team with only an unadopted placeholder has nothing to restore",
+            vec![team_agent(
+                "codex",
+                "launch_019f2cecea067320b667c5946d266e64",
+                "coder",
+                "/repo/forge",
+                1,
+            )],
+            teams.clone(),
+            None,
         ),
         (
             "a missing member launches fresh beside the resumed one",

--- a/crates/rimz/src/harness/resume/tests/cohort.rs
+++ b/crates/rimz/src/harness/resume/tests/cohort.rs
@@ -588,18 +588,41 @@ fn cohort_relaunch_presence_table() {
         member("codex", "fresher", "launch_group", 1, 1),
     ];
 
-    for (label, agents, cells, expected) in [
-        ("absent", Vec::new(), &one_cell, CohortRelaunchState::Absent),
+    let placeholder = paneless(team_agent(
+        "codex",
+        "launch_019f2cecea067320b667c5946d266e64",
+        "coder",
+        "/code/feature",
+        1,
+    ));
+    let live_placeholder = AgentState {
+        runtime_owner: Some(crate::store::runtime::current_process_owner(
+            crate::pane::RuntimeOwnerKind::Agent,
+            placeholder.agent_id.to_string(),
+        )),
+        ..placeholder.clone()
+    };
+
+    for (label, agents, cells, team, expected) in [
+        (
+            "absent",
+            Vec::new(),
+            &one_cell,
+            None,
+            CohortRelaunchState::Absent,
+        ),
         (
             "ended",
             vec![closed(agent("codex", "ended", "/code/feature", 4))],
             &one_cell,
+            None,
             CohortRelaunchState::Closed,
         ),
         (
             "unknown with pane",
             vec![with_pane],
             &one_cell,
+            None,
             CohortRelaunchState::Present {
                 focus_pane: Some(pane_id("terminal_pane")),
             },
@@ -608,31 +631,65 @@ fn cohort_relaunch_presence_table() {
             "unknown without pane",
             vec![paneless(agent("codex", "paneless", "/code/feature", 2))],
             &one_cell,
+            None,
             CohortRelaunchState::Closed,
         ),
         (
             "live without pane",
             vec![live_without_pane],
             &one_cell,
+            None,
             CohortRelaunchState::Present { focus_pane: None },
         ),
         (
             "newest inline group decides, and it is closed",
             closed_newest_group,
             &two_cells,
+            None,
             CohortRelaunchState::Closed,
         ),
         (
             "focus lands on the freshest present pane",
             present_group,
             &two_cells,
+            None,
             CohortRelaunchState::Present {
                 focus_pane: Some(pane_id("terminal_fresher")),
             },
         ),
+        (
+            "an unadopted team has no cohort to resume",
+            vec![placeholder.clone()],
+            &one_cell,
+            Some("forge"),
+            CohortRelaunchState::Absent,
+        ),
+        (
+            "a live placeholder still protects the starting team",
+            vec![live_placeholder],
+            &one_cell,
+            Some("forge"),
+            CohortRelaunchState::Present { focus_pane: None },
+        ),
+        (
+            "a partially adopted team still offers resume",
+            vec![
+                placeholder,
+                closed(team_agent(
+                    "claude",
+                    "planner",
+                    "planner",
+                    "/code/feature",
+                    3,
+                )),
+            ],
+            &two_cells,
+            Some("forge"),
+            CohortRelaunchState::Closed,
+        ),
     ] {
         assert_eq!(
-            inspect_cohort_relaunch(&agents, Path::new("/code/feature"), cells, None),
+            inspect_cohort_relaunch(&agents, Path::new("/code/feature"), cells, team),
             expected,
             "{label}"
         );

--- a/crates/rimz/src/harness/resume/tests/mod.rs
+++ b/crates/rimz/src/harness/resume/tests/mod.rs
@@ -113,6 +113,14 @@ fn cohort_cell(kind: &str, role: Option<&str>) -> CohortCell {
     CohortCell {
         kind: AgentKind::new_unchecked(kind),
         role: role.map(ToOwned::to_owned),
+        profile: None,
+    }
+}
+
+fn profile_cell(kind: &str, profile: &str) -> CohortCell {
+    CohortCell {
+        profile: Some(profile.to_owned()),
+        ..cohort_cell(kind, None)
     }
 }
 

--- a/crates/rimz/tests/integration/backend/tmux/agent_lifecycle.rs
+++ b/crates/rimz/tests/integration/backend/tmux/agent_lifecycle.rs
@@ -745,7 +745,7 @@ fn cohort_resume_selects_closed_profile_parent_over_live_child_and_dead_placehol
         .iter()
         .find(|agent| agent.agent_id == parent_id)
         .expect("closed parent");
-    assert!(parent.is_root() && parent.ended_at.is_some());
+    assert!(parent.parent_agent_id.is_none() && parent.ended_at.is_some());
     let placeholder = projection
         .agents
         .iter()

--- a/crates/rimz/tests/integration/backend/tmux/agent_lifecycle.rs
+++ b/crates/rimz/tests/integration/backend/tmux/agent_lifecycle.rs
@@ -565,6 +565,231 @@ fn resumed_lazy_agent_is_addressable_before_provider_registration() {
 }
 
 #[test]
+fn cohort_resume_selects_closed_profile_parent_over_live_child_and_dead_placeholder() {
+    require_tmux!();
+    if git_missing() {
+        return;
+    }
+    let env = Env::new();
+    std::fs::write(env.home_root.join(".zshrc"), "").expect("disable zsh first-run menu");
+    init_repo(&env.project_root);
+    let worktree = env.home_root.join("project-worktrees/resume");
+    git(
+        &env.project_root,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "resume",
+            worktree.to_str().expect("worktree path"),
+        ],
+    );
+    let config_dir = env.config_root().join("rimz");
+    std::fs::create_dir_all(&config_dir).expect("mkdir config");
+    std::fs::write(
+        config_dir.join("agents.toml"),
+        "[agents.profiles.astra]\nagent = \"codex\"\n",
+    )
+    .expect("write astra profile");
+    let agent_bin = write_sleeping_agent_shim(&env, "codex");
+    let argv_path = env.home_root.join("resume-argv");
+    let ready = env.home_root.join("resume-ready");
+    std::fs::write(
+        agent_bin.join("codex"),
+        "#!/bin/bash\n\
+         case \"$1\" in --version) printf 'codex 0.0.0\\n'; exit 0;; app-server) exit 0;; esac\n\
+         printf '%s\\n' \"$@\" >> \"$RIMZ_TEST_AGENT_ARGV\"\n\
+         printf ready > \"$RIMZ_TEST_AGENT_READY\"\n\
+         exec -a codex sleep 300\n",
+    )
+    .expect("write argv-recording codex shim");
+    let launch_command = || {
+        let mut command = env.rimz();
+        command
+            .current_dir(&worktree)
+            .env("PATH", path_with_front(&agent_bin))
+            .env("SHELL", "/definitely/not/a/shell")
+            .env("RIMZ_TEST_AGENT_ARGV", &argv_path)
+            .env("RIMZ_TEST_AGENT_READY", &ready)
+            .args(["--mux", "tmux", "agents", "astra", "--resume"])
+            .stdin(std::process::Stdio::null());
+        command
+    };
+    let workspace = WorkspaceResolver::resolve(&worktree, None).expect("resolve workspace");
+    let server = TmuxServer::in_runtime_root(&env.runtime_root);
+    let mut options = session_opts(
+        &workspace.session_name,
+        workspace.workspace_id.clone(),
+        &workspace.project_root,
+        &workspace.worktree_root,
+        Some((160, 40)),
+    );
+    options
+        .extra_env
+        .extend(launch_command().get_envs().filter_map(|(key, value)| {
+            value.map(|value| {
+                (
+                    key.to_string_lossy().into_owned(),
+                    value.to_string_lossy().into_owned(),
+                )
+            })
+        }));
+    server
+        .backend
+        .ensure_session(&options)
+        .expect("ensure room");
+    let child_pane = server.stdout(&[
+        "new-window",
+        "-d",
+        "-P",
+        "-F",
+        "#{pane_id}",
+        "-t",
+        &workspace.session_name,
+        "-n",
+        "child",
+        "/bin/bash -c 'exec -a codex sleep 300'",
+    ]);
+    let child_pid = server
+        .display(&child_pane, "#{pane_pid}")
+        .parse()
+        .expect("child pid");
+    let parent_id = "cohort-parent-session";
+    let child_id = "cohort-child-session";
+    let placeholder_id = "launch_019f2cecea067320b667c5946d266e64";
+    let store = env.store();
+    let kind = AgentKind::new_unchecked("codex");
+    for (index, (agent_id, profile)) in [
+        (parent_id, "astra"),
+        (child_id, "general"),
+        (placeholder_id, "astra"),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let is_child = agent_id == child_id;
+        let mut event = EventEnvelope::agent_launched(
+            workspace.workspace_id.clone(),
+            &workspace.session_name,
+            &kind,
+            AgentLaunchPayload {
+                agent_id: agent_id.into(),
+                launch_id: Some(agent_id.into()),
+                agent_name: if agent_id == placeholder_id {
+                    "empty-launch".to_owned()
+                } else {
+                    profile.to_owned()
+                },
+                agent_name_explicit: true,
+                launch: LaunchParams {
+                    profile: Some(profile.to_owned()),
+                    parent_agent_id: is_child.then(|| parent_id.into()),
+                    launch_depth: Some(if is_child { 2 } else { 1 }),
+                    ..LaunchParams::default()
+                },
+                state: if agent_id == placeholder_id {
+                    AgentLaunchState::Starting
+                } else {
+                    AgentLaunchState::Bound
+                },
+                run_id: None,
+                pane_id: is_child.then(|| PaneId::from_parts(MuxName::Tmux, &child_pane)),
+                runtime_owner: Some(rimz::pane::RuntimeOwner::new(
+                    rimz::pane::RuntimeOwnerKind::Agent,
+                    agent_id,
+                    if is_child { child_pid } else { u32::MAX },
+                    None,
+                )),
+                worktree_path: Some(worktree.display().to_string()),
+                worktree_branch: Some("resume".to_owned()),
+                prompt: None,
+                description: None,
+            },
+        );
+        event.timestamp = jiff::Timestamp::from_second(1_700_000_000 + index as i64 * 10).unwrap();
+        store.append_event(&event).expect("seed cohort member");
+        if agent_id == parent_id {
+            let transcript = env.home_root.join("parent.jsonl");
+            std::fs::write(&transcript, "{}\n").expect("write parent conversation");
+            let mut observation =
+                AgentLifecycleObservation::new(Some(parent_id.into()), LifecycleSignal::Ended);
+            observation.transcript_path = Some(transcript.display().to_string());
+            let mut ended = EventEnvelope::agent_lifecycle(
+                workspace.workspace_id.clone(),
+                &workspace.session_name,
+                "codex",
+                "SessionEnd",
+                &observation,
+            );
+            ended.timestamp = jiff::Timestamp::from_second(1_700_000_001).unwrap();
+            store
+                .append_event(&ended)
+                .expect("close parent conversation");
+        }
+    }
+    let projection = store
+        .runtime_projection(rimz::RuntimeScope::Audit)
+        .expect("seeded cohort");
+    let child = projection
+        .agents
+        .iter()
+        .find(|agent| agent.agent_id == child_id)
+        .expect("child");
+    assert!(child.is_launched_child());
+    assert!(matches!(
+        rimz::store::runtime::agent_liveness(child),
+        rimz::store::runtime::AgentLiveness::Live { .. }
+    ));
+    let parent = projection
+        .agents
+        .iter()
+        .find(|agent| agent.agent_id == parent_id)
+        .expect("closed parent");
+    assert!(parent.is_root() && parent.ended_at.is_some());
+    let placeholder = projection
+        .agents
+        .iter()
+        .find(|agent| agent.agent_id == placeholder_id)
+        .expect("dead placeholder");
+    assert!(placeholder.agent_id.is_provisional());
+    assert_eq!(
+        rimz::store::runtime::agent_liveness(placeholder),
+        rimz::store::runtime::AgentLiveness::Dead
+    );
+    assert!(parent.last_activity < child.last_activity);
+    assert!(child.last_activity < placeholder.last_activity);
+
+    let output = launch_command()
+        .bounded_output()
+        .expect("resume astra cohort");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    wait_for_path(&ready, "resumed provider did not start");
+    let argv = std::fs::read_to_string(&argv_path).expect("provider argv");
+    let args = argv.lines().collect::<Vec<_>>();
+    assert!(args.starts_with(&["resume", parent_id]), "{argv}");
+    assert!(!args.contains(&child_id));
+    assert!(!args.contains(&placeholder_id));
+
+    let output = launch_command()
+        .bounded_output()
+        .expect("refuse live parent resume");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("still live") && stderr.contains(parent_id),
+        "{stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&argv_path).expect("provider argv"),
+        argv
+    );
+}
+
+#[test]
 fn fresh_cohort_relaunch_preserves_dirty_checkout_and_does_not_duplicate_live_agents() {
     use std::io::Write;
     use std::os::unix::fs::MetadataExt;

--- a/crates/rimz/tests/integration/backend/tmux/agent_lifecycle.rs
+++ b/crates/rimz/tests/integration/backend/tmux/agent_lifecycle.rs
@@ -808,7 +808,10 @@ fn fresh_cohort_relaunch_preserves_dirty_checkout_and_does_not_duplicate_live_ag
     std::fs::write(
         agent_bin.join("claude"),
         format!(
-            "#!/bin/bash\nprintf ready > '{}/'$$\nexec -a claude sleep 300\n",
+            "#!/bin/bash\nset -e\n\
+             printf '{{\"hook_event_name\":\"SessionStart\",\"session_id\":\"cohort-%s\"}}\\n' \"$$\" | \
+             RIMZ_AGENT_PID=$$ \"$RIMZ_TEST_RIMZ_BIN\" hooks feed --source claude >/dev/null\n\
+             printf ready > '{}/'$$\nexec -a claude sleep 300\n",
             ready.display()
         ),
     )
@@ -818,6 +821,7 @@ fn fresh_cohort_relaunch_preserves_dirty_checkout_and_does_not_duplicate_live_ag
         command
             .env("PATH", path_with_front(&agent_bin))
             .env("SHELL", "/definitely/not/a/shell")
+            .env("RIMZ_TEST_RIMZ_BIN", env.rimz_bin())
             .args(["--mux", "tmux", "agents", "claude,claude", "-w", "fresh"]);
         command
     };
@@ -924,6 +928,7 @@ fn fresh_cohort_relaunch_preserves_dirty_checkout_and_does_not_duplicate_live_ag
                 .count();
             if ready_count == count
                 && rows.iter().filter(|agent| agent.ended_at.is_none()).count() == 2
+                && rows.iter().all(|agent| !agent.agent_id.is_provisional())
             {
                 return rows;
             }

--- a/docs/guide/teams.md
+++ b/docs/guide/teams.md
@@ -179,6 +179,8 @@ When the tree is instead clean and its content has landed, the choices are `remo
 
 `--resume` (alias `--continue`) forces the resume path, reopening the newest matching set of sessions: by team name and role for a team, or by cell order for an inline spec. Resume takes identity, working directory, and channel from RimZ's durable records and each role's model, effort, system prompt, and permission mode from its profile, so a resumed team comes back configured exactly as it launched. It stands alone: no prompt, model, or channel flags ride with it.
 
+For one agent, a kind resumes its newest closed root conversation; a profile such as `rimz agents astra --resume` selects only conversations launched from that profile. Subagents never compete with their parent, and a matching root that is still live refuses the command.
+
 ```sh
 rimz teams resume forge            # reopen the newest closed forge team
 rimz agents claude,codex --resume  # reopen the newest matching inline pair

--- a/docs/internals/harness/fleet.md
+++ b/docs/internals/harness/fleet.md
@@ -287,6 +287,8 @@ Lane resume picks one of four actions, and `LaneResumeAction` names them: `List`
 
 Missing cells launch fresh in the matched cohort's cwd and channel, so the layout stays whole. Cleanly ended members stay candidates, so a closed team resumes while its worktree still exists. Launched children and provider-native subagents, empty session ids, missing worktrees, and launch placeholders that never adopted a session and are no longer live are never candidates. A matched member whose process is still live refuses the whole resume and names it, because launching beside it would duplicate the addressable role or kind. A kind whose adapter has no native resume argv launches fresh and is reported as such.
 
+Relaunch reconciliation uses the same admission rule, so a worktree containing only non-live launch placeholders has no cohort to offer for resume and proceeds to a fresh launch.
+
 Flat resume keeps pane identity when a stamp survives: newest-first candidates sharing one pane collapse to the newest session. A rebirth boundary retires pane stamps, because pane ids renumber across a mux restart; an unstamped root stays a candidate and deduplicates by `(kind, session id)`. Subagents are excluded by their parent identity rather than by their lack of a pane.
 
 `resume.max` bounds how many agents one reborn session auto-resumes (`DEFAULT_RESUME_MAX`, 128), so a long-lived workspace cannot fork-bomb the machine on birth. Anything past the cap is reported as a skip, never silently dropped, and every `ResumeSkip` carries its reason (`no resume CLI`, `no saved conversation`, `over the resume cap`, or `no prompt replacement`) into the start report.

--- a/docs/internals/harness/fleet.md
+++ b/docs/internals/harness/fleet.md
@@ -283,9 +283,9 @@ Lane resume picks one of four actions, and `LaneResumeAction` names them: `List`
 
 - A **named team spec** matches prior root agents with the same `team`, then maps role cells by role, taking the newest member per role.
 - An **inline multi-agent spec** matches the newest `launch_group` that maps onto its agent cells by `launch_ordinal`, falling back to kind when old records lack ordinals.
-- A **single-agent spec** ignores cohort membership and resumes the newest dead or unknown root session of that kind.
+- A **single-agent spec** ignores cohort membership and resumes the newest dead or unknown root session of that kind, and of that profile when the spec named one.
 
-Missing cells launch fresh in the matched cohort's cwd and channel, so the layout stays whole. Cleanly ended members stay candidates, so a closed team resumes while its worktree still exists. Subagents, empty session ids, and missing worktrees are never candidates. A matched member whose process is still live refuses the whole resume and names it, because launching beside it would duplicate the addressable role or kind. A kind whose adapter has no native resume argv launches fresh and is reported as such.
+Missing cells launch fresh in the matched cohort's cwd and channel, so the layout stays whole. Cleanly ended members stay candidates, so a closed team resumes while its worktree still exists. Launched children and provider-native subagents, empty session ids, missing worktrees, and launch placeholders that never adopted a session and are no longer live are never candidates. A matched member whose process is still live refuses the whole resume and names it, because launching beside it would duplicate the addressable role or kind. A kind whose adapter has no native resume argv launches fresh and is reported as such.
 
 Flat resume keeps pane identity when a stamp survives: newest-first candidates sharing one pane collapse to the newest session. A rebirth boundary retires pane stamps, because pane ids renumber across a mux restart; an unstamped root stays a candidate and deduplicates by `(kind, session id)`. Subagents are excluded by their parent identity rather than by their lack of a pane.
 

--- a/docs/reference/cli/agents.md
+++ b/docs/reference/cli/agents.md
@@ -123,11 +123,12 @@ rimz agents forge --resume                           # reopen the newest closed 
 rimz agents forge -w restore-living-team --resume    # reopen that exact team instance
 rimz agents claude,codex --resume                    # reopen the newest matching inline cohort
 rimz agents claude --resume                          # resume the freshest closed Claude session
+rimz agents astra --resume                           # resume the freshest closed session launched from the astra profile
 ```
 
 What matches what:
 
-- A team resumes by team name and role; an inline multi-agent spec resumes by the saved launch group and cell order; a single kind resumes the freshest closed root session of that kind.
+- A team resumes by team name and role; an inline multi-agent spec resumes by the saved launch group and cell order; a single kind resumes the freshest closed root session of that kind; a profile resumes the freshest closed root session launched from that profile.
 - Add `-w <NAME>` to resume that exact worktree's cohort. Use bare `-w`, or omit the flag while running inside a worktree, to scope resume to that worktree; run from the project root to keep the room-wide newest-by-spec behavior.
 - Cleanly closed cohort members still match when their worktree exists. Cells with no resumable prior member launch fresh in the matched cohort's cwd and channel. A matched member that is still live refuses the command, so the room does not duplicate the same address.
 


### PR DESCRIPTION
## Context

`rimz agents <profile> --resume`, in a worktree whose root Codex agent died, selected the wrong session. The planner matched a single-cell spec by provider kind alone, over a candidate pool that excluded only provider-native subagents. Three results followed from one seam:

- A pane-backed `rimz subagents` child of the dead root was selected, then refused as `still live`.
- After that child ended, the same match would resume the child conversation in the root's place.
- An unrelated profile's empty launch placeholder, being the newest row of that kind, made the whole cohort start fresh, so the original conversation was silently abandoned.

## Design choices

- **A root is an agent with no parent.** The cohort path tests `parent_agent_id.is_none()` in place of `!is_provider_subagent()`. Team members and agent-launched peers carry a launch depth but never a parent, so they stay candidates; both child kinds drop out. A child is resumed through the subagent machinery, never through `rimz agents <spec> --resume`.
- **Profile matching is strict.** A cell that named a profile matches only rows of that profile. A bare kind keeps the prior newest-of-kind rule and still matches profiled rows. A fallback to another profile would reintroduce the wrong-target class this change closes.
- **A placeholder that is not live is not a candidate.** A provisional `launch_...` row that never adopted a provider session has no conversation to restore and no process to protect. A live placeholder stays in the pool, so an agent that is still starting is selected and refuses the command as before.
- **One admission rule for both consumers.** Resume planning and fresh-launch reconciliation share `cohort_admits`, so the command that offers a resume and the command that runs it always agree about which rows exist.
- Liveness is still measured on the selected member only, and the rebirth and lane paths keep their prior candidate rule.

## Implementation

`CohortCell` carries the resolved profile, and `cohort_cells` copies it from the layout. `cohort_admits` holds the root, empty-id, and placeholder rules; `cohort_candidates` and `inspect_cohort_relaunch` both filter through it, the first with the caller's liveness function and the second with `agent_liveness`. `match_single_cohort` compares the profile when the spec named one. The resume suggestion list uses the same root predicate.

A worktree that holds only non-live launch placeholders therefore reads `Absent` and goes to a fresh launch. Before, reconciliation read it as a closed cohort and offered `resume` as the default answer, but that resume then failed with `nothing to resume`.

Deviation from the plan: the proposed public `AgentState::is_root()` helper was not added, because the agents API surface ratchet has no budget for it. The call sites test the existing `parent_agent_id` field directly, which is also the root idiom used elsewhere in the store projection. Behavior is identical.

Coverage: unit tests over child exclusion, profile selection, placeholder admission, and the three relaunch states a placeholder can produce, plus a real-CLI regression against tmux that seeds a closed profiled parent, a live child, and a dead placeholder, then asserts the provider argv resumes the parent and that a second call refuses the now-live parent without a new launch. The matching contract is documented in the fleet internals page, the CLI reference, and the teams guide.

## Advisories

- `rimz teams resume <team>` on a cohort whose every member is an unadopted placeholder now reports `nothing to resume` instead of relaunching fresh, and rebirth no longer restores such a tab. This is an accepted consequence of the placeholder rule, and it makes the cohort path agree with the flat path.
- A live member blocks a resume only when it is the selected member. A live older root of the same identity still does not block a resume of a newer closed one. Widening that check is separate work.
- Whether room rebirth should auto-resume launched children stays an open product question.
- Why the original Codex process exited is not diagnosed and is outside this change.

<details>
<summary>Implemented by the <a href="https://github.com/rimio-ai/rimz">RimZ</a> <code>forge</code> team · 3 agents · 42m active · $25.58 · 6 messages (1 from you)</summary>

<br/>

**Agents**

- **planner** — Claude `claude-fable-5-1@high`
  - effort: 13m active · $5.93
  - subagents: 1 × explorer · $0.70
  - activity: 40 tool calls
  - messages: 1 from you · 1 from teammates · 3 to teammates
  - tokens: 165.2k input, 47.8k output, 127k cache write, 4.7m cache read
- **coder** — Codex `gpt-6-astra@high`
  - effort: 16m active · $11.17
  - subagents: 1 × implementer · $1.69
  - activity: 107 tool calls
  - messages: 2 from teammates · 3 to teammates
  - tokens: 228.6k input, 28.9k output, 7.4m cache read
- **reviewer** — Claude `claude-opus-5@high`
  - effort: 12m active · $8.48
  - subagents: 2 × finder · $1.96
  - activity: 72 tool calls
  - messages: 2 from teammates · 3 to teammates
  - tokens: 125.5k input, 55.9k output, 166.6k cache write, 7.6m cache read

**Models**

- `gpt-6-astra` — $13.13 · 354k input, 33.1k output, 7.9m cache read
- `claude-opus-5` — $6.52 · 124 input, 51.7k output, 166.6k cache write, 7.1m cache read
- `claude-fable-5-1` — $5.24 · 94 input, 36k output, 127k cache write, 3.6m cache read
- `gpt-5.6-terra` — $0.70 · 165.1k input, 11.8k output, 1.1m cache read

</details>